### PR TITLE
Fix parallel build issue ( Fixes #167 )

### DIFF
--- a/CMakeModules/KiCadDocumentation.cmake
+++ b/CMakeModules/KiCadDocumentation.cmake
@@ -153,6 +153,12 @@ macro( KiCadDocumentation DOCNAME )
             add_dependencies( ${DOCNAME}_epub_${LANGUAGE} ${DOCNAME}_translate_${LANGUAGE} )
             add_dependencies( ${DOCNAME} ${DOCNAME}_epub_${LANGUAGE} )
 
+            # Make the epub target depend on the PDF build as the targets have a race
+            # condition, probably with intermediary files
+            if( NOT "${PDF_BUILD}" EQUAL "-1" )
+                add_dependencies( ${DOCNAME}_epub_${LANGUAGE} ${DOCNAME}_pdf_${LANGUAGE} )
+            endif()
+
             install( FILES ${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}/${DOCNAME}.epub DESTINATION ${KICAD_DOC_PATH}/${LANGUAGE} COMPONENT epub-${LANGUAGE})
         endif()
     endforeach()

--- a/CMakeModules/MonolithicManual.cmake
+++ b/CMakeModules/MonolithicManual.cmake
@@ -1,9 +1,0 @@
-
-# Get the list of chapters
-
-set( EESCHEMA_ADOC_MONO "" )
-
-foreach( EESCHEMA_CHAPTER_SOURCE EESCHEMA_ADOC_SOURCES )
-    file( READ CHAPTER ${EESCHEMA_CHAPTER_SOURCE} )
-    set( EESCHEMA_ADOC_MONO "${EESCHEMA_ADOC_MONO} ${CHAPTER}" )
-endforeach()


### PR DESCRIPTION
I got interested in the parallel build issue and fixed it. The epub and pdf build targets have a race condition probably with some intermediary file that causes the build to fail in paralllel builds. I tested with -j8 to test the failure and also to test the solution which looks good.