### PR TITLE
eliminate multi byte double quotation from adoc

### DIFF
--- a/src/eeschema/eeschema_component_library_editor.adoc
+++ b/src/eeschema/eeschema_component_library_editor.adoc
@@ -374,7 +374,7 @@ value for the value field in the schematic editor), the reference designator
 (U, IC, R...), the number of units per package (for example a 7400 is made of
 4 units per package) and if an alternate body style (sometimes referred to
 as DeMorgan) is desired. If the reference designator field is left empty, it
-will default to “U”. These properties changed later, but it is preferable to
+will default to "U". These properties changed later, but it is preferable to
 set them correctly at the creation of the component.
 
 image:images/1000000000000153000001795877268E.png[1000000000000153000001795877268E_png]
@@ -432,16 +432,16 @@ package after pin creation and editing, there will be additional work
 introduced to add the new unit pins and symbols. Nevertheless, it is
 possible to modify these properies at any time.
 
-The graphic options “Show pin number” and “Show pin name” define the
+The graphic options "Show pin number" and "Show pin name" define the
 visibility of the pin number and pin name text. This text will be
-visible if the corresponding options are checked. The option “Place pin
-names inside” defines the pin name position relative to the pin body.
+visible if the corresponding options are checked. The option "Place pin
+names inside" defines the pin name position relative to the pin body.
 This text will be displayed inside the component outline if the option
-is checked. In this case the “Pin Name Position Offset” property defines
+is checked. In this case the "Pin Name Position Offset" property defines
 the shift of the text away from the body end of the pin. A value from 30
 to 40 (in 1/1000 inch) is reasonable.
 
-The example below shows a component with the “Place pin name inside”
+The example below shows a component with the "Place pin name inside"
 option unchecked. Notice the position of the names and pin numbers.
 
 image:images/2000000800003D8000002550D6E11DAF.png[2000000800003D8000002550D6E11DAF_png]
@@ -499,11 +499,11 @@ The properties of a graphic element are:
 
 * Line width which defines the width of the element's line in the
   current drawing units.
-* The “Common to all units in component” setting defines if the
+* The "Common to all units in component" setting defines if the
   graphical element is drawn for each unit in component with more than one
   unit per package or if the graphical element is only drawn for the
   current unit.
-* The “Common by all body styles (DeMorgan)” setting defines if the
+* The "Common by all body styles (DeMorgan)" setting defines if the
   graphical element is drawn for each symbolic representation in
   components with an alternate body style or if the graphical element is
   only drawn for the current body style.
@@ -524,7 +524,7 @@ graphical text items are not fields.
 === Multiple Units per Component and Alternate Body Styles
 
 Components can have two symbolic representations (a standard symbol and
-an alternate symbol often referred to as “DeMorgan”) and/or have more
+an alternate symbol often referred to as "DeMorgan") and/or have more
 than one unit per package (logic gates for example). Some components can
 have more than one unit per package each with different symbols and pin
 configurations.
@@ -581,7 +581,7 @@ interchangeable with units 1 and 2.
 Shown below are properties for a graphic body element. From the relay
 example above, the three units have different symbolic representations.
 Therefore, each unit was created separately and the graphical body
-elements must have the “Common to all units in component” disabled.
+elements must have the "Common to all units in component" disabled.
 
 image:images/2000000900003855000027B1F162801F.png[2000000900003855000027B1F162801F_png]
 
@@ -600,9 +600,9 @@ edited, deleted, and/or moved.
 ==== Pin Overview
 
 A pin is defined by its graphical representation, its name and its
-“number”. The pin's “number” is defined by a set of 4 letters and / or
+"number". The pin's "number" is defined by a set of 4 letters and / or
 numbers. For the Electrical Rules Check (ERC) tool to be useful, the
-pin's “electrical” type (input, output, tri-state...) must also be
+pin's "electrical" type (input, output, tri-state...) must also be
 defined correctly. If this type is not defined properly, the schematic
 ERC check results may be invalid.
 
@@ -615,9 +615,9 @@ Important notes:
 * If the pin name is reduced to a single symbol, the pin is regarded as
   unnamed.
 * Pin names starting with `#`, are reserved for power port symbols.
-* A pin “number” consists of 1 to 4 letters and/ or numbers. 1,2,..9999
+* A pin "number" consists of 1 to 4 letters and/ or numbers. 1,2,..9999
   are valid numbers. A1, B3, Anod, Gnd, Wire, etc. are also valid.
-* Duplicate pin “numbers” cannot exist in a component.
+* Duplicate pin "numbers" cannot exist in a component.
 
 [[pin-properties]]
 ==== Pin Properties
@@ -698,7 +698,7 @@ on the main tool bar. This will allow you to create pins for each unit
 and representation completely independently.
 
 A component can have two symbolic representations (representation known
-as “DeMorgan”) and can be made up of more than one unit as in the case
+as "DeMorgan") and can be made up of more than one unit as in the case
 of components with logic gates. For certain components, you may want
 several different graphic elements and pins. Like the relay sample shown
 in section 11.7.1, a relay can be represented by three distinct units: a
@@ -768,8 +768,8 @@ Important notes:
   or has the invisible attribute enable.
 * The footprint is defined as an absolute footprint using the
   LIBNAME:FPNAME format where LIBNAME is the name of the footprint library
-  defined in the footprint library table (see the “Footprint Library
-  Table” section in the Pcbnew “Reference Manual”) and FPNAME is the name
+  defined in the footprint library table (see the "Footprint Library
+  Table" section in the Pcbnew "Reference Manual") and FPNAME is the name
   of the footprint in the library LIBNAME.
 
 [[power-symbols]]
@@ -777,8 +777,8 @@ Important notes:
 
 Power symbols are created the same way as normal components. It may be
 useful to place them in a dedicated library such as power.lib. Power
-symbols consist of a graphical symbol and a pin of the type “Power
-Invisible”. Power port symbols are handled like any other component by
+symbols consist of a graphical symbol and a pin of the type "Power
+Invisible". Power port symbols are handled like any other component by
 the schematic capture software. Some precautions are essential. Below is
 an example of a power +5V symbol.
 
@@ -786,9 +786,9 @@ image:images/1000000000000438000002C20F7CD114.png[1000000000000438000002C20F7CD1
 
 To create a power symbol, use the following steps:
 
-* Add a pin of type “Power input” named +5V (important because this name
+* Add a pin of type "Power input" named +5V (important because this name
   will establish connection to the net +5V), with a pin number of 1
-  (number of no importance), a length of 0, and a “Line” “Graphic Style”.
+  (number of no importance), a length of 0, and a "Line" "Graphic Style".
 * Place a small circle and a segment from the pin to the circle as
   shown.
 * The anchor of the symbol is on the pin.

--- a/src/eeschema/eeschema_creating_customized_netlists_and_bom_files.adoc
+++ b/src/eeschema/eeschema_creating_customized_netlists_and_bom_files.adoc
@@ -826,13 +826,13 @@ file to convert>_
 
 In KiCad under Windows the command line is the following.
 
-_f:/kicad/bin/xsltproc.exe -o “%O”
-f:/kicad/bin/plugins/netlist_form_pads-pcb.xsl “%I”_
+_f:/kicad/bin/xsltproc.exe -o "%O"
+f:/kicad/bin/plugins/netlist_form_pads-pcb.xsl "%I"_
 
 Under Linux the command becomes as following.
 
-_xsltproc -o “%O” /usr/local/kicad/bin/plugins/netlist_form_pads-pcb.xsl
-“%I”_
+_xsltproc -o "%O" /usr/local/kicad/bin/plugins/netlist_form_pads-pcb.xsl
+"%I"_
 
 Where _netlist_form_pads-pcb.xsl_ is the style-sheet that you are
 applying. Do not forget the double quotes around the file names, this
@@ -861,13 +861,13 @@ The command line format for xsltproc is the following:
 
 _under Windows._
 
-*f:/kicad/bin/xsltproc.exe -o “%O”
-f:/kicad/bin/plugins/netlist_form_pads-pcb.xsl “%I”*
+*f:/kicad/bin/xsltproc.exe -o "%O"
+f:/kicad/bin/plugins/netlist_form_pads-pcb.xsl "%I"*
 
 under Linux:
 
-*xsltproc -o “%O” /usr/local/kicad/bin/plugins/netlist_form_pads-pcb.xsl
-“%I”*
+*xsltproc -o "%O" /usr/local/kicad/bin/plugins/netlist_form_pads-pcb.xsl
+"%I"*
 
 The above examples assume xsltproc is installed on your PC under Windows
 and all files located in kicad/bin.
@@ -897,11 +897,11 @@ python <script file name> <input filename> <output filename>
 
 under Windows:
 
-*python *.exe f:/kicad/python/my_python_script.py “%I” “%O”*
+*python *.exe f:/kicad/python/my_python_script.py "%I" "%O"*
 
 under Linux:
 
-*python /usr/local/kicad/python/my_python_script.py “%I” “%O”*
+*python /usr/local/kicad/python/my_python_script.py "%I" "%O"*
 
 Assuming python is installed on your PC.
 
@@ -1153,7 +1153,7 @@ contains the list of schematic libraries used in the project.
 ==== The nets section
 
 The nets section has the delimiter <nets>. This section contains the
-“connectivity” of the schematic.
+"connectivity" of the schematic.
 
 -----------------------------
 <nets>

--- a/src/eeschema/eeschema_design_verification_with_erc.adoc
+++ b/src/eeschema/eeschema_design_verification_with_erc.adoc
@@ -15,7 +15,7 @@ many oversights and small errors.
 In fact all detected errors must be checked and then corrected before
 proceeding as normal. The quality of the ERC is directly related to the
 care taken in declaring electrical pin properties during library
-creation. ERC output is reported as “errors” or “warnings”.
+creation. ERC output is reported as "errors" or "warnings".
 
 image:images/en/dialog_erc.png[ERC dialog]
 
@@ -74,7 +74,7 @@ designs, the power is provided by connectors that are not power sources
 The ERC thus won't detect any Power out pin to control this wire and
 will declare them not driven by a power source.
 
-To avoid this warning you have to place a “PWR_FLAG” on such a power
+To avoid this warning you have to place a "PWR_FLAG" on such a power
 port. Take a look at the following example:
 
 image:images/20000008000030E4000026DDFDF3D5E2.png[20000008000030E4000026DDFDF3D5E2_png]

--- a/src/eeschema/eeschema_generic_commands.adoc
+++ b/src/eeschema/eeschema_generic_commands.adoc
@@ -8,15 +8,15 @@ You can reach the various commands by:
 * Clicking on the menu bar (top of screen).
 * Clicking on the icons on top of the screen (general commands).
 * Clicking on the icons on the right side of the screen (particular
-  commands or “tools”).
+  commands or "tools").
 * Clicking on the icons on the left side of the screen (display
   options).
 * Pressing the mouse buttons (important complementary commands). In
   particular a right click opens a contextual menu for the
   element under the cursor (Zoom, grid and edition of the elements).
 * Function keys (F1, F2, F3, F4, Insert and space keys).
-  Specifically: The “Escape” key often allows the canceling of a command
-  in progress. The “Insert” key allows the duplication of the last element
+  Specifically: The "Escape" key often allows the canceling of a command
+  in progress. The "Insert" key allows the duplication of the last element
   created.
 
 Here are the various possible command locations:
@@ -67,7 +67,7 @@ image::images/en/main_window_popup.png[main window popup]
 
 === Hotkeys
 
-* The “?” key displays the current hotkey list.
+* The "?" key displays the current hotkey list.
 * Hotkeys can be managed by choosing "Edit Hotkeys" in the Preferences menu.
 
 Here is the default hot key list:
@@ -251,8 +251,8 @@ This toolbar contains tools to:
 
 |=======================================================================
 
-The detailed use of these tools is described in the chapter “Diagram
-Creation/Editing”. An outline of their use is given below.
+The detailed use of these tools is described in the chapter "Diagram
+Creation/Editing". An outline of their use is given below.
 
 [width="100%",cols="10%,90%",]
 |=======================================================================
@@ -337,7 +337,7 @@ Delete selected element.
 If several superimposed elements are selected, the priority is given to
 the smallest (in the decreasing priorities: junction, NoConnect, wire,
 bus, text, component). This also applies to hierarchical sheets. Note:
-the “Undelete” function of the general toolbar allows you to cancel last
+the "Undelete" function of the general toolbar allows you to cancel last
 deletions.
 
 |=======================================================================

--- a/src/eeschema/eeschema_hierarchical_schematics.adoc
+++ b/src/eeschema/eeschema_hierarchical_schematics.adoc
@@ -19,7 +19,7 @@ on its readability.
 
 From the root sheet, you must be able to find all sub-sheets.
 Hierarchical schematics management is very easy with Eeschema, thanks to
-an integrated “hierarchy navigator” accessible via the icon
+an integrated "hierarchy navigator" accessible via the icon
 image:images/icons/hierarchy_nav.png[icons/hierarchy_nav_png]
 of the upper and right toolbar.
 
@@ -102,7 +102,7 @@ labels and/or global labels.
 
 You have to:
 
-* Place in the root sheet a hierarchy symbol called “sheet symbol”.
+* Place in the root sheet a hierarchy symbol called "sheet symbol".
 * Enter into the new schematic (sub-sheet) with the navigator and draw
   it, like any other schematic.
 * Draw the electric connections between the two schematics by placing
@@ -162,7 +162,7 @@ The second solution is quite preferable.
 * Click on the hierarchy symbol where you want to place this pin.
 
 See below an example of the creation of the hierarchical pin called
-“CONNEXION”.
+"CONNEXION".
 
 image:images/1000000000000160000000CD797712D0.png[1000000000000160000000CD797712D0_png]
 
@@ -235,19 +235,19 @@ schematic sheet where they are placed. This is due to the fact that :
 * Each sheet has a sheet number.
 * This sheet number is associated to a label.
 
-Thus, if you place the label “TOTO” in sheet n° 3, in fact the true
-label is “TOTO_3”. If you also place a label “TOTO” in sheet n° 1 (root
-sheet) you place in fact a label called “TOTO_1”, different from
-“TOTO_3”. This is always true, even if there is only one sheet.
+Thus, if you place the label "TOTO" in sheet n° 3, in fact the true
+label is "TOTO_3". If you also place a label "TOTO" in sheet n° 1 (root
+sheet) you place in fact a label called "TOTO_1", different from
+"TOTO_3". This is always true, even if there is only one sheet.
 
 [[hierarchical-labels]]
 ===== Hierarchical labels
 
 What is said for the simple labels is also true for hierarchical labels.
 
-Thus in the same sheet, a HLabel “TOTO” is considered to be connected to
-a local label “TOTO”, but not connected to a HLabel or label called
-“TOTO” in another sheet.
+Thus in the same sheet, a HLabel "TOTO" is considered to be connected to
+a local label "TOTO", but not connected to a HLabel or label called
+"TOTO" in another sheet.
 
 However a HLabel is considered to be connected to the corresponding
 SheetLabel symbol in the hierarchical symbol placed in the root sheet.
@@ -256,8 +256,8 @@ SheetLabel symbol in the hierarchical symbol placed in the root sheet.
 ===== Invisible power pins
 
 It was seen that invisible power pins were connected together if they
-have the same name. Thus all the power pins declared “Invisible Power
-Pins“ and named VCC are connected and form the equipotential VCC,
+have the same name. Thus all the power pins declared "Invisible Power
+Pins" and named VCC are connected and form the equipotential VCC,
 whatever the sheet they are placed on.
 
 This means that if you place a VCC label in a sub-sheet, it will not be

--- a/src/eeschema/eeschema_plot_and_print.adoc
+++ b/src/eeschema/eeschema_plot_and_print.adoc
@@ -27,7 +27,7 @@ This command allows you to create PostScript files.
 image:images/100000000000017A000001555B390DD5.png[100000000000017A000001555B390DD5_png]
 
 The file name is the sheet name with an extension .ps. You can disable
-the option “Plot border and title block”. This is useful if you want to create a
+the option "Plot border and title block". This is useful if you want to create a
 postscript file for encapsulation (format .eps) often used to insert a
 diagram in a word processing software. The message window displays the
 file names created.
@@ -111,10 +111,10 @@ printer.
 
 image:images/100000000000015A000000C1CF6CC2C5.png[100000000000015A000000C1CF6CC2C5_png]
 
-The “Print sheet reference and title block” option enables or disables
+The "Print sheet reference and title block" option enables or disables
 sheet references and title block.
 
-The “Print in black and white” option sets printing in monochrome. This
+The "Print in black and white" option sets printing in monochrome. This
 option is generally necessary if you use a black and white laser
 printer, because colors are printed into half-tones that are often not
 so readable.

--- a/src/eeschema/eeschema_viewlib.adoc
+++ b/src/eeschema/eeschema_viewlib.adoc
@@ -7,7 +7,7 @@
 Viewlib allows you to quickly examine the content of libraries. Viewlib
 is called by the tool
 image:images/icons/library_browse.png[icons/library_browse_png]
-or by the “place component” tool available from the right-hand side
+or by the "place component" tool available from the right-hand side
 toolbar.
 
 image:images/100000000000016D000000E7007BA5B8.png[100000000000016D000000E7007BA5B8_png]

--- a/src/gui_translation_howto/gui_translation_howto.adoc
+++ b/src/gui_translation_howto/gui_translation_howto.adoc
@@ -62,7 +62,7 @@ KiCad sources are currently hosted on Launchpad:
 
 https://launchpad.net/kicad
 
-Files can be downloaded from Launchpad by using a tool named “bazaar”
+Files can be downloaded from Launchpad by using a tool named "bazaar"
 (bzr in commands). So:
 
 * Install, if not already done, the tool named bazaar (easy to install

--- a/src/idf_exporter/idf_exporter.adoc
+++ b/src/idf_exporter/idf_exporter.adoc
@@ -59,7 +59,7 @@ to specify models for multiple exporters.
 
 From within the module editor or pcbnew, edit the footprint parameters
 and click on the 3D settings tab (see link:#figure-1[figure 1]), click on Add 3D
-Shape, and select the filter “IDFv3 component files (*.idf)” (see
+Shape, and select the filter "IDFv3 component files (*.idf)" (see
 link:#figure-2[figure 2]). Select the desired outline file and enter any
 necessary values for the offset and rotation. Note that only the offset
 values and the Z rotation value are used by the IDF exporter; all other
@@ -134,12 +134,12 @@ which has four fields:
 1.  Geometry Name: a string which in combination with the Part Number
     must form a unique identifier for the component outline. For
     standardized packages, the package name is a good value for the
-    geometry name, for example “SOT-23”. For unique packages the
+    geometry name, for example "SOT-23". For unique packages the
     manufacturer's part number is a good choice for the geometry name.
 
 2.  Part Number: although obviously intended for the part number, for
     example BS107, it is better to use this string to help describe the
-    package. For example if the geometry name is “TO-92”, the part number
+    package. For example if the geometry name is "TO-92", the part number
     entry may be used to describe the layout of the pads or the
     orientation of this particular TO-92 outline file.
 

--- a/src/kicad/kicad.adoc
+++ b/src/kicad/kicad.adoc
@@ -284,8 +284,8 @@ recommended to create a project as follows:
 * *Create a working directory for the project* (using KiCad or by other
   means).
 * *In this directory, use KiCad to create a project file* (file with
-  extension .pro) via the “Create a new project”
-  or “Create a new project from template” icon.
+  extension .pro) via the "Create a new project"
+  or "Create a new project from template" icon.
 
 [WARNING]
 It is recommended to use a unique directory for each KiCad project.

--- a/src/pcbnew/pcbnew_general_operations.adoc
+++ b/src/pcbnew/pcbnew_general_operations.adoc
@@ -421,7 +421,7 @@ shown in Pcbnew:
     *Note:*
     When Deleting, if several superimposed elements are
     pointed to, priority is given to the smallest (in the decreasing
-    set of priorities tracks, text, module). The function “Undelete”
+    set of priorities tracks, text, module). The function "Undelete"
     of the upper toolbar allows the cancellation of the last item
     deleted.
 | image:images/icons/pcb_offset.png[]

--- a/src/pcbnew/pcbnew_installation.adoc
+++ b/src/pcbnew/pcbnew_installation.adoc
@@ -44,7 +44,7 @@ issue with the footprint library list when duplicate footprint names
 exist in more than one library.  When this occurs, the footprint
 will be loaded from the first library found in the list. If this is an
 issue (you cannot load the footprint you want), either change the
-library list order using the “Up” and “Down” buttons in the dialog
+library list order using the "Up" and "Down" buttons in the dialog
 above or give the footprint a unique name using the footprint
 editor.
 
@@ -58,8 +58,8 @@ accessible by:
 image:images/Library_tables_menu_item.png[]
 
 The image below shows the footprint library table editing dialog
-which can be opened by invoking the “Library Tables” entry from the
-“Preferences” menu.
+which can be opened by invoking the "Library Tables" entry from the
+"Preferences" menu.
 
 image:images/Footprint_tables_list.png[]
 
@@ -165,9 +165,9 @@ Typically GitHub URLs take the form:
 
      https://github.com/user_name/repo_name
 
-The "Plugin Type" must be set to "Github".  To enable the “Copy-On-Write"
+The "Plugin Type" must be set to "Github".  To enable the "Copy-On-Write"
 feature the option `allow_pretty_writing_to_this_dir` must be
-added to the “Options” setting of the footprint library table entry.
+added to the "Options" setting of the footprint library table entry.
 This option is the "Library Path" for local storage of modified
 copies of footprints read from the GitHub repo.  The footprints
 saved to this path are combined with the read-only part of the
@@ -225,7 +225,7 @@ than once.  Also, do not use the same COW (`*.pretty`) directory in
 a footprint library table entry.  This would likely create a mess.
 The value of the option `allow_pretty_writing_to_this_dir` will
 expand any environment variable using the `${}` notation to create
-the path in the same way as the “Library Path” setting.
+the path in the same way as the "Library Path" setting.
 
 What's the point of COW?  It is to turbo-charge the sharing of
 footprints.  If you periodically email your COW pretty footprint

--- a/src/pl_editor/pl_editor.adoc
+++ b/src/pl_editor/pl_editor.adoc
@@ -229,7 +229,7 @@ image:images/icons/title_block_preview.png[] activated.
 Title block displayed like in Eeschema and Pcbnew
 
 |image:images/en/show_fields_codes.png[]
-a|“Native” display mode:
+a|"Native" display mode:
 
 image:images/icons/title_block_edit.png[] activated.
 
@@ -244,7 +244,7 @@ Texts can be multi-line.
 
 There are 2 ways to insert a new line in texts:
 
-1.  Insert the “n” 2 chars sequence (mainly in Page setup dialog in
+1.  Insert the "n" 2 chars sequence (mainly in Page setup dialog in
     KiCad)
 
 2.  Insert a new line in Pl_Editor Design window.
@@ -265,7 +265,7 @@ Setup
 
 In the page setup dialog, text controls do not accept a multi-line text.
 
-The *“\n”* 2 chars sequence should be inserted to force a new line inside a
+The *"\n"* 2 chars sequence should be inserted to force a new line inside a
 text.
 
 Here is a two lines text, in _comment 2_ field:
@@ -276,7 +276,7 @@ Here is the actual text:
 
 image:images/en/multi_line_2.png[]
 
-However, if you really want the *“\n”* inside the text, enter *“\\n”*.
+However, if you really want the *"\n"* inside the text, enter *"\\n"*.
 
 image:images/en/insert_slashnewline_code.png[]
 
@@ -295,7 +295,7 @@ When using Eeschema, the full schematic often uses more than one page.
 Usually page layout items are displayed on all pages.
 
 But if a user want some items to be displayed only on page 1, or not on
-page 1, the “page 1 option” this is possible by setting this option:
+page 1, the "page 1 option" this is possible by setting this option:
 
 [width="100%",cols="29%,71%",]
 |=================================================================
@@ -420,7 +420,7 @@ page layout in user mode: texts are shown like in Eeschema or Pcbnew:
 text format symbols are replaced by the user texts.
 
 |image:images/icons/title_block_edit.png[] |Show the
-page layout in native mode: texts are displayed “as is”, with the
+page layout in native mode: texts are displayed "as is", with the
 contained formats, without any replacement.
 
 |image:images/en/set_base_corner.png[]


### PR DESCRIPTION
eliminate multi byte double quotation for issue #166

I also would like to eliminate from 
eeschema_schematic_creation_and_editing.adoc,
but this causes build error of eeschema_pdf_pl,
so I didn't fix this file only.

I left °(degree) in these 2 files.
`\&deg;` seems work as °, but I couldn't tell it was right.
- eeschema_component_library_editor.adoc
- eeschema_hierarchical_schematics.adoc
