### PR TITLE
Make KICAD_DOC_PATH relative so that the packager can work okay

### DIFF
--- a/CMakeModules/KiCadDocumentation.cmake
+++ b/CMakeModules/KiCadDocumentation.cmake
@@ -13,10 +13,10 @@ macro( KiCadDocumentation DOCNAME )
 
     # Define the install path
     if( APPLE )
-        set( KICAD_DOC_PATH ${CMAKE_INSTALL_PREFIX}/help
+        set( KICAD_DOC_PATH ./help
             CACHE PATH "Location of KiCad doc files." )
     else()
-        set( KICAD_DOC_PATH ${CMAKE_INSTALL_PREFIX}/share/doc/kicad/help
+        set( KICAD_DOC_PATH ./share/doc/kicad/help
             CACHE PATH "Location of KiCad doc files." )
     endif()
 


### PR DESCRIPTION
At the moment `make package` fails because `KICAD_DOC_PATH` is not a relative path. With this fix you can set `CMAKE_INSTALL_PREFIX` and run `make install` successfully as well as build the package target