### PR TITLE
Avoid using the network during documentation build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ add_adoc_option( --section-numbers )
 add_adoc_option( --theme flask )
 
 # Add the common a2x options
+add_a2x_option( --xsltproc-opts=--nonet )
 add_a2x_option( --no-xmllint )
 add_a2x_option( -f pdf )
 #add_a2x_option( --verbose )

--- a/CMakeModules/AsciidocHelpers.cmake
+++ b/CMakeModules/AsciidocHelpers.cmake
@@ -60,7 +60,8 @@ macro( add_adoc_epub_target TARGET INFILE OUTFILE LANGUAGE )
     string(REGEX REPLACE "_epub_.." "" DOCINFO_OUT "${LANGUAGE}/${TARGET}-docinfo.xml" )
     configure_file( ${CMAKE_SOURCE_DIR}/CMakeSupport/epub-cover-docinfo-template.xml # Prepare cover docinfo
                     ${DOCINFO_OUT} )
-    set( _A2X_OPTIONS -f epub -a docinfo -a lang=${LANGUAGE} )
+    set( _A2X_OPTIONS ${A2X_OPTIONS} )
+    list( APPEND _A2X_OPTIONS -f epub -a docinfo -a lang=${LANGUAGE} )
     add_custom_target( ${TARGET} ALL ${A2X_COMMAND} ${_A2X_OPTIONS} ${INFILE} )
 endmacro()
 


### PR DESCRIPTION
This should stop the documentation build from trying to pull in external files during the build.