### PR TITLE
Fill in LICENSE.adoc and new link to webpage with licenses

### DIFF
--- a/LICENSE.adoc
+++ b/LICENSE.adoc
@@ -1,7 +1,10 @@
 LICENSE
 =======
 
-The programs and files in this archive are published under the same
-free license of the KiCad documentation project.
+The KiCad documentation is dual licensed. 
+You may distribute it and/or modify it under the terms of either
+the GNU General Public License (http://www.gnu.org/licenses/gpl.html),
+version 3 or later, or the Creative Commons Attribution License
+(http://creativecommons.org/licenses/by/3.0/), version 3.0 or later.
 
-See: http://www.kicad-pcb.org/
+See: http://kicad-pcb.org/about/licenses/


### PR DESCRIPTION
The LICENSE file previously linked to just the webpage root which never had license.
Also the docs carry the dual license notice so best to also shove it here.