### PR TITLE
Remove warning about matching directory and project name

### DIFF
--- a/src/KiCad/KiCad.adoc
+++ b/src/KiCad/KiCad.adoc
@@ -303,8 +303,8 @@ recommended to create a project as follows:
   or “Create a new project from template” icon.
 
 [WARNING]
-It is _strongly_ recommended to use the same name for both project file
-and its directory.
+It is recommended to use a unique directory for each KiCad project.
+Do not combine multiple projects into a single directory.
 
 Kicad creates a file with a .pro extension that maintains a number of
 parameters for project management (such as the list of libraries


### PR DESCRIPTION
It is not necessary for a project to be created in a directory with the same name. I'm not sure if it ever was. This commit rewrites the warning to urge the user to keep each project in a unique directory, without the warning that the names much match.