### PR TITLE
Update pcbnew intro and getting started in kicad intro

### DIFF
--- a/src/Getting_Started_in_KiCad/Getting_Started_in_KiCad.adoc
+++ b/src/Getting_Started_in_KiCad/Getting_Started_in_KiCad.adoc
@@ -63,7 +63,7 @@ tools:
 |Program name|Description|File extension
 |KiCad |Project manager|+*.pro+
 |Eeschema |Schematic editor (both schematic and component)|+*.sch, *.lib, *.net+
-|CvPcb |Footprint selector|+*.net, *.cmp+
+|CvPcb |Footprint selector|+*.net+
 |Pcbnew |Circuit board board editor|+*.kicad_pcb+
 |GerbView |Gerber viewer|All the usual gerbers
 |Bitmap2Component |Convert bitmap images to components or footprints|+*.lib, *.kicad_mod, *.kicad_wks+
@@ -94,26 +94,34 @@ On the Internet, the home of KiCad is:
 
 http://www.kicad-pcb.org/
 
-The old and original site was:
-
-http://iut-tice.ujf-grenoble.fr/kicad/index.html
 
 [[download-and-install-kicad]]
 === Download and install KiCad
 
-KiCad runs on GNU/Linux, Apple OS X and Windows. You can download a
-copy of KiCad from:
+KiCad runs on GNU/Linux, Apple OS X and Windows.
+You can find the most up to date instructions and download links at:
 
 http://www.kicad-pcb.org/display/KICAD/Installing+KiCad
 
-*Whatever installation method you choose, always go for a recent
-version of KiCad.*
+IMPORTANT: The current KiCad stable builds have not been updated since 2013. As 
+such they are missing many new features that have been added to KiCad. It is 
+suggested that you install the unstable nightly builds which occasionally 
+introduce new bugs, but are updated frequently and generally stable.
 
 [[under-linux]]
 === Under GNU/Linux
 
-Under GNU/Linux, the easiest way to install KiCad (daily build) is via _PPA_ and __Aptitude__. Type
-into your Terminal:
+.Stable builds
+Stable releases of KiCad can be found in most distibution's package managers as
+kicad and kicad-doc.
+
+.Unstable (nightly development) builds
+Unstable builds are built from the most recent source code. They can sometimes
+have bugs that cause file corruption, generate bad gerbers, etc, but are generally
+stable and have the latest features.
+
+Under Ubuntu, the easiest way to install an unstable nightly build of KiCad is 
+via _PPA_ and __Aptitude__. Type the following into your Terminal:
 
 __________________________________________________
 sudo add-apt-repository ppa:js-reynaud/ppa-kicad 
@@ -123,24 +131,44 @@ sudo aptitude update && sudo aptitude safe-upgrade
 sudo aptitude install kicad kicad-doc-en
 __________________________________________________
 
-At the time of writing, the standard _apt-get_ repository of Ubuntu
-offers a version of KiCad that is about two years old.
+
+Under fedora the easiest way to install an unstable nightly build is via _copr_.
+To install KiCad via copr type the following in to copr:
+
+__________________________________________________
+sudo dnf copr enable mangelajo/kicad
+
+sudo dnf install kicad
+__________________________________________________
 
 Alternatively, you can download and install a pre-compiled version of
 KiCad, or directly download the source code, compile and install KiCad.
 
 [[under-apple-os-x]]
 === Under Apple OS X
+.Stable builds
+There are currently no stable builds of KiCad for OS X.
 
-At the time of writing, the best way to install KiCad on Apple OS X is
-to download a nightly pre-build binary from:
+.Unstable (nightly development) builds
+Unstable builds are built from the most recent source code. They can sometimes
+have bugs that cause file corruption, generate bad gerbers, etc, but are generally
+stable and have the latest features.
 
+Unstable nightly development builds can be found at: 
 http://downloads.kicad-pcb.org/osx/
 
 [[under-Windows]]
 === Under Windows
-For Windows you can find the most recent build at:
+.Stable builds
+Stable builds of KiCad can be found at:
+http://iut-tice.ujf-grenoble.fr/cao/
 
+.Unstable (nightly development) builds
+Unstable builds are built from the most recent source code. They can sometimes
+have bugs that cause file corruption, generate bad gerbers, etc, but are generally
+stable and have the latest features.
+
+For Windows you can find nightly development builds at:
 http://www2.futureware.at/~nickoe/
 
 [[support]]

--- a/src/Getting_Started_in_KiCad/Getting_Started_in_KiCad.adoc
+++ b/src/Getting_Started_in_KiCad/Getting_Started_in_KiCad.adoc
@@ -169,7 +169,7 @@ have bugs that cause file corruption, generate bad gerbers, etc, but are general
 stable and have the latest features.
 
 For Windows you can find nightly development builds at:
-http://www2.futureware.at/~nickoe/
+http://downloads.kicad-pcb.org/windows/
 
 [[support]]
 === Support

--- a/src/Pcbnew/Pcbnew_introduction.adoc
+++ b/src/Pcbnew/Pcbnew_introduction.adoc
@@ -99,7 +99,3 @@ at CERN. This includes features such as a new renderer (OpenGL and Cairo view mo
 an interative push and shove router, differential and meander trace routing and tuning,
 a reworked footprint editor, and many other features. Please note that most of
 these new features *only* exist in the new OpenGL and Cairo view modes.
-
-Please read through this fully to see what changes have been introduced. If you
-want to see what else CERN has on its roadmap for KiCad please check the following
-page: http://www.ohwr.org/projects/cern-kicad/wiki/WorkPackages

--- a/src/Pcbnew/Pcbnew_introduction.adoc
+++ b/src/Pcbnew/Pcbnew_introduction.adoc
@@ -5,37 +5,24 @@
 
 Pcbnew is a powerful printed circuit board software tool available
 for the Linux, Microsoft Windows and Apple OS X operating systems.
+Pcbnew is used in association with the schematic capture 
+program Eeschema to create printed circuit boards. 
 
-Pcbnew is used in association with the schematic capture software
-program Eeschema, which provides the Netlist file - this describes
-the electrical connections of the PCB being designed.
+Pcbnew manages libraries of footprints. Each footprint is a drawing of the
+physical component including its land pattern (the layout of pads
+on the circuit board). The required footprints are
+automatically loaded during the reading of the Netlist. Any changes to footprint
+selection or annotation can be changed in the schematic and updated in pcbnew
+by regenerating the netlist and reading it in pcbnew again.
 
-A second program CvPcb is used to assign each component in the
-Netlist produced by Eeschema, to a module that is used by Pcbnew.
-This can be done either interactively or automatically using
-equivalence files.
-
-Pcbnew manages libraries of modules. Each module is a drawing of the
-physical component including its footprint - the layout of pads
-providing connections to the component. The required modules are
-automatically loaded during the reading of the Netlist produced by
-CvPcb.
-
-Pcbnew integrates, automatically and immediately, any circuit
-modification, by removal of any erroneous tracks, addition of the
-new components, or by modifying any value (and under certain
-conditions any reference) of the old or new modules, according to
-the electrical connections appearing in the schematic.
+Pcbnew provides a design rules check tool which prevents track and pad clearence
+issues as well as preventing nets from being connected that aren't connected
+in the netlist/schematic. When using the interactive router it continuously 
+runs the design rules check and will help automatically route individual traces.
 
 Pcbnew provides a rats nest display, a hairline connecting the pads
-of modules which are connected on the schematic. These connections
-move dynamically as track and module movements are made.
-
-Pcbnew has an active Design Rules Check (DRC) function which automatically
-indicates any error of track layout in real time.
-
-Pcbnew can automatically generate a copper plane, with or without
-thermal breaks on the pads.
+of footprints which are connected on the schematic. These connections
+move dynamically as track and footprint movements are made.
 
 Pcbnew has a simple but effective autorouter to assist in the
 production of the circuit board. An Export/Import in SPECCTRA dsn format
@@ -45,17 +32,12 @@ Pcbnew provides options specifically provided for the production of ultra
 high frequency microwave circuits (such as pads of trapezoidal and complex
 form, automatic layout of coils on the printed circuit, etc).
 
-Pcbnew displays the elements (tracks, pads, texts, drawings and
-more) as actual size and according to the following personal preferences:
-
-* Display in full or outline.
-* Display of the track/pad clearance.
-
 === Principal design features
 
-Pcbnew has an internal resolution of 1/10000 inch.
+The smallest unit in pcbnew is 1 nanometer. All dimensions are stored as integer
+nanometers.
 
-Pcbnew works on 32 layers of copper, 14 technical layers (silk screen,
+Pcbnew can generate up to 32 layers of copper, 14 technical layers (silk screen,
 solder mask, component adhesive, solder paste and edge cuts) plus
 4 auxiliary layers (drawings and comments) and manages in real time
 the hairline indication (rats nest) of missing tracks.
@@ -65,30 +47,31 @@ can be customizable:
 
 * In full or outline.
 * With or without track clearance.
-* By hiding certain elements (copper layers, technical layers, zones of
-  copper, modules...), which is useful for high-density multi-layer
-  circuits.
 
-For the complex circuits, the display of layers, zones, components
-can be removed in a selective way for clarity on screen.
+For the complex circuits the display of layers, zones, components
+can be hidden in a selective way for clarity on screen. Nets of traces can be
+highlighted to provide high contrast as well.
 
-Modules can be rotated to any angle, with a step of 0.1 degree.
+Footprints can be rotated to any angle, with a resolution of 0.1 degree.
 
-Pads can be round, rectangular, oval or trapezoidal (the latter is
-necessary for the production of ultra high frequency circuits). In
-addition several basic pads can be grouped.
+Pcbnew includes a footprint editor that allows editing of individual footprints
+that have been on a pcb or editing a footprint in a library.
 
-Both the size of each pad, and the layers where they appear, can be
-adjusted. The drilling of holes can be offset.
+The footprint editor provides many time saving tools such as:
 
-Pcbnew can automatically generate copper planes, with automatic
-generation of thermal breaks around the pads concerned.
+* Fast pad numbering by simply dragging the mouse over pads in the order you 
+  want them numbered.
+* Easy generation of rectangular and circular arrays of pads for LGA/BGA 
+  or circular footprints.
+* Semi-automatic aligning of rows or columns of pads.
 
-The Footprint Editor can be accessed from the Pcbnew toolbar. The
-Editor allows creation or modification of a footprint from the PCB or a
-library and then saved to either. A footprint saved to the PCB can be
-subsequently saved to a library. In addition all footprints on the PCB
-can be saved to a library by creating a footprint archive.
+Footprint pads have a variety of properties that can be adjusted. The pads can be 
+round, rectangular, oval or trapezoidal. For through hole parts drills can be offset
+inside the pad and be round or a slot. Individual pads can also be rotated and have
+unique soldermask, net, or paste clearence. Pads can also have a solid connection
+or a thermal relief connection for easier manufacturing. Any combination of unique
+pads can be placed within a footprint.
+
 
 Pcbnew generates in an extremely simple way all the documents
 necessary:
@@ -107,7 +90,16 @@ necessary:
 
 === General remarks
 
-Pcbnew requires a 3 button mouse. The 3rd button is mandatory.
+Due to the degree of control necessary it is highly suggested to use a 3 button 
+mouse with pcbnew. Many features such as panning and zooming require a 3 button
+mouse.
 
-Finally it should be noted that the diagrammatic tool Eeschema and
-CvPcb are needed to create the required netlists.
+In the new release of KiCad pcbnew has seen wide sweeping changes from developers
+at CERN. This includes features such as a new renderer (OpenGL and Cairo view modes),
+an interative push and shove router, differential and meander trace routing and tuning,
+a reworked footprint editor, and many other features. Please note that most of
+these new features *only* exist in the new OpenGL and Cairo view modes.
+
+Please read through this fully to see what changes have been introduced. If you
+want to see what else CERN has on its roadmap for KiCad please check the following
+page: http://www.ohwr.org/projects/cern-kicad/wiki/WorkPackages


### PR DESCRIPTION
Updated both intros so they have accurate information.

I changed the installation part in getting started in kicad intro so it has a better structure (includes info about stable and unstable).

I think there is a LOT of fluff and unnecessary info that could be removed before the stable release to make the docs clearer. Lots of the pcbnew docs need to be rewritten to include info about GAL tools, change "module" to footprint, etc.