### PR TITLE
remove FAQ section from GSiK and add doc web link

### DIFF
--- a/src/getting_started_in_kicad/getting_started_in_kicad.adoc
+++ b/src/getting_started_in_kicad/getting_started_in_kicad.adoc
@@ -1434,7 +1434,7 @@ described here.
 
 This has been a quick guide on most of the features in KiCad. For more
 detailed instructions consult the help files which you can access
-through each KiCad module. Click on *Help* -> **Contents** or **Manual**.
+through each KiCad module. Click on *Help* -> **Manual**.
 
 KiCad comes with a pretty good set of multi-language manuals for all its
 four software components.
@@ -1461,10 +1461,10 @@ On OS X:
 
  /Library/Application Support/kicad/help/en
 
-[[kicad-frequently-asked-questions-faq]]
-=== KiCad Frequently Asked Questions (FAQ)
+[[kicad-documentation-on-the-web]]
+=== KiCad documentation on the Web
 
-A very good and frequently updated source of information is the KiCad
-http://www.kicad-pcb.org/display/KICAD/Frequently+Asked+Questions[FAQ] list available.
+Latest KiCad documentations are available in multi-language on the Web.
 
+http://kicad-pcb.org/help/documentation/
 

--- a/src/getting_started_in_kicad/getting_started_in_kicad.adoc
+++ b/src/getting_started_in_kicad/getting_started_in_kicad.adoc
@@ -1464,7 +1464,7 @@ On OS X:
 [[kicad-documentation-on-the-web]]
 === KiCad documentation on the Web
 
-Latest KiCad documentations are available in multi-language on the Web.
+Latest KiCad documentations are available in multiple languages on the Web.
 
 http://kicad-pcb.org/help/documentation/
 


### PR DESCRIPTION
This PR is for issue https://github.com/KiCad/kicad-doc/issues/164.
I also removed description about "Contents" of Help menu since it is unified to "Manual".
