### PR TITLE
Fixing regressions in getting_started_in_kicad.adoc

### DIFF
--- a/src/getting_started_in_kicad/getting_started_in_kicad.adoc
+++ b/src/getting_started_in_kicad/getting_started_in_kicad.adoc
@@ -301,7 +301,7 @@ image:images/choose_component.png[Choose Component]
     mouse button to pan horizontally and vertically.
 
 9.  Try to hover the mouse over the component 'R' and press the r key. The component should rotate. You do not need to actually click on the component to rotate it.
-
++
 NOTE: If your mouse was also over the _Field Reference_ ('R') or the _Field Value_ ('R?'), a menu will appear. You will see these 'Clarify Selection' menu often in KiCad, they allow working on objects that are on top of each other. In this case, tell KiCad you want to perform the action on the 'Component ...R...'.
 
 10. Right click in the middle of the component and select *Edit
@@ -364,34 +364,34 @@ be connected. We will see later on why this is the case.
 
 19. We are going to add a component from a library that isn't configured in the default project. In the menu, choose *Preferences* -> **Component Libraries** and click the **Add** button for **Component library files**.
 
-19. You need to find where the official KiCad libraries are installed on your computer. Look for a `library` directory containing a hundred of `.dcm` and `.lib` files. Try in `C:\Program Files (x86)\KiCad\share\` (Windows) and `/usr/share/kicad/library/` (Linux). When you have found the directory, choose and add the 'microchip_pic12mcu' library and close the window.
+20. You need to find where the official KiCad libraries are installed on your computer. Look for a `library` directory containing a hundred of `.dcm` and `.lib` files. Try in `C:\Program Files (x86)\KiCad\share\` (Windows) and `/usr/share/kicad/library/` (Linux). When you have found the directory, choose and add the 'microchip_pic12mcu' library and close the window.
 
-19. Repeat the add-component steps, however this time select the
+21. Repeat the add-component steps, however this time select the
     'microchip_pic12mcu' library instead of the 'device' library and pick the
     'PIC12C508A-I/SN' component.
 
-20. Hover the mouse over the microcontroller component. Press the y key
+22. Hover the mouse over the microcontroller component. Press the y key
     or the x key on the keyboard. Notice how the component is flipped over
     its x axis or its y axis. Press the key again to return it to its
     original orientation.
 
-21. Repeat the add-component steps, this time choosing the 'device'
+23. Repeat the add-component steps, this time choosing the 'device'
     library and picking the 'LED' component from it.
 
-22. Organise all components on your schematic sheet as shown below.
+24. Organise all components on your schematic sheet as shown below.
 +
 image:images/gsik_tutorial1_010.png[gsik_tutorial1_010_png]
 
-23. We now need to create the schematic component 'MYCONN3' for our
+25. We now need to create the schematic component 'MYCONN3' for our
     3-pin connector. You can jump to the section titled
     <<make-schematic-components-in-kicad,Make Schematic Components in KiCad>>
     to learn how to make this component from scratch and then return 
     to this section to continue with the board.
 
-24. You can now place the freshly made component. Press the 'a' key and
+26. You can now place the freshly made component. Press the 'a' key and
     pick the 'MYCONN3' component in the 'myLib' library.
 
-25. The component identifier 'J?' will appear under the 'MYCONN3' label.
+27. The component identifier 'J?' will appear under the 'MYCONN3' label.
     If you want to change its position, right click on 'J?' and click on
     'Move Field' (equivalent to the m key option). It might be helpful to
     zoom in before/while doing this. Reposition 'J?' under the component as
@@ -399,26 +399,26 @@ image:images/gsik_tutorial1_010.png[gsik_tutorial1_010_png]
 +
 image:images/gsik_myconn3_s.png[gsik_myconn3_s_png]
 
-26. It is time to place the power and ground symbols. Click on the
+28. It is time to place the power and ground symbols. Click on the
     'Place a power port' button image:images/icons/add_power.png[add_power_png] on
     the right toolbar. Alternatively, press the 'p' key. In the component 
     selection window, scroll down and select 'VCC' from the 'power' library.
     Click OK.
 
-27. Click above the pin of the 1k resistor to place the VCC part. Click
+29. Click above the pin of the 1k resistor to place the VCC part. Click
     on the area above the microcontroller 'VDD'. In the 'Component Selection
     history' section select 'VCC' and place it next to the VDD pin. Repeat
     the add process again and place a VCC part above the VCC pin of
     'MYCONN3'.
 
-28. Repeat the add-pin steps but this time select the GND part. Place a
+30. Repeat the add-pin steps but this time select the GND part. Place a
     GND part under the GND pin of 'MYCONN3'. Place another GND symbol on the
     right of the VSS pin of the microcontroller. Your schematic should now
     look something like this:
 +
 image:images/gsik_tutorial1_020.png[gsik_tutorial1_020_png]
 
-29. Next, we will wire all our components. Click on the 'Place wire'
+31. Next, we will wire all our components. Click on the 'Place wire'
     icon image:images/icons/add_line.png[Place wire] on the right
     toolbar.
 +
@@ -427,7 +427,7 @@ beneath this button but has thicker lines. The section
 <<bus-connections-in-kicad,Bus Connections in KiCad>> will explain how
 to use a bus section.
 
-30. Click on the little circle at the end of pin 7 of the
+32. Click on the little circle at the end of pin 7 of the
     microcontroller and then click on the little circle on pin 2 of
     the LED.  You can zoom in while you are placing the connection.
 +
@@ -438,7 +438,7 @@ have forgotten how to move a component.
 +
 image:images/gsik_tutorial1_030.png[gsik_tutorial1_030_png]
 
-31. Repeat this process and wire up all the other components as shown
+33. Repeat this process and wire up all the other components as shown
     below. To terminate a wire just double-click. When wiring up the
     VCC and GND symbols, the wire should touch the bottom of the VCC
     symbol and the middle top of the GND symbol. See the screenshot
@@ -446,15 +446,15 @@ image:images/gsik_tutorial1_030.png[gsik_tutorial1_030_png]
 +
 image:images/gsik_tutorial1_040.png[gsik_tutorial1_040_png]
 
-32. We will now consider an alternative way of making a connection
+34. We will now consider an alternative way of making a connection
     using labels. Pick a net labelling tool by clicking on the 'Place
     net name' icon image:images/icons/add_line_label.png[add_line_label_png] on the right
     toolbar. You can also use the l key.
 
-33. Click in the middle of the wire connected to pin 6 of the
+35. Click in the middle of the wire connected to pin 6 of the
     microcontroller. Name this label 'INPUT'.
 
-34. Follow the same procedure and place another label on line on the
+36. Follow the same procedure and place another label on line on the
     right of the 100 ohm resistor. Also name it 'INPUT'. The two
     labels, having the same name, create an invisible connection
     between pin 6 of the PIC and the 100 ohm resistor. This is a
@@ -463,40 +463,40 @@ image:images/gsik_tutorial1_040.png[gsik_tutorial1_040_png]
     a label you do not necessarily need a wire, you can simply attach
     the label to a pin.
 
-35. Labels can also be used to simply label wires for informative
+37. Labels can also be used to simply label wires for informative
     purposes. Place a label on pin 7 of the PIC. Enter the name
     'uCtoLED'.  Name the wire between the resistor and the LED as
     'LEDtoR'. Name the wire between 'MYCONN3' and the resistor as
     'INPUTtoR'.
 
-36. You do not have to label the VCC and GND lines because the labels
+38. You do not have to label the VCC and GND lines because the labels
     are implied from the power objects they are connected to.
 
-37. Below you can see what the final result should look like.
+39. Below you can see what the final result should look like.
 +
 image:images/gsik_tutorial1_050.png[gsik_tutorial1_050_png]
 
-38. Let's now deal with unconnected wires. Any pin or wire that is not
+40. Let's now deal with unconnected wires. Any pin or wire that is not
     connected will generate a warning when checked by KiCad. To avoid
     these warnings you can either instruct the program that the
     unconnected wires are deliberate or manually flag each unconnected
     wire or pin as unconnected.
 
-39. Click on the 'Place no connect flag' icon
+41. Click on the 'Place no connect flag' icon
     image:images/icons/noconn.png[noconn_png] on the right toolbar. Click on
     pins 2, 3, 4 and 5. An X will appear to signify that the lack of a
     wire connection is intentional.
 +
 image:images/gsik_tutorial1_060.png[gsik_tutorial1_060_png]
 
-40. Some components have power pins that are invisible. You can make
+42. Some components have power pins that are invisible. You can make
     them visible by clicking on the 'Show hidden pins' icon
     image:images/icons/hidden_pin.png[hidden_pin_png] on the left
     toolbar. Hidden power pins get automatically connected if VCC and
     GND naming is respected. Generally speaking, you should try not to
     make hidden power pins.
 
-41. It is now necessary to add a 'Power Flag' to indicate to KiCad
+43. It is now necessary to add a 'Power Flag' to indicate to KiCad
     that power comes in from somewhere. Press the a key, select 'List
     All', double click on the 'power' library and search for
     'PWR_FLAG'. Place two of them. Connect them to a GND pin and to
@@ -507,23 +507,23 @@ image:images/gsik_tutorial1_070.png[gsik_tutorial1_070_png]
 NOTE: This will avoid the classic schematic checking warning:
 Warning Pin power_in not driven (Net xx)
 
-42. Sometimes it is good to write comments here and there. To add
+44. Sometimes it is good to write comments here and there. To add
     comments on the schematic use the 'Place graphic text (comment)'
     icon image:images/icons/add_text.png[add_text_png] on the right toolbar.
 
-43. All components now need to have unique identifiers. In fact, many
+45. All components now need to have unique identifiers. In fact, many
     of our components are still named 'R?' or 'J?'. Identifier
     assignation can be done automatically by clicking on the 'Annotate
     schematic' icon image:images/icons/annotate.png[annotate_png] on the top toolbar.
 
-44. In the Annotate Schematic window, select 'Use the entire
+46. In the Annotate Schematic window, select 'Use the entire
     schematic' and click on the 'Annotation' button. Click OK in the
     confirmation message and then click 'Close'. Notice how all the
     '?' have been replaced with numbers. Each identifier is now
     unique. In our example, they have been named 'R1', 'R2', 'U1',
     'D1' and 'J1'.
 
-45. We will now check our schematic for errors. Click on the 'Perform
+47. We will now check our schematic for errors. Click on the 'Perform
     electrical rules check' icon image:images/icons/erc.png[erc_png] on the top toolbar. Click on
     the 'Run' button. A report informing you of any errors or
     warnings such as disconnected wires is generated. You should have
@@ -532,20 +532,20 @@ Warning Pin power_in not driven (Net xx)
     error or the warning is located. Check 'Create ERC file report' and
     press the 'Run' button again to receive more information
     about the errors.
-
++
 NOTE: If you have a warning with "No default editor found you must choose it", try setting the path to `c:\windows\notepad.exe` (windows) or `/usr/bin/gedit` (Linux).
 
-46. The schematic is now finished. We can now create a Netlist file to
+48. The schematic is now finished. We can now create a Netlist file to
     which we will add the footprint of each component. Click on the
     'Generate netlist' icon image:images/icons/netlist.png[netlist_png] on
     the top toolbar. Click on the 'Generate' button and save under the default file name.
 
-47. After generating the Netlist file, click on the 'Run Cvpcb' icon
+49. After generating the Netlist file, click on the 'Run Cvpcb' icon
     image:images/icons/cvpcb.png[cvpcb_png] on the top
     toolbar. If a missing file error window pops up, just ignore it
     and click OK.
 
-48. _Cvpcb_ allows you to link all the components in your schematic
+50. _Cvpcb_ allows you to link all the components in your schematic
     with footprints in the KiCad library. The pane on the center shows
     all the components used in your schematic. Here select 'D1'. In
     the pane on the right you have all the available footprints, here
@@ -553,7 +553,7 @@ NOTE: If you have a warning with "No default editor found you must choose it", t
 +
 image:images/icons/cvpcb.png[cvpcb_png]
 
-49. It is possible that the pane on the right shows only a selected
+51. It is possible that the pane on the right shows only a selected
     subgroup of available footprints. This is because KiCad is trying
     to suggest to you a subset of suitable footprints. Click on the
     icons image:images/icons/module_filtered_list.png[module_filtered_list_png],
@@ -561,11 +561,11 @@ image:images/icons/cvpcb.png[cvpcb_png]
     image:images/icons/module_library_list.png[module_library_list_png] to
     enable or disable these filters.
 
-50. For 'IC1' select the 'Housings_DIP:DIP-8_W7.62mm' footprint.
+52. For 'IC1' select the 'Housings_DIP:DIP-8_W7.62mm' footprint.
     For 'J1' select the 'Connect:Banana_Jack_3Pin' footprint.
     For 'R1' and 'R2' select the 'Discret:R1' footprint.
 
-51. If you are interested in knowing what the footprint you are
+53. If you are interested in knowing what the footprint you are
     choosing looks like, you have two options. You can click on the
     'View selected footprint' icon
     image:images/icons/show_footprint.png[show_footprint_png] for a preview
@@ -576,7 +576,7 @@ image:images/icons/cvpcb.png[cvpcb_png]
     print it out and check your components to make sure that the
     dimensions match.
 
-52. You are done. You can now update your netlist file with all the
+54. You are done. You can now update your netlist file with all the
     associated footprints. Click on *File* -> **Save As**. The default
     name 'tutorial1.net' is fine, click save. Otherwise you can use the
     icon image:images/icons/save.png[Save icon].  Your netlist file has now
@@ -585,20 +585,20 @@ image:images/icons/cvpcb.png[cvpcb_png]
     footprints. This will be explained in a later section of this
     document.
 
-53. You can close _Cvpcb_ and go back to the _Eeschema_ schematic
+55. You can close _Cvpcb_ and go back to the _Eeschema_ schematic
     editor. Save the project by clicking on *File* -> **Save Whole
     Schematic Project**. Close the schematic editor.
 
-54. Switch to the KiCad project manager.
+56. Switch to the KiCad project manager.
 
-55. The netlist file describes all components and their respective pin
+57. The netlist file describes all components and their respective pin
     connections. The netlist file is actually a text file that you can
     easily inspect, edit or script.
 +
 NOTE: Library files (__*.lib__) are text files too and they are also
 easily editable or scriptable.
 
-56. To create a Bill Of Materials (BOM), go to the _Eeschema_ schematic 
+58. To create a Bill Of Materials (BOM), go to the _Eeschema_ schematic 
     editor and click on the 'Bill of materials' icon 
     image:images/icons/bom.png[bom_png] on the top toolbar.
     By default there is no plugin active. You add one, by clicking on
@@ -628,7 +628,7 @@ xsltproc -o "%O.csv" "/home/<user>/kicad/eeschema/plugins/bom2csv.xsl" "%I"
 +
 Press Help button for more info.
 
-57. Now press 'Generate'. The file (same name as your project) is
+59. Now press 'Generate'. The file (same name as your project) is
     located in your project folder.  Open the **.csv* file with
     LibreOffice Calc or Excel. An import window will appear, press OK.
 

--- a/src/getting_started_in_kicad/getting_started_in_kicad.adoc
+++ b/src/getting_started_in_kicad/getting_started_in_kicad.adoc
@@ -119,11 +119,11 @@ Unstable builds are built from the most recent source code. They can sometimes
 have bugs that cause file corruption, generate bad gerbers, etc, but are generally
 stable and have the latest features.
 
-Under Ubuntu, the easiest way to install an unstable nightly build of KiCad is 
+Under Ubuntu, the easiest way to install an unstable nightly build of KiCad is
 via _PPA_ and __Aptitude__. Type the following into your Terminal:
 
 __________________________________________________
-sudo add-apt-repository ppa:js-reynaud/ppa-kicad 
+sudo add-apt-repository ppa:js-reynaud/ppa-kicad
 
 sudo aptitude update && sudo aptitude safe-upgrade
 
@@ -197,8 +197,8 @@ library are necessary for these two tasks. KiCad has plenty of both.
 Just in case that is not enough, KiCad also has the tools necessary to
 make new ones.
 
-In the picture below, you see a flowchart representing the KiCad work-flow. 
-The picture explains which steps you need to take, in which order. 
+In the picture below, you see a flowchart representing the KiCad work-flow.
+The picture explains which steps you need to take, in which order.
 When applicable, the icon is added as well for convenience.
 
 image:images/kicad_flowchart.png["KiCad Flowchart"]
@@ -282,9 +282,9 @@ image:images/kicad_main_window.png[KiCad Main Window]
 NOTE: You can see a list of all available shortcut keys by pressing
 the '?' key.
 
-6.  Click on the middle of your schematic sheet. A __Choose Component__ 
+6.  Click on the middle of your schematic sheet. A __Choose Component__
     window will appear on the screen.
-    We're going to place a resistor. Search / filter on the 'R' of 
+    We're going to place a resistor. Search / filter on the 'R' of
     **R**esistor.
     You may notice the 'device' heading above the Resistor. This
     'device' heading is the name of the library where the component is
@@ -300,9 +300,15 @@ image:images/choose_component.png[Choose Component]
     use the mouse wheel to zoom in and zoom out. Press the wheel (central)
     mouse button to pan horizontally and vertically.
 
-9.  Try to hover the mouse over the component 'R' and press the r key. The component should rotate. You do not need to actually click on the component to rotate it.
+9.  Try to hover the mouse over the component 'R' and press the r key. The
+    component should rotate. You do not need to actually click on the component
+    to rotate it.
 +
-NOTE: If your mouse was also over the _Field Reference_ ('R') or the _Field Value_ ('R?'), a menu will appear. You will see these 'Clarify Selection' menu often in KiCad, they allow working on objects that are on top of each other. In this case, tell KiCad you want to perform the action on the 'Component ...R...'.
+NOTE: If your mouse was also over the _Field Reference_ ('R') or the _Field
+Value_ ('R?'), a menu will appear. You will see these 'Clarify Selection' menu
+often in KiCad, they allow working on objects that are on top of each other. In
+this case, tell KiCad you want to perform the action on the 'Component
+...R...'.
 
 10. Right click in the middle of the component and select *Edit
     Component* -> **Value**. You can achieve the same result by hovering
@@ -362,9 +368,15 @@ be connected. We will see later on why this is the case.
     select**. __In general, it is recommendable to use a grid of 50.0 mils
     for the schematic sheet__.
 
-19. We are going to add a component from a library that isn't configured in the default project. In the menu, choose *Preferences* -> **Component Libraries** and click the **Add** button for **Component library files**.
+19. We are going to add a component from a library that isn't configured in the
+    default project. In the menu, choose *Preferences* -> **Component Libraries**
+    and click the **Add** button for **Component library files**.
 
-20. You need to find where the official KiCad libraries are installed on your computer. Look for a `library` directory containing a hundred of `.dcm` and `.lib` files. Try in `C:\Program Files (x86)\KiCad\share\` (Windows) and `/usr/share/kicad/library/` (Linux). When you have found the directory, choose and add the 'microchip_pic12mcu' library and close the window.
+20. You need to find where the official KiCad libraries are installed on your
+    computer. Look for a `library` directory containing a hundred of `.dcm` and
+    `.lib` files. Try in `C:\Program Files (x86)\KiCad\share\` (Windows) and
+    `/usr/share/kicad/library/` (Linux). When you have found the directory,
+    choose and add the 'microchip_pic12mcu' library and close the window.
 
 21. Repeat the add-component steps, however this time select the
     'microchip_pic12mcu' library instead of the 'device' library and pick the
@@ -385,7 +397,7 @@ image:images/gsik_tutorial1_010.png[gsik_tutorial1_010_png]
 25. We now need to create the schematic component 'MYCONN3' for our
     3-pin connector. You can jump to the section titled
     <<make-schematic-components-in-kicad,Make Schematic Components in KiCad>>
-    to learn how to make this component from scratch and then return 
+    to learn how to make this component from scratch and then return
     to this section to continue with the board.
 
 26. You can now place the freshly made component. Press the 'a' key and
@@ -401,7 +413,7 @@ image:images/gsik_myconn3_s.png[gsik_myconn3_s_png]
 
 28. It is time to place the power and ground symbols. Click on the
     'Place a power port' button image:images/icons/add_power.png[add_power_png] on
-    the right toolbar. Alternatively, press the 'p' key. In the component 
+    the right toolbar. Alternatively, press the 'p' key. In the component
     selection window, scroll down and select 'VCC' from the 'power' library.
     Click OK.
 
@@ -448,8 +460,8 @@ image:images/gsik_tutorial1_040.png[gsik_tutorial1_040_png]
 
 34. We will now consider an alternative way of making a connection
     using labels. Pick a net labelling tool by clicking on the 'Place
-    net name' icon image:images/icons/add_line_label.png[add_line_label_png] on the right
-    toolbar. You can also use the l key.
+    net name' icon image:images/icons/add_line_label.png[add_line_label_png]
+    on the right toolbar. You can also use the l key.
 
 35. Click in the middle of the wire connected to pin 6 of the
     microcontroller. Name this label 'INPUT'.
@@ -514,7 +526,8 @@ Warning Pin power_in not driven (Net xx)
 45. All components now need to have unique identifiers. In fact, many
     of our components are still named 'R?' or 'J?'. Identifier
     assignation can be done automatically by clicking on the 'Annotate
-    schematic' icon image:images/icons/annotate.png[annotate_png] on the top toolbar.
+    schematic' icon image:images/icons/annotate.png[annotate_png] on the top
+    toolbar.
 
 46. In the Annotate Schematic window, select 'Use the entire
     schematic' and click on the 'Annotation' button. Click OK in the
@@ -524,16 +537,17 @@ Warning Pin power_in not driven (Net xx)
     'D1' and 'J1'.
 
 47. We will now check our schematic for errors. Click on the 'Perform
-    electrical rules check' icon image:images/icons/erc.png[erc_png] on the top toolbar. Click on
-    the 'Run' button. A report informing you of any errors or
-    warnings such as disconnected wires is generated. You should have
-    0 Errors and 0 Warnings. In case of errors or warnings, a small
-    green arrow will appear on the schematic in the position where the
-    error or the warning is located. Check 'Create ERC file report' and
-    press the 'Run' button again to receive more information
-    about the errors.
+    electrical rules check' icon image:images/icons/erc.png[erc_png] on the top
+    toolbar. Click on the 'Run' button. A report informing you of any errors or
+    warnings such as disconnected wires is generated. You should have 0 Errors
+    and 0 Warnings. In case of errors or warnings, a small green arrow will
+    appear on the schematic in the position where the error or the warning is
+    located. Check 'Create ERC file report' and press the 'Run' button again to
+    receive more information about the errors.
 +
-NOTE: If you have a warning with "No default editor found you must choose it", try setting the path to `c:\windows\notepad.exe` (windows) or `/usr/bin/gedit` (Linux).
+NOTE: If you have a warning with "No default editor found you must choose it",
+try setting the path to `c:\windows\notepad.exe` (windows) or `/usr/bin/gedit`
+(Linux).
 
 48. The schematic is now finished. We can now create a Netlist file to
     which we will add the footprint of each component. Click on the
@@ -598,11 +612,11 @@ image:images/icons/cvpcb.png[cvpcb_png]
 NOTE: Library files (__*.lib__) are text files too and they are also
 easily editable or scriptable.
 
-58. To create a Bill Of Materials (BOM), go to the _Eeschema_ schematic 
-    editor and click on the 'Bill of materials' icon 
+58. To create a Bill Of Materials (BOM), go to the _Eeschema_ schematic
+    editor and click on the 'Bill of materials' icon
     image:images/icons/bom.png[bom_png] on the top toolbar.
     By default there is no plugin active. You add one, by clicking on
-    *Add Plugin* button. Select the *.xsl file you want to use, in 
+    *Add Plugin* button. Select the *.xsl file you want to use, in
     this case, we select __bom2csv.xsl__.
 +
 [NOTE]
@@ -758,14 +772,14 @@ image:images/design_rules.png[Design Rules Window]
     __ratsnest__. Make sure that the 'Hide board ratsnest' button
     image:images/icons/general_ratsnest.png[general_ratsnest_png] is
     pressed. In this way you can see the ratsnest linking all
-    components. 
+    components.
 +
 NOTE: The tool-tip is backwards; pressing this button
 actually displays the ratsnest.
 
 9.  You can move each component by hovering over it and pressing the g
     key. Click where you want to place them. Move all components around
-    until you minimise the number of wire crossovers. 
+    until you minimise the number of wire crossovers.
 +
 NOTE: If instead of grabbing the components (with the g key ) you
 move them around using the m key you will later note that you lose the
@@ -955,13 +969,13 @@ and it is needed to build by yourself to use with KiCad.
 Source code of Freerouter can be found on this site:
 https://github.com/nikropht/FreeRouting
 
-1.  From _Pcbnew_ click on *File* -> *Export* -> *Specctra DSN* 
-    or click on *Tools* -> *FreeRoute* -> **Export a Specctra 
+1.  From _Pcbnew_ click on *File* -> *Export* -> *Specctra DSN*
+    or click on *Tools* -> *FreeRoute* -> **Export a Specctra
     Design (*.dsn) file** and save the file locally.
     Launch FreeRouter and click on the 'Open Your Own Design'
     button, browse for the _dsn_ file and load it.
 +
-NOTE: The *Tools* -> *FreeRoute* dialog has a nice help button 
+NOTE: The *Tools* -> *FreeRoute* dialog has a nice help button
 that opens a file viewer with a little document inside named
 **Freerouter Guidelines**. Please follow these guidelines to
 use FreeRoute effectively.

--- a/src/getting_started_in_kicad/po/de.po
+++ b/src/getting_started_in_kicad/po/de.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KiCad\n"
-"POT-Creation-Date: 2016-01-07 20:18+0100\n"
-"PO-Revision-Date: 2016-01-05 17:17+0100\n"
+"POT-Creation-Date: 2016-01-07 20:26+0100\n"
+"PO-Revision-Date: 2016-01-07 20:31+0100\n"
 "Last-Translator: Carsten Schoenert <c.schoenert@t-online.de>\n"
 "Language-Team: \n"
 "Language: de\n"
@@ -748,17 +748,14 @@ msgstr ""
 
 #. type: Plain text
 #: getting_started_in_kicad.adoc:306
-#, fuzzy
-#| msgid ""
-#| "Hover the mouse over the component 'R' and press the r key. Notice how "
-#| "the component rotates."
 msgid ""
 "Try to hover the mouse over the component 'R' and press the r key. The "
 "component should rotate. You do not need to actually click on the component "
 "to rotate it."
 msgstr ""
 "Bewegen Sie den Mauszeiger über das Bauteil 'R' und betätigen die Taste 'r'. "
-"Beachten Sie wie das Bauteil jeweils um 90° rotiert."
+"Das Bauteil sollte rotierten. Sie müssen nicht auf das Bauteil klicken um "
+"dieses zu rotieren."
 
 #. type: Plain text
 #: getting_started_in_kicad.adoc:312
@@ -769,6 +766,11 @@ msgid ""
 "In this case, tell KiCad you want to perform the action on the 'Component ..."
 "R...'."
 msgstr ""
+"Wenn Ihre Maus gleichzeitig über _Feld Referenz_ ('R') oder _Feld Wert_ "
+"('R?') war wird ein Menü erscheinen. Sie werden das Menü 'Klarstellung der "
+"Auswahl' oft in KiCad sehen, dieses erlaubt das Arbeiten an Objekten die "
+"aufeinander liegen. In diesem Fall hier sagen Sie KiCad das Sie die Aktion "
+"auf das 'Bauteil ...R...' ausführen wollen."
 
 #. type: Plain text
 #: getting_started_in_kicad.adoc:318
@@ -931,6 +933,10 @@ msgid ""
 "default project. In the menu, choose *Preferences* -> **Component "
 "Libraries** and click the **Add** button for **Component library files**."
 msgstr ""
+"Wir werden nun ein Bauteil aus einer Bibliothek hinzufügen welche nicht im "
+"Standard Projekt konfiguriert ist. In der Menüleiste wählen Sie "
+"*Einstellungen* -> **Bauteilbibliotheksdateien** und betätigen den Button "
+"*Hinzufügen* im Bereich **Bauteilbibliotheksdateien**."
 
 #. type: Plain text
 #: getting_started_in_kicad.adoc:380
@@ -941,20 +947,23 @@ msgid ""
 "`/usr/share/kicad/library/` (Linux). When you have found the directory, "
 "choose and add the 'microchip_pic12mcu' library and close the window."
 msgstr ""
+"Sie müssen wissen wo die offiziellen KiCad Bibliotheken auf Ihrem Computer "
+"installiert sind. Suchen Sie nach einem `library` Ordner der Hunderte von `."
+"dcm`und `.lib` Dateien enthält. Suchen Sie unter Windows in `C:\\Program "
+"Files (x86)\\KiCad\\share\\` und unter Linux in `/usr/share/kicad/library/`. "
+"Wenn Sie den Ordner gefunden haben wählen Sie 'microchip_pic12mcu' als "
+"Bibliothek aus und schließen das Fenster."
 
 #. type: Plain text
 #: getting_started_in_kicad.adoc:384
-#, fuzzy
-#| msgid ""
-#| "Repeat the add-component steps, this time choosing the 'device' library "
-#| "and picking the 'LED' component from it."
 msgid ""
 "Repeat the add-component steps, however this time select the "
 "'microchip_pic12mcu' library instead of the 'device' library and pick the "
 "'PIC12C508A-I/SN' component."
 msgstr ""
-"Wiederholen Sie die Schritte des Hinzuzufügens, dieses mal wählen Sie aus "
-"der 'device' Bibliothek das 'LED' Bauteil aus."
+"Wiederholen Sie die Schritte des Hinzuzufügens, dieses mal wählen Sie die "
+"Bibliothek 'microchip_pic12mcu' statt 'device' aus und wählen das Bauteil  "
+"'PIC12C508A-I/SN' aus."
 
 #. type: Plain text
 #: getting_started_in_kicad.adoc:389
@@ -1329,19 +1338,13 @@ msgstr ""
 
 #. type: Plain text
 #: getting_started_in_kicad.adoc:531
-#, fuzzy
-#| msgid ""
-#| "All components now need to have unique identifiers. In fact, many of our "
-#| "components are still named 'R?' or 'J?'. Identifier assignation can be "
-#| "done automatically by clicking on the 'Annotate schematic' icon image:"
-#| "images/icons/annotate.png[annotate_png]."
 msgid ""
 "All components now need to have unique identifiers. In fact, many of our "
 "components are still named 'R?' or 'J?'. Identifier assignation can be done "
 "automatically by clicking on the 'Annotate schematic' icon image:images/"
 "icons/annotate.png[annotate_png] on the top toolbar."
 msgstr ""
-"Nun benötigen alle Bauteile eine eindeutige Idendifikation. Aktuell sind "
+"Nun benötigen alle Bauteile eine eindeutige Identifikation. Aktuell sind "
 "alle Komponenten immer noch 'R?' oder 'J?' benannt. Eine "
 "Identifikationszuweisung kann automatisch erfolgen indem das Icon "
 "'Annotation im Schaltplan durchführen' image:images/icons/annotate."
@@ -1365,16 +1368,6 @@ msgstr ""
 
 #. type: Plain text
 #: getting_started_in_kicad.adoc:547
-#, fuzzy
-#| msgid ""
-#| "We will now check our schematic for errors. Click on the 'Perform "
-#| "Electric Rules Check' icon image:images/icons/erc.png[erc_png]. Click on "
-#| "the 'Test ERC' button. A report informing you of any errors or warnings "
-#| "such as disconnected wires is generated. You should have 0 Errors and 0 "
-#| "Warnings. In case of errors or warnings, a small green arrow will appear "
-#| "on the schematic in the position where the error or the warning is "
-#| "located. Check 'Write ERC report' and press the 'Test ERC' button again "
-#| "to receive more information about the errors."
 msgid ""
 "We will now check our schematic for errors. Click on the 'Perform electrical "
 "rules check' icon image:images/icons/erc.png[erc_png] on the top toolbar. "
@@ -1404,16 +1397,13 @@ msgid ""
 "try setting the path to `c:\\windows\\notepad.exe` (windows) or `/usr/bin/"
 "gedit` (Linux)."
 msgstr ""
+"Wenn Sie eine Warnung erhalten 'Keine Einstellungen für Editor gefunden. "
+"Bitte einen vorgeben.\" stellen Sie bitte unter Windows `c:\\windows"
+"\\notepad.exe` ein bzw. unter Linux z.B. `/usr/bin/gedit` (Gnome) oder auch "
+"`/usr/bin/kwrite` (KDE)."
 
 #. type: Plain text
 #: getting_started_in_kicad.adoc:556
-#, fuzzy
-#| msgid ""
-#| "The schematic is now finished. We can now create a Netlist file to which "
-#| "we will add the footprint of each component. Click on the 'Netlist "
-#| "generation' icon image:images/icons/netlist.png[netlist_png] on the top "
-#| "toolbar. Click on 'Netlist' then click on 'save'. Save under the default "
-#| "file name."
 msgid ""
 "The schematic is now finished. We can now create a Netlist file to which we "
 "will add the footprint of each component. Click on the 'Generate netlist' "
@@ -1424,8 +1414,8 @@ msgstr ""
 "erstellen zu der wir später die Footprints für jedes Bauteil hinzufügen. "
 "Klicken Sie auf das Icon 'Netzliste erstellen' image:images/icons/netlist."
 "png[netlist_png] in der oberen Toolbar. Klicken Sie auf 'Erstellen' und im "
-"sich öffenenden Dateidialog auf den Button Speichern. Speichern Sie die "
-"Datei mit dem voreingestellten Dateinamen."
+"sich öffnenden Dateidialog auf den Button Speichern. Speichern Sie die Datei "
+"mit dem voreingestellten Dateinamen."
 
 #. type: Plain text
 #: getting_started_in_kicad.adoc:561
@@ -2879,13 +2869,6 @@ msgstr ""
 
 #. type: Plain text
 #: getting_started_in_kicad.adoc:1147
-#, fuzzy
-#| msgid ""
-#| "Next, draw the contour of the component. Click on the 'Add rectangle' "
-#| "icon image:images/icons/add_rectangle.png[add_rectangle_png]. We want to "
-#| "draw a rectangle next to the pins, as shown below. To do this, click "
-#| "where you want the top left corner of the rectangle to be. Click again "
-#| "where you want the bottom right corner of the rectangle to be."
 msgid ""
 "Next, draw the contour of the component. Click on the 'Add rectangle' icon "
 "image:images/icons/add_rectangle.png[add_rectangle_png]. We want to draw a "
@@ -3791,22 +3774,3 @@ msgstr ""
 #: getting_started_in_kicad.adoc:1525
 msgid "http://kicad-pcb.org/help/documentation/"
 msgstr ""
-
-#~ msgid "You do not need to actually click on the component to rotate it."
-#~ msgstr ""
-#~ "Sie müssen hier nicht aktiv auf das Bauteil klicken um es zu rotieren."
-
-#~ msgid ""
-#~ "Repeat the add-component steps, however this time select the "
-#~ "'microchip_pic12mcu' library instead of the 'device' library and pick the "
-#~ "'PIC12C508A-I/SN' component instead of the 'R' component from it.  Before "
-#~ "add-component, add 'microchip_pic12mcu' to your Component library files "
-#~ "by *Preferences* -> **Component Libraries** and press Add button."
-#~ msgstr ""
-#~ "Wiederholen Sie die Schritte zum Hinzufügen, diesmal wählen Sie die "
-#~ "'microchip_pic12mcu' Bibliothek anstatt der 'device' Bibliothek. Suchen "
-#~ "Sie das Bauteil 'PIC12C508A-I/SN' statt dem Bauteil 'R'. Vor dem "
-#~ "Hinzufügen des neuen Bauteils übernehmen Sie 'microchip_pic12mcu' zu "
-#~ "ihren Bauteilbibliotheksdateien durch *Einstellungen* -> **Bauteil "
-#~ "Bibliotheken** und betätigen den Hinzufügen Button. Wählen Sie die Datei "
-#~ "'microchip_pic12mcu.lib'."

--- a/src/getting_started_in_kicad/po/de.po
+++ b/src/getting_started_in_kicad/po/de.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KiCad\n"
-"POT-Creation-Date: 2016-01-06 23:55+0100\n"
+"POT-Creation-Date: 2016-01-07 20:18+0100\n"
 "PO-Revision-Date: 2016-01-05 17:17+0100\n"
 "Last-Translator: Carsten Schoenert <c.schoenert@t-online.de>\n"
 "Language-Team: \n"
@@ -747,7 +747,7 @@ msgstr ""
 "Arbeitsblatt horizontal und vertikal zu verschieben."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:304
+#: getting_started_in_kicad.adoc:306
 #, fuzzy
 #| msgid ""
 #| "Hover the mouse over the component 'R' and press the r key. Notice how "
@@ -761,7 +761,7 @@ msgstr ""
 "Beachten Sie wie das Bauteil jeweils um 90° rotiert."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:306
+#: getting_started_in_kicad.adoc:312
 msgid ""
 "If your mouse was also over the _Field Reference_ ('R') or the _Field Value_ "
 "('R?'), a menu will appear. You will see these 'Clarify Selection' menu "
@@ -771,7 +771,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:312
+#: getting_started_in_kicad.adoc:318
 msgid ""
 "Right click in the middle of the component and select *Edit Component* -> "
 "**Value**. You can achieve the same result by hovering over the component "
@@ -788,12 +788,12 @@ msgstr ""
 
 # No translation needed.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:314
+#: getting_started_in_kicad.adoc:320
 msgid "image:images/edit_component_dropdown.png[Edit component menu]"
 msgstr "image:images/de/edit_component_dropdown.png[Bauteilwert ändern]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:317
+#: getting_started_in_kicad.adoc:323
 msgid ""
 "The Component value window will appear. Replace the current value 'R' with "
 "'1k'. Click OK."
@@ -802,7 +802,7 @@ msgstr ""
 "aktuellen Wert 'R' mit '1k' und bestätigen mit OK."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:320
+#: getting_started_in_kicad.adoc:326
 msgid ""
 "Do not change the Reference field (R?), this will be done automatically "
 "later on. The value inside the resistor should now be '1k'."
@@ -812,12 +812,12 @@ msgstr ""
 
 # No translation needed.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:322
+#: getting_started_in_kicad.adoc:328
 msgid "image:images/resistor_value.png[Resistor Value]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:325
+#: getting_started_in_kicad.adoc:331
 msgid ""
 "To place another resistor, simply click where you want the resistor to "
 "appear. The Component Selection window will appear again."
@@ -827,7 +827,7 @@ msgstr ""
 "'Bauteilauswahl' wird wieder geöffnet."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:328
+#: getting_started_in_kicad.adoc:334
 msgid ""
 "The resistor you previously chose is now in your history list, appearing as "
 "'R'. Click OK and place the component."
@@ -836,12 +836,12 @@ msgstr ""
 "'R' angezeigt. Betätigen Sie OK und platzieren das Bauteil."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:330
+#: getting_started_in_kicad.adoc:336
 msgid "image:images/component_history.png[Component history]"
 msgstr "image:images/de/component_history.png[Bauteil Historie]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:335
+#: getting_started_in_kicad.adoc:341
 msgid ""
 "In case you make a mistake and want to delete a component, right click on "
 "the component and click 'Delete Component'. This will remove the component "
@@ -854,7 +854,7 @@ msgstr ""
 "den Mauszeiger über das Bauteil und betätigt die 'Entf' Taste."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:339
+#: getting_started_in_kicad.adoc:345
 msgid ""
 "You can edit any default shortcut key by going to *Preferences* -> *Hotkeys* "
 "-> **Edit hotkeys**. Any modification will be saved immediately."
@@ -864,7 +864,7 @@ msgstr ""
 "aufrufen. Alle Veränderungen werden sofort gespeichert."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:343
+#: getting_started_in_kicad.adoc:349
 msgid ""
 "You can also duplicate a component already on your schematic sheet by "
 "hovering over it and pressing the c key. Click where you want to place the "
@@ -876,7 +876,7 @@ msgstr ""
 "werden soll dann einfach klicken."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:349
+#: getting_started_in_kicad.adoc:355
 msgid ""
 "Right click on the second resistor. Select 'Drag Component'.  Reposition the "
 "component and left click to drop. The same functionality can be achieved by "
@@ -890,7 +890,7 @@ msgstr ""
 "Bauteil rotieren. Die Tasten 'x' und 'y' spiegeln das Bauteil."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:354
+#: getting_started_in_kicad.adoc:360
 #, no-wrap
 msgid ""
 "*Right-Click* -> *Move component* (equivalent to the m key\n"
@@ -900,7 +900,7 @@ msgid ""
 msgstr "*Rechts Klick* -> *Bauteil bewegen* (äquivalente Option zur Taste 'm') ist ebenfalls eine mögliche Variante um etwas zu bewegen, aber es ist besser dies nur für Bauteilbeschriftungen und Bauteile zu benutzen die noch nicht verbunden sind. Wir werden später sehen warum dies der Fall ist.\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:358
+#: getting_started_in_kicad.adoc:364
 msgid ""
 "Edit the second resistor by hovering over it and pressing the v key.  "
 "Replace 'R' with '100'. You can undo any of your editing actions with the "
@@ -911,7 +911,7 @@ msgstr ""
 "Kombination 'Strg+z' rückgängig machen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:364
+#: getting_started_in_kicad.adoc:370
 msgid ""
 "Change the grid size. You have probably noticed that on the schematic sheet "
 "all components are snapped onto a large pitch grid. You can easily change "
@@ -925,7 +925,7 @@ msgstr ""
 "Schaltpläne zu verwenden.__"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:366
+#: getting_started_in_kicad.adoc:374
 msgid ""
 "We are going to add a component from a library that isn't configured in the "
 "default project. In the menu, choose *Preferences* -> **Component "
@@ -933,7 +933,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:368
+#: getting_started_in_kicad.adoc:380
 msgid ""
 "You need to find where the official KiCad libraries are installed on your "
 "computer. Look for a `library` directory containing a hundred of `.dcm` and "
@@ -943,7 +943,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:372
+#: getting_started_in_kicad.adoc:384
 #, fuzzy
 #| msgid ""
 #| "Repeat the add-component steps, this time choosing the 'device' library "
@@ -957,7 +957,7 @@ msgstr ""
 "der 'device' Bibliothek das 'LED' Bauteil aus."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:377
+#: getting_started_in_kicad.adoc:389
 msgid ""
 "Hover the mouse over the microcontroller component. Press the y key or the x "
 "key on the keyboard. Notice how the component is flipped over its x axis or "
@@ -969,7 +969,7 @@ msgstr ""
 "ursprüngliche Ausrichtung zurück gedreht."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:380
+#: getting_started_in_kicad.adoc:392
 msgid ""
 "Repeat the add-component steps, this time choosing the 'device' library and "
 "picking the 'LED' component from it."
@@ -978,7 +978,7 @@ msgstr ""
 "der 'device' Bibliothek das 'LED' Bauteil aus."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:382
+#: getting_started_in_kicad.adoc:394
 msgid "Organise all components on your schematic sheet as shown below."
 msgstr ""
 "Alle Bauteile in Deinem Schaltplan sollten in etwa wie folgend organisiert "
@@ -986,12 +986,12 @@ msgstr ""
 
 # No translation needed.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:384
+#: getting_started_in_kicad.adoc:396
 msgid "image:images/gsik_tutorial1_010.png[gsik_tutorial1_010_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:390
+#: getting_started_in_kicad.adoc:402
 msgid ""
 "We now need to create the schematic component 'MYCONN3' for our 3-pin "
 "connector. You can jump to the section titled <<make-schematic-components-in-"
@@ -1006,7 +1006,7 @@ msgstr ""
 "kehren."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:393
+#: getting_started_in_kicad.adoc:405
 msgid ""
 "You can now place the freshly made component. Press the 'a' key and pick the "
 "'MYCONN3' component in the 'myLib' library."
@@ -1015,7 +1015,7 @@ msgstr ""
 "'a' und wählen das Bauteil 'MYCONN3' aus der 'myLib' Bibliothek."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:399
+#: getting_started_in_kicad.adoc:411
 msgid ""
 "The component identifier 'J?' will appear under the 'MYCONN3' label.  If you "
 "want to change its position, right click on 'J?' and click on 'Move "
@@ -1032,12 +1032,12 @@ msgstr ""
 
 # No translation needed.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:401
+#: getting_started_in_kicad.adoc:413
 msgid "image:images/gsik_myconn3_s.png[gsik_myconn3_s_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:407
+#: getting_started_in_kicad.adoc:419
 msgid ""
 "It is time to place the power and ground symbols. Click on the 'Place a "
 "power port' button image:images/icons/add_power.png[add_power_png] on the "
@@ -1052,7 +1052,7 @@ msgstr ""
 "Auswahl mit dem OK Button."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:413
+#: getting_started_in_kicad.adoc:425
 msgid ""
 "Click above the pin of the 1k resistor to place the VCC part. Click on the "
 "area above the microcontroller 'VDD'. In the 'Component Selection history' "
@@ -1067,7 +1067,7 @@ msgstr ""
 "von 'MYCONN3'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:418
+#: getting_started_in_kicad.adoc:430
 msgid ""
 "Repeat the add-pin steps but this time select the GND part. Place a GND part "
 "under the GND pin of 'MYCONN3'. Place another GND symbol on the right of the "
@@ -1082,12 +1082,12 @@ msgstr ""
 
 # No translation needed.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:420
+#: getting_started_in_kicad.adoc:432
 msgid "image:images/gsik_tutorial1_020.png[gsik_tutorial1_020_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:424
+#: getting_started_in_kicad.adoc:436
 msgid ""
 "Next, we will wire all our components. Click on the 'Place wire' icon image:"
 "images/icons/add_line.png[Place wire] on the right toolbar."
@@ -1097,7 +1097,7 @@ msgstr ""
 "in der rechten Toolbar."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:429
+#: getting_started_in_kicad.adoc:441
 msgid ""
 "Be careful not to pick 'Place a bus', which appears directly beneath this "
 "button but has thicker lines. The section <<bus-connections-in-kicad,Bus "
@@ -1109,7 +1109,7 @@ msgstr ""
 "verwaltet und benutzt."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:433
+#: getting_started_in_kicad.adoc:445
 msgid ""
 "Click on the little circle at the end of pin 7 of the microcontroller and "
 "then click on the little circle on pin 2 of the LED.  You can zoom in while "
@@ -1121,7 +1121,7 @@ msgstr ""
 
 # The step 24 seems wrong!
 #. type: Plain text
-#: getting_started_in_kicad.adoc:438
+#: getting_started_in_kicad.adoc:450
 msgid ""
 "If you want to reposition wired components, it is important to use the g key "
 "(grab) option and not the m key (move) option. Using the grab option will "
@@ -1136,12 +1136,12 @@ msgstr ""
 
 # No translation needed.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:440
+#: getting_started_in_kicad.adoc:452
 msgid "image:images/gsik_tutorial1_030.png[gsik_tutorial1_030_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:446
+#: getting_started_in_kicad.adoc:458
 msgid ""
 "Repeat this process and wire up all the other components as shown below. To "
 "terminate a wire just double-click. When wiring up the VCC and GND symbols, "
@@ -1156,12 +1156,12 @@ msgstr ""
 
 # No translation needed.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:448
+#: getting_started_in_kicad.adoc:460
 msgid "image:images/gsik_tutorial1_040.png[gsik_tutorial1_040_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:453
+#: getting_started_in_kicad.adoc:465
 msgid ""
 "We will now consider an alternative way of making a connection using labels. "
 "Pick a net labelling tool by clicking on the 'Place net name' icon image:"
@@ -1174,7 +1174,7 @@ msgstr ""
 "rechten Toolbar. Sie können ebenfalls die Taste 'l' benutzen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:456
+#: getting_started_in_kicad.adoc:468
 msgid ""
 "Click in the middle of the wire connected to pin 6 of the microcontroller. "
 "Name this label 'INPUT'."
@@ -1183,7 +1183,7 @@ msgstr ""
 "Benennen Sie dieses Label 'INPUT'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:465
+#: getting_started_in_kicad.adoc:477
 msgid ""
 "Follow the same procedure and place another label on line on the right of "
 "the 100 ohm resistor. Also name it 'INPUT'. The two labels, having the same "
@@ -1204,7 +1204,7 @@ msgstr ""
 "ein Label zuzuweisen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:471
+#: getting_started_in_kicad.adoc:483
 msgid ""
 "Labels can also be used to simply label wires for informative purposes. "
 "Place a label on pin 7 of the PIC. Enter the name 'uCtoLED'.  Name the wire "
@@ -1217,7 +1217,7 @@ msgstr ""
 "und die Verbindung zwischen 'MYCONN3' und dem Resitor als 'INPUTtoR'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:474
+#: getting_started_in_kicad.adoc:486
 msgid ""
 "You do not have to label the VCC and GND lines because the labels are "
 "implied from the power objects they are connected to."
@@ -1226,18 +1226,18 @@ msgstr ""
 "sind schon von den Objekten der jeweiligen Spannungen impliziert."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:476
+#: getting_started_in_kicad.adoc:488
 msgid "Below you can see what the final result should look like."
 msgstr "Nachfolgend können Sie sehen wie das finale Ergebnis aussehen sollte."
 
 # No translation needed.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:478
+#: getting_started_in_kicad.adoc:490
 msgid "image:images/gsik_tutorial1_050.png[gsik_tutorial1_050_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:484
+#: getting_started_in_kicad.adoc:496
 msgid ""
 "Let's now deal with unconnected wires. Any pin or wire that is not connected "
 "will generate a warning when checked by KiCad. To avoid these warnings you "
@@ -1251,7 +1251,7 @@ msgstr ""
 "Signale keine Fehler sind."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:489
+#: getting_started_in_kicad.adoc:501
 msgid ""
 "Click on the 'Place no connect flag' icon image:images/icons/noconn."
 "png[noconn_png] on the right toolbar. Click on pins 2, 3, 4 and 5. An X will "
@@ -1264,12 +1264,12 @@ msgstr ""
 
 # No translation needed.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:491
+#: getting_started_in_kicad.adoc:503
 msgid "image:images/gsik_tutorial1_060.png[gsik_tutorial1_060_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:498
+#: getting_started_in_kicad.adoc:510
 msgid ""
 "Some components have power pins that are invisible. You can make them "
 "visible by clicking on the 'Show hidden pins' icon image:images/icons/"
@@ -1286,7 +1286,7 @@ msgstr ""
 "versteckten Pins zur Spannungsversorgung zu erstellen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:504
+#: getting_started_in_kicad.adoc:516
 msgid ""
 "It is now necessary to add a 'Power Flag' to indicate to KiCad that power "
 "comes in from somewhere. Press the a key, select 'List All', double click on "
@@ -1301,14 +1301,14 @@ msgstr ""
 
 # No translation needed.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:506
+#: getting_started_in_kicad.adoc:518
 msgid "image:images/gsik_tutorial1_070.png[gsik_tutorial1_070_png]"
 msgstr ""
 
 # FIXME!
 # The warning message needs to be translated, the respective string seems to be missing in kicad-i18n.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:509
+#: getting_started_in_kicad.adoc:521
 msgid ""
 "This will avoid the classic schematic checking warning: Warning Pin power_in "
 "not driven (Net xx)"
@@ -1317,7 +1317,7 @@ msgstr ""
 "'Warning Pin power_in not driven (Net xx)'"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:513
+#: getting_started_in_kicad.adoc:525
 msgid ""
 "Sometimes it is good to write comments here and there. To add comments on "
 "the schematic use the 'Place graphic text (comment)' icon image:images/icons/"
@@ -1328,7 +1328,7 @@ msgstr ""
 "icons/add_text.png[add_text_png] in der rechten Toolbar."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:518
+#: getting_started_in_kicad.adoc:531
 #, fuzzy
 #| msgid ""
 #| "All components now need to have unique identifiers. In fact, many of our "
@@ -1348,7 +1348,7 @@ msgstr ""
 "png[annotate_png] in der oberen Toolbar angeklickt wird."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:525
+#: getting_started_in_kicad.adoc:538
 msgid ""
 "In the Annotate Schematic window, select 'Use the entire schematic' and "
 "click on the 'Annotation' button. Click OK in the confirmation message and "
@@ -1364,7 +1364,7 @@ msgstr ""
 "'D1' und 'J1' bezeichnet."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:535
+#: getting_started_in_kicad.adoc:547
 #, fuzzy
 #| msgid ""
 #| "We will now check our schematic for errors. Click on the 'Perform "
@@ -1398,7 +1398,7 @@ msgstr ""
 "der weitere Information über die Fehler/Warnungen stehen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:537
+#: getting_started_in_kicad.adoc:551
 msgid ""
 "If you have a warning with \"No default editor found you must choose it\", "
 "try setting the path to `c:\\windows\\notepad.exe` (windows) or `/usr/bin/"
@@ -1406,7 +1406,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:542
+#: getting_started_in_kicad.adoc:556
 #, fuzzy
 #| msgid ""
 #| "The schematic is now finished. We can now create a Netlist file to which "
@@ -1428,7 +1428,7 @@ msgstr ""
 "Datei mit dem voreingestellten Dateinamen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:547
+#: getting_started_in_kicad.adoc:561
 msgid ""
 "After generating the Netlist file, click on the 'Run Cvpcb' icon image:"
 "images/icons/cvpcb.png[cvpcb_png] on the top toolbar. If a missing file "
@@ -1440,7 +1440,7 @@ msgstr ""
 "ignorieren Sie dies bitte und betätigen den OK Button."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:553
+#: getting_started_in_kicad.adoc:567
 msgid ""
 "_Cvpcb_ allows you to link all the components in your schematic with "
 "footprints in the KiCad library. The pane on the center shows all the "
@@ -1458,12 +1458,12 @@ msgstr ""
 # FIXME
 # Is this the correct file? Seems not.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:555
+#: getting_started_in_kicad.adoc:569
 msgid "image:images/icons/cvpcb.png[cvpcb_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:563
+#: getting_started_in_kicad.adoc:577
 msgid ""
 "It is possible that the pane on the right shows only a selected subgroup of "
 "available footprints. This is because KiCad is trying to suggest to you a "
@@ -1482,7 +1482,7 @@ msgstr ""
 "png[module_library_list_png] um diese Filterfunktion ein oder auszuschalten."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:567
+#: getting_started_in_kicad.adoc:581
 msgid ""
 "For 'IC1' select the 'Housings_DIP:DIP-8_W7.62mm' footprint.  For 'J1' "
 "select the 'Connect:Banana_Jack_3Pin' footprint.  For 'R1' and 'R2' select "
@@ -1493,7 +1493,7 @@ msgstr ""
 "wählen Sie den 'Discret:R1' Footprint."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:578
+#: getting_started_in_kicad.adoc:592
 msgid ""
 "If you are interested in knowing what the footprint you are choosing looks "
 "like, you have two options. You can click on the 'View selected footprint' "
@@ -1517,7 +1517,7 @@ msgstr ""
 # FIXME
 # The current menu on the netlist editor is different. There is no **Save As**!
 #. type: Plain text
-#: getting_started_in_kicad.adoc:587
+#: getting_started_in_kicad.adoc:601
 msgid ""
 "You are done. You can now update your netlist file with all the associated "
 "footprints. Click on *File* -> **Save As**. The default name 'tutorial1.net' "
@@ -1537,7 +1537,7 @@ msgstr ""
 "vorhanden sind. Dies wird später in einer eigenen Sektion erklärt."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:591
+#: getting_started_in_kicad.adoc:605
 msgid ""
 "You can close _Cvpcb_ and go back to the _Eeschema_ schematic editor. Save "
 "the project by clicking on *File* -> **Save Whole Schematic Project**. Close "
@@ -1548,12 +1548,12 @@ msgstr ""
 "Schaltplan speichern**. Schließen Sie den Schaltplaneditor."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:593
+#: getting_started_in_kicad.adoc:607
 msgid "Switch to the KiCad project manager."
 msgstr "Wechseln Sie zum KiCad Projektmanager."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:597
+#: getting_started_in_kicad.adoc:611
 msgid ""
 "The netlist file describes all components and their respective pin "
 "connections. The netlist file is actually a text file that you can easily "
@@ -1564,7 +1564,7 @@ msgstr ""
 "einfach anschauen, verändern oder skripten können."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:600
+#: getting_started_in_kicad.adoc:614
 msgid ""
 "Library files (__*.lib__) are text files too and they are also easily "
 "editable or scriptable."
@@ -1573,7 +1573,7 @@ msgstr ""
 "veränderbar oder skriptfähig."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:607
+#: getting_started_in_kicad.adoc:621
 msgid ""
 "To create a Bill Of Materials (BOM), go to the _Eeschema_ schematic editor "
 "and click on the 'Bill of materials' icon image:images/icons/bom."
@@ -1589,7 +1589,7 @@ msgstr ""
 "Datei die Sie benutzen möchten, in diesem Fall wählen wir __bom2csv.xsl__."
 
 #. type: delimited block =
-#: getting_started_in_kicad.adoc:612
+#: getting_started_in_kicad.adoc:626
 msgid ""
 "The *.xsl file is located in __plugins__ directory of the KiCad "
 "installation, which is located at: /usr/lib/kicad/plugins/."
@@ -1598,47 +1598,47 @@ msgstr ""
 "finden, dieser befindet sich in /usr/lib/kicad/plugins/."
 
 #. type: delimited block =
-#: getting_started_in_kicad.adoc:614
+#: getting_started_in_kicad.adoc:628
 msgid "Or get the file via:"
 msgstr "Oder holen die Datei von:"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:616
+#: getting_started_in_kicad.adoc:630
 #, no-wrap
 msgid "wget https://raw.githubusercontent.com/KiCad/kicad-source-mirror/master/eeschema/plugins/bom2csv.xsl\n"
 msgstr ""
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:619
+#: getting_started_in_kicad.adoc:633
 #, no-wrap
 msgid "KiCad automatically generates the command, for example:"
 msgstr "Kicad erstellt den Programmaufruf automatisch, zum Beispiel:"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:622
+#: getting_started_in_kicad.adoc:636
 #, no-wrap
 msgid "xsltproc -o \"%O\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 msgstr ""
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:624
+#: getting_started_in_kicad.adoc:638
 #, no-wrap
 msgid "You may want to add the extension, so change this command line to:"
 msgstr "Wenn Sie die Erweiterung hinzufügen wollen dann verändern Sie das Kommando zu:"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:627
+#: getting_started_in_kicad.adoc:641
 #, no-wrap
 msgid "xsltproc -o \"%O.csv\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:630
+#: getting_started_in_kicad.adoc:644
 msgid "Press Help button for more info."
 msgstr "Benutzen Sie den Hilfe Button für mehr Information."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:634
+#: getting_started_in_kicad.adoc:648
 msgid ""
 "Now press 'Generate'. The file (same name as your project) is located in "
 "your project folder.  Open the **.csv* file with LibreOffice Calc or Excel. "
@@ -1649,7 +1649,7 @@ msgstr ""
 "Sie die **.csv* Datei mit LibreOffice oder auch Excel."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:638
+#: getting_started_in_kicad.adoc:652
 msgid ""
 "You are now ready to move to the PCB layout part, which is presented in the "
 "next section. However, before moving on let's take a quick look at how to "
@@ -1660,13 +1660,13 @@ msgstr ""
 "Bauteilpins mit Bus Linien verbindet."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:640
+#: getting_started_in_kicad.adoc:654
 #, no-wrap
 msgid "Bus connections in KiCad"
 msgstr "Bus Verbindungen in KiCad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:646
+#: getting_started_in_kicad.adoc:660
 msgid ""
 "Sometimes you might need to connect several sequential pins of component A "
 "with some other sequential pins of component B. In this case you have two "
@@ -1680,7 +1680,7 @@ msgstr ""
 "Informationen wie man dies umsetzt."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:653
+#: getting_started_in_kicad.adoc:667
 msgid ""
 "Let us suppose that you have three 4-pin connectors that you want to connect "
 "together pin to pin. Use the label option (press the l key) to label pin 4 "
@@ -1697,7 +1697,7 @@ msgstr ""
 "Bezeichner automatisch 'a2' benannt wird."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:657
+#: getting_started_in_kicad.adoc:671
 msgid ""
 "Press the Ins Key two more times. The Ins key corresponds to the action "
 "'Repeat last item' and it is an infinitely useful command that can make your "
@@ -1708,7 +1708,7 @@ msgstr ""
 "Kommando welches das Arbeiten in KiCad sehr erleichtert."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:668
+#: getting_started_in_kicad.adoc:682
 msgid ""
 "Repeat the same labelling action on the two other connectors CONN_2 and "
 "CONN_3 and you are done. If you proceed and make a PCB you will see that the "
@@ -1730,7 +1730,7 @@ msgstr ""
 "Aber bedenken Sie, das hat keinen Effekt auf die Leiterplatte."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:672
+#: getting_started_in_kicad.adoc:686
 msgid ""
 "It should be pointed out that the short wire attached to the pins in Figure "
 "2 is not strictly necessary. In fact, the labels could have been applied "
@@ -1741,7 +1741,7 @@ msgstr ""
 "Bezeichner direkt auf die Pins anzuwenden."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:679
+#: getting_started_in_kicad.adoc:693
 msgid ""
 "Let's take it one step further and suppose that you have a fourth connector "
 "named CONN_4 and, for whatever reason, its labelling happens to be a little "
@@ -1758,7 +1758,7 @@ msgstr ""
 "bezeichnet mit einer Bezeichnung pro Bus."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:686
+#: getting_started_in_kicad.adoc:700
 msgid ""
 "Connect and label CONN_4 using the labelling method explained before. Name "
 "the pins b1, b2, b3 and b4. Connect the pin to a series of 'Wire to bus "
@@ -1774,7 +1774,7 @@ msgstr ""
 "png[add_bus_png]. Siehe Figur 4."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:689
+#: getting_started_in_kicad.adoc:703
 msgid ""
 "Put a label (press the l key option) on the bus of CONN_4 and name it "
 "'b[1..4]'."
@@ -1783,7 +1783,7 @@ msgstr ""
 "CONN_4 und benennen diesen 'b[1..4]'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:692
+#: getting_started_in_kicad.adoc:706
 msgid ""
 "Put a label (press the l key option) on the previous a bus and name it "
 "'a[1..4]'."
@@ -1792,7 +1792,7 @@ msgstr ""
 "Bus und benennen diesen 'a[1..4]'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:695
+#: getting_started_in_kicad.adoc:709
 msgid ""
 "What we can now do is connect bus a[1..4] with bus b[1..4] using a bus line "
 "with the button image:images/icons/add_bus.png[add_bus_png]."
@@ -1802,7 +1802,7 @@ msgstr ""
 "zu verbinden."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:699
+#: getting_started_in_kicad.adoc:713
 msgid ""
 "By connecting the two buses together, pin a1 will be automatically connected "
 "to pin b1, a2 will be connected to b2 and so on. Figure 4 shows what the "
@@ -1813,7 +1813,7 @@ msgstr ""
 "aussieht."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:704
+#: getting_started_in_kicad.adoc:718
 msgid ""
 "The 'Repeat last item' option accessible via the Ins key can be successfully "
 "used to repeat period item insertions. For instance, the short wires "
@@ -1826,7 +1826,7 @@ msgstr ""
 "Figur 4 wurden mit dieser Funktion erstellt."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:708
+#: getting_started_in_kicad.adoc:722
 msgid ""
 "The 'Repeat last item' option accessible via the Ins key has also been "
 "extensively used to place the many series of 'Wire to bus entry' using the "
@@ -1839,18 +1839,18 @@ msgstr ""
 
 # No translation needed.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:710
+#: getting_started_in_kicad.adoc:724
 msgid "image:images/gsik_bus_connection.png[gsik_bus_connection_png]"
 msgstr ""
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:712
+#: getting_started_in_kicad.adoc:726
 #, no-wrap
 msgid "Layout printed circuit boards"
 msgstr "Gedruckte Schaltungen (Leiterplatten) entwerfen"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:716
+#: getting_started_in_kicad.adoc:730
 msgid ""
 "It is now time to use the netlist file you generated to lay out the PCB.  "
 "This is done with the _Pcbnew_ tool."
@@ -1860,13 +1860,13 @@ msgstr ""
 "durch geführt."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:718
+#: getting_started_in_kicad.adoc:732
 #, no-wrap
 msgid "Using Pcbnew"
 msgstr "Benutzung von Pcbnew"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:724
+#: getting_started_in_kicad.adoc:738
 msgid ""
 "From the KiCad project manager, click on the 'Pcbnew' icon image:images/"
 "icons/pcbnew.png[pcbnew_png]. The 'Pcbnew' window will open. If you get an "
@@ -1880,7 +1880,7 @@ msgstr ""
 "Button 'Ja'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:728
+#: getting_started_in_kicad.adoc:742
 msgid ""
 "Begin by entering some schematic information. Click on the 'Page settings' "
 "icon image:images/icons/sheetset.png[sheetset_png] on the top toolbar. Set "
@@ -1892,7 +1892,7 @@ msgstr ""
 "Setzen Sie die Papiergröße auf 'A4' und den Titel auf 'Tutorial1'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:737
+#: getting_started_in_kicad.adoc:751
 msgid ""
 "It is a good idea to start by setting the *clearance* and the *minimum track "
 "width* to those required by your PCB manufacturer. In general you can set "
@@ -1912,12 +1912,12 @@ msgstr ""
 "Die Werte sind in Millimeter."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:739
+#: getting_started_in_kicad.adoc:753
 msgid "image:images/design_rules.png[Design Rules Window]"
 msgstr "image:images/de/design_rules.png[Fenster Design Regeln Editor]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:743
+#: getting_started_in_kicad.adoc:757
 msgid ""
 "Click on the 'Global Design Rules' tab and set 'Min track width' to 0.25'. "
 "Click the OK button to commit your changes and close the Design Rules Editor "
@@ -1928,7 +1928,7 @@ msgstr ""
 "Veränderungen und schließen Sie den Design Regel Editor."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:749
+#: getting_started_in_kicad.adoc:763
 msgid ""
 "Now we will import the netlist file. Click on the 'Read Netlist' icon image:"
 "images/icons/netlist.png[netlist_png] on the top toolbar. Click on the "
@@ -1942,7 +1942,7 @@ msgstr ""
 "sollten nicht auftreten, klicken Sie auf den Button Schließen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:752
+#: getting_started_in_kicad.adoc:766
 msgid ""
 "All components should now be visible in the top left hand corner just above "
 "the page. Scroll up if you cannot see them."
@@ -1951,7 +1951,7 @@ msgstr ""
 "Arbeitsebene um mehr Details zu sehen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:756
+#: getting_started_in_kicad.adoc:770
 msgid ""
 "Select all components with the mouse and move them to the middle of the "
 "board. If necessary you can zoom in and out while you move the components."
@@ -1960,7 +1960,7 @@ msgstr ""
 "Bauteile. Verschieben Sie die ausgewählten Komponenten wenn nötig."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:762
+#: getting_started_in_kicad.adoc:776
 msgid ""
 "All components are connected via a thin group of wires called __ratsnest__. "
 "Make sure that the 'Hide board ratsnest' button image:images/icons/"
@@ -1974,14 +1974,14 @@ msgstr ""
 "verbinden."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:765
+#: getting_started_in_kicad.adoc:779
 msgid ""
 "The tool-tip is backwards; pressing this button actually displays the "
 "ratsnest."
 msgstr "Der Button muss aktiviert sein um die Netzlinien sichtbar zu machen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:769
+#: getting_started_in_kicad.adoc:783
 msgid ""
 "You can move each component by hovering over it and pressing the g key. "
 "Click where you want to place them. Move all components around until you "
@@ -1993,7 +1993,7 @@ msgstr ""
 "Kreuzungen der Netzlinien soweit möglich."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:774
+#: getting_started_in_kicad.adoc:788
 msgid ""
 "If instead of grabbing the components (with the g key ) you move them around "
 "using the m key you will later note that you lose the track connection (the "
@@ -2008,12 +2008,12 @@ msgstr ""
 
 # We need to take screenshot from the German GUI.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:776
+#: getting_started_in_kicad.adoc:790
 msgid "image:images/gsik_tutorial1_080.png[gsik_tutorial1_080_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:783
+#: getting_started_in_kicad.adoc:797
 msgid ""
 "If the ratsnest disappears or the screen gets messy, right click and click "
 "'Redraw view'. Note how one pin of the 100 ohm resistor is connected to pin "
@@ -2029,7 +2029,7 @@ msgstr ""
 "Methode für Verbindungen da diese einen Schaltplan übersichtlich halten."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:791
+#: getting_started_in_kicad.adoc:805
 msgid ""
 "Now we will define the edge of the PCB. Select 'Edge.Cuts' from the drop "
 "down menu in the top toolbar. Click on the 'Add graphic line or polygon' "
@@ -2048,7 +2048,7 @@ msgstr ""
 "Umrisslinie der Außenkante vorhalten müssen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:795
+#: getting_started_in_kicad.adoc:809
 msgid ""
 "Next, connect up all the wires except GND. In fact, we will connect all GND "
 "connections in one go using a ground plane placed on the bottom copper "
@@ -2060,7 +2060,7 @@ msgstr ""
 "genannt) erstellen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:799
+#: getting_started_in_kicad.adoc:813
 msgid ""
 "Now we must choose which copper layer we want to work on. Select 'F.Cu "
 "(PgUp)' in the drag down menu on the top toolbar. This is the front top "
@@ -2072,12 +2072,12 @@ msgstr ""
 "schauen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:801
+#: getting_started_in_kicad.adoc:815
 msgid "image:images/select_top_copper.png[Select the Front top copper layer]"
 msgstr "image:images/de/select_top_copper.png[Auswahl der oberen Kupfer Lage]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:807
+#: getting_started_in_kicad.adoc:821
 msgid ""
 "If you decide, for instance, to do a 4 layer PCB instead, go to *Design "
 "Rules* -> *Layers Setup* and change 'Copper Layers' to 4. In the 'Layers' "
@@ -2092,7 +2092,7 @@ msgstr ""
 "Voreinstellungen in der Auswahl 'Voreinstellung für Lagengruppierungen' gibt."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:815
+#: getting_started_in_kicad.adoc:829
 msgid ""
 "Click on the 'Add Tracks and vias' icon image:images/icons/add_tracks."
 "png[add_tracks_png] on the right toolbar. Click on pin 1 of 'J1' and run a "
@@ -2111,14 +2111,14 @@ msgstr ""
 "hinterlegt."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:817
+#: getting_started_in_kicad.adoc:831
 msgid "image:images/pcbnew_1.png[pcbnew_1_png]"
 msgstr ""
 "image:images/de/select_track_width.png[Auswahl Leiterbahnbreite in der "
 "oberen Toolbar]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:823
+#: getting_started_in_kicad.adoc:837
 msgid ""
 "If you would like to add more track widths go to: *Design Rules* -> *Design "
 "Rules* -> *Global Design Rules* tab and at the bottom right of this window "
@@ -2134,13 +2134,13 @@ msgstr ""
 "Beispiel (Maße sind in mm)."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:825
+#: getting_started_in_kicad.adoc:839
 msgid "image:images/custom_tracks_width.png[custom_tracks_width_png]"
 msgstr ""
 "image:images/de/custom_tracks_width.png[Benutzerdefinierte Leiterbahnbreiten]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:832
+#: getting_started_in_kicad.adoc:846
 msgid ""
 "Alternatively, you can add a Net Class in which you specify a set of "
 "options. Go to *Design Rules* -> *Design Rules* -> *Net Classes Editor* and "
@@ -2159,7 +2159,7 @@ msgstr ""
 "die Pfeil Buttons um die Zugehörigkeit zu übertragen)"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:836
+#: getting_started_in_kicad.adoc:850
 msgid ""
 "If you want to change the grid size, *Right click* -> **Grid Select**. Be "
 "sure to select the appropriate grid size before or after laying down the "
@@ -2171,7 +2171,7 @@ msgstr ""
 "verlegen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:839
+#: getting_started_in_kicad.adoc:853
 msgid ""
 "Repeat this process until all wires, except pin 3 of J1, are connected. Your "
 "board should look like the example below."
@@ -2181,12 +2181,12 @@ msgstr ""
 
 # No translation needed.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:841
+#: getting_started_in_kicad.adoc:855
 msgid "image:images/gsik_tutorial1_090.png[gsik_tutorial1_090_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:849
+#: getting_started_in_kicad.adoc:863
 msgid ""
 "Let's now run a track on the other copper side of the PCB. Select 'B.Cu' in "
 "the drag down menu on the top toolbar. Click on the 'Add tracks and vias' "
@@ -2204,7 +2204,7 @@ msgstr ""
 "Sie jedoch das die Farbe für die verlegte Leiterbahn sich verändert hat."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:856
+#: getting_started_in_kicad.adoc:870
 #, no-wrap
 msgid ""
 "**Go from pin A to pin B by changing layer**. It is possible to\n"
@@ -2217,13 +2217,13 @@ msgstr "Es ist auch möglich die Lage beim Verlegen einer Leiterbahn mit Hilfe e
 
 # We need to take screenshot from the German GUI.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:858
+#: getting_started_in_kicad.adoc:872
 #, no-wrap
 msgid "image:images/place_a_via.png[place_a_via_png]\n"
 msgstr "image:images/de/place_a_via.png[Platzieren eines Vias]\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:864
+#: getting_started_in_kicad.adoc:878
 msgid ""
 "When you want to inspect a particular connection you can click on the 'Net "
 "highlight' icon image:images/icons/net_highlight.png[net_highlight_png] on "
@@ -2238,7 +2238,7 @@ msgstr ""
 
 #  'Pad in Zone' to 'Thermal relief' and 'Zone edges orient' to 'H,V' sems to not live anymore!
 #. type: Plain text
-#: getting_started_in_kicad.adoc:872
+#: getting_started_in_kicad.adoc:886
 msgid ""
 "Now we will make a ground plane that will be connected to all GND pins. "
 "Click on the 'Add Zones' icon image:images/icons/add_zone.png[add_zone_png] "
@@ -2255,7 +2255,7 @@ msgstr ""
 "'Thermische Abführung [Alle]' und klicken auf OK."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:877
+#: getting_started_in_kicad.adoc:891
 msgid ""
 "Trace around the outline of the board by clicking each corner in rotation. "
 "Double-click to finish your rectangle. Right click inside the area you have "
@@ -2270,12 +2270,12 @@ msgstr ""
 "Das Board sollte sich nun grün füllen und ungefähr so aussehen:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:879
+#: getting_started_in_kicad.adoc:893
 msgid "image:images/gsik_tutorial1_100.png[gsik_tutorial1_100_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:885
+#: getting_started_in_kicad.adoc:899
 msgid ""
 "Run the design rules checker by clicking on the 'Perform Design Rules Check' "
 "icon image:images/icons/drc.png[drc_png] on the top toolbar.  Click on "
@@ -2290,7 +2290,7 @@ msgstr ""
 "schließen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:888
+#: getting_started_in_kicad.adoc:902
 msgid ""
 "Save your file by clicking on *File* -> **Save**. To admire your board in "
 "3D, click on *View* -> **3D Viewer**."
@@ -2299,17 +2299,17 @@ msgstr ""
 "Board in 3D zu betrachten klicken Sie auf *Ansicht* -> **3D Viewer**."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:890
+#: getting_started_in_kicad.adoc:904
 msgid "image:images/pcbnew_3d_viewer.png[pcbnew_3d_viewer_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:892
+#: getting_started_in_kicad.adoc:906
 msgid "You can drag your mouse around to rotate the PCB."
 msgstr "Benutzen Sie die Maus um die Platine zu rotieren."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:895
+#: getting_started_in_kicad.adoc:909
 msgid ""
 "Your board is complete. To send it off to a manufacturer you will need to "
 "generate all Gerber files."
@@ -2318,13 +2318,13 @@ msgstr ""
 "müssen Sie noch Gerber Dateien von Ihrer Platine erstellen."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:897
+#: getting_started_in_kicad.adoc:911
 #, no-wrap
 msgid "Generate Gerber files"
 msgstr "Erstellung von Gerber Dateien"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:902
+#: getting_started_in_kicad.adoc:916
 msgid ""
 "Once your PCB is complete, you can generate Gerber files for each layer and "
 "send them to your favourite PCB manufacturer, who will make the board for "
@@ -2336,7 +2336,7 @@ msgstr ""
 
 # The original icons is wrong.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:906
+#: getting_started_in_kicad.adoc:920
 msgid ""
 "From KiCad, open the _Pcbnew_ software tool and load your board file by "
 "clicking on the icon image:images/icons/open_document.png[open_document_png]."
@@ -2346,7 +2346,7 @@ msgstr ""
 "damit Ihre Leiterplattendatei."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:910
+#: getting_started_in_kicad.adoc:924
 msgid ""
 "Click on *File* -> **Plot**. Select 'Gerber' as the 'Plot Format' and select "
 "the folder in which to put all Gerber files.  Proceed by clicking on the "
@@ -2357,7 +2357,7 @@ msgstr ""
 "werden sollen. Starten Sie die Ausgabe durch Klicken des 'Plotten' Button."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:913
+#: getting_started_in_kicad.adoc:927
 msgid ""
 "These are the layers you need to select for making a typical 2-layer PCB:"
 msgstr ""
@@ -2365,7 +2365,7 @@ msgstr ""
 "Leiterplatte zu erstellen:"
 
 #. type: delimited block |
-#: getting_started_in_kicad.adoc:924
+#: getting_started_in_kicad.adoc:938
 #, no-wrap
 msgid ""
 "|Layer |KiCad Layer Name |Old KiCad Layer Name |Default Gerber Extension\n"
@@ -2387,13 +2387,13 @@ msgstr ""
 "|Edges |Edge.Cuts |Edges_Pcb |.GBR |.GM1\n"
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:927
+#: getting_started_in_kicad.adoc:941
 #, no-wrap
 msgid "Using GerbView"
 msgstr "Benutzen von GerbView"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:936
+#: getting_started_in_kicad.adoc:950
 msgid ""
 "To view all your Gerber files go to the KiCad project manager and click on "
 "the 'GerbView' icon.  On the drag down menu select 'Layer 1'. Click on "
@@ -2410,7 +2410,7 @@ msgstr ""
 "Lagen übereinander gelegt dargestellt werden."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:939
+#: getting_started_in_kicad.adoc:953
 msgid ""
 "Use the menu on the right to select/deselect which layer to show.  Carefully "
 "inspect each layer before sending them for production."
@@ -2420,7 +2420,7 @@ msgstr ""
 "Produktion geben."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:942
+#: getting_started_in_kicad.adoc:956
 msgid ""
 "To generate the drill file, from _Pcbnew_ go again for the *File* -> *Plot* "
 "option. Default settings should be fine."
@@ -2430,13 +2430,13 @@ msgstr ""
 "klicken Sie auf den Button 'Bohrdatei generieren'."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:944
+#: getting_started_in_kicad.adoc:958
 #, no-wrap
 msgid "Automatically route with FreeRouter"
 msgstr "Automatisches Routen mit FreeRouter"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:952
+#: getting_started_in_kicad.adoc:966
 msgid ""
 "Routing a board by hand is quick and fun, however, for a board with lots of "
 "components you might want to use an autorouter. Remember that you should "
@@ -2452,7 +2452,7 @@ msgstr ""
 "FreeRouter von __freerouting.net__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:957
+#: getting_started_in_kicad.adoc:971
 msgid ""
 "Freerouter is a open source java application, and it is needed to build by "
 "yourself to use with KiCad.  Source code of Freerouter can be found on this "
@@ -2464,7 +2464,7 @@ msgstr ""
 "herunter geladen werden."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:963
+#: getting_started_in_kicad.adoc:977
 msgid ""
 "From _Pcbnew_ click on *File* -> *Export* -> *Specctra DSN* or click on "
 "*Tools* -> *FreeRoute* -> **Export a Specctra Design (*.dsn) file** and save "
@@ -2478,7 +2478,7 @@ msgstr ""
 "laden diese."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:968
+#: getting_started_in_kicad.adoc:982
 msgid ""
 "The *Tools* -> *FreeRoute* dialog has a nice help button that opens a file "
 "viewer with a little document inside named **Freerouter Guidelines**. Please "
@@ -2489,7 +2489,7 @@ msgstr ""
 "FreeRoute effektiv nutzen zu können."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:974
+#: getting_started_in_kicad.adoc:988
 msgid ""
 "FreeRouter has some features that KiCad does not currently have, both for "
 "manual routing and for automatic routing. FreeRouter operates in two main "
@@ -2503,7 +2503,7 @@ msgstr ""
 "nehmen, dies können Sie aber zu jeder Zeit unterbrechen wenn nötig."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:982
+#: getting_started_in_kicad.adoc:996
 msgid ""
 "You can start the automatic routing by clicking on the 'Autorouter' button "
 "on the top bar. The bottom bar gives you information about the on-going "
@@ -2522,7 +2522,7 @@ msgstr ""
 "Netzkreuzungen der einzelnen Netze verringern."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:987
+#: getting_started_in_kicad.adoc:1001
 msgid ""
 "Making a left-click on the mouse can stop the automatic routing and "
 "automatically start the optimisation process. Another left-click will stop "
@@ -2533,7 +2533,7 @@ msgstr ""
 "beginnt den automatischen Optimierungsprozess."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:991
+#: getting_started_in_kicad.adoc:1005
 msgid ""
 "Click on the *File* -> *Export Specctra Session File* menu and save the "
 "board file with the _.ses_ extension. You do not really need to save the "
@@ -2544,7 +2544,7 @@ msgstr ""
 "nicht speichern."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:996
+#: getting_started_in_kicad.adoc:1010
 msgid ""
 "Back to __Pcbnew__. You can import your freshly routed board by clicking on "
 "the link *Tools* -> *FreeRoute* and then on the icon 'Back Import the "
@@ -2556,7 +2556,7 @@ msgstr ""
 "der zugehörigen _.ses_ Datei."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1001
+#: getting_started_in_kicad.adoc:1015
 msgid ""
 "If there is any routed trace that you do not like, you can delete it and re-"
 "route it again, using the del key and the routing tool, which is the 'Add "
@@ -2570,13 +2570,13 @@ msgstr ""
 "Toolbar danach auf."
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1003
+#: getting_started_in_kicad.adoc:1017
 #, no-wrap
 msgid "Forward annotation in KiCad"
 msgstr "Vorwärts Annotation in KiCad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1009
+#: getting_started_in_kicad.adoc:1023
 msgid ""
 "Once you have completed your electronic schematic, the footprint assignment, "
 "the board layout and generated the Gerber files, you are ready to send "
@@ -2588,7 +2588,7 @@ msgstr ""
 "Board Realität werden kann."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1017
+#: getting_started_in_kicad.adoc:1031
 msgid ""
 "Often, this linear work-flow turns out to be not so uni-directional. For "
 "instance, when you have to modify/extend a board for which you or others "
@@ -2606,7 +2606,7 @@ msgstr ""
 "Routen müssen. Statt dessen möchten Sie wohl folgendes tun:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1020
+#: getting_started_in_kicad.adoc:1034
 msgid ""
 "Let's suppose that you want to replace a hypothetical connector CON1 with "
 "CON2."
@@ -2615,14 +2615,14 @@ msgstr ""
 "tauschen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1022
+#: getting_started_in_kicad.adoc:1036
 msgid "You already have a completed schematic and a fully routed PCB."
 msgstr ""
 "Sie haben einen vollständigen Schaltplan und eine vollendete Leiterplatte."
 
 # There is a typo in the original text, 'c lick on the netlist'.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1028
+#: getting_started_in_kicad.adoc:1042
 msgid ""
 "From KiCad, start __Eeschema__, make your modifications by deleting CON1 and "
 "adding CON2. Save your schematic project with the icon image:images/icons/"
@@ -2636,7 +2636,7 @@ msgstr ""
 "erstellen' image:images/icons/netlist.png[netlist_png] in der oberen Toolbar."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1031
+#: getting_started_in_kicad.adoc:1045
 msgid ""
 "Click on 'Netlist' then on 'save'. Save to the default file name.  You have "
 "to rewrite the old one."
@@ -2645,7 +2645,7 @@ msgstr ""
 "die alte Datei überschreiben."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1037
+#: getting_started_in_kicad.adoc:1051
 msgid ""
 "Now assign a footprint to CON2. Click on the 'Run Cvpcb' icon image:images/"
 "icons/cvpcb.png[cvpcb] on the top toolbar. Assign the footprint to the new "
@@ -2660,7 +2660,7 @@ msgstr ""
 
 # The menu entry need to be changed to *File* --> *Save ...*
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1040
+#: getting_started_in_kicad.adoc:1054
 msgid ""
 "Back in the schematic editor, save the project by clicking on 'File' -> "
 "'Save Whole Schematic Project'. Close the schematic editor."
@@ -2669,7 +2669,7 @@ msgstr ""
 "*Datei* -> *Schaltplanprojekt speichern*. Schließen Sie den Schaltplaneditor."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1043
+#: getting_started_in_kicad.adoc:1057
 msgid ""
 "From the KiCad project manager, click on the 'Pcbnew' icon. The 'Pcbnew' "
 "window will open."
@@ -2678,7 +2678,7 @@ msgstr ""
 "pcbnew.png[pcbnew_png]. Das Fenster von 'Pcbnew' öffnet sich."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1047
+#: getting_started_in_kicad.adoc:1061
 msgid ""
 "The old, already routed, board should automatically open. Let's import the "
 "new netlist file. Click on the 'Read Netlist' icon image:images/icons/"
@@ -2689,7 +2689,7 @@ msgstr ""
 "einlesen' in der oberen Toolbar."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1051
+#: getting_started_in_kicad.adoc:1065
 msgid ""
 "Click on the 'Browse Netlist Files' button, select the netlist file in the "
 "file selection dialogue, and click on 'Read Current Netlist'.  Then click "
@@ -2700,7 +2700,7 @@ msgstr ""
 "Schließen Sie den Dialog."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1056
+#: getting_started_in_kicad.adoc:1070
 msgid ""
 "At this point you should be able to see a layout with all previous "
 "components already routed. On the top left corner you should see all "
@@ -2714,7 +2714,7 @@ msgstr ""
 "Platz."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1059
+#: getting_started_in_kicad.adoc:1073
 msgid ""
 "Place CON2 and route it. Once done, save and proceed with the Gerber file "
 "generation as usual."
@@ -2723,7 +2723,7 @@ msgstr ""
 "Sie und erstellen erneut die Gerber Dateien wie zuvor."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1067
+#: getting_started_in_kicad.adoc:1081
 msgid ""
 "The process described here can easily be repeated as many times as you need. "
 "Beside the Forward Annotation method described above, there is another "
@@ -2740,13 +2740,13 @@ msgstr ""
 "Annotation nicht so zweckdienlich und deswegen nicht weiter hier beschrieben."
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1069
+#: getting_started_in_kicad.adoc:1083
 #, no-wrap
 msgid "Make schematic components in KiCad"
 msgstr "Erstellen von Bauteilen in Kicad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1076
+#: getting_started_in_kicad.adoc:1090
 msgid ""
 "Sometimes a component that you want to place on your schematic is not in the "
 "KiCad libraries. This is quite normal and there is no reason to worry. In "
@@ -2764,12 +2764,12 @@ msgstr ""
 
 # No need for translation.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1078
+#: getting_started_in_kicad.adoc:1092
 msgid "http://per.launay.free.fr/kicad/kicad_php/composant.php"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1083
+#: getting_started_in_kicad.adoc:1097
 msgid ""
 "In KiCad, a component is a piece of text that starts with a 'DEF' and ends "
 "with 'ENDDEF'. One or more components are normally placed in a library file "
@@ -2783,13 +2783,13 @@ msgstr ""
 "kopieren und einfügen."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1085
+#: getting_started_in_kicad.adoc:1099
 #, no-wrap
 msgid "Using Component Library Editor"
 msgstr "Benutzen des Bauteileditors"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1091
+#: getting_started_in_kicad.adoc:1105
 msgid ""
 "We can use the _Component Library Editor_ (part of __Eeschema__)  to make "
 "new components. In our project folder 'tutorial1' let's create a folder "
@@ -2802,7 +2802,7 @@ msgstr ""
 "_myLib.lib_ ab sobald wir unser neues Bauteil kreiert haben."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1106
+#: getting_started_in_kicad.adoc:1120
 msgid ""
 "Now we can start creating our new component. From KiCad, start __Eeschema__, "
 "click on the 'Library Editor' icon image:images/icons/libedit."
@@ -2831,7 +2831,7 @@ msgstr ""
 "vom 'MYCONN3' Label."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1110
+#: getting_started_in_kicad.adoc:1124
 msgid ""
 "In the Pin Properties window that appears, set the pin name to 'VCC', set "
 "the pin number to '1', and the 'Electrical type' to 'Passive' then click OK."
@@ -2841,12 +2841,12 @@ msgstr ""
 "'Passiv' und klicken auf OK."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1112
+#: getting_started_in_kicad.adoc:1126
 msgid "image:images/pin_properties.png[Pin Properties]"
 msgstr "image:images/de/pin_properties.png[Pin Eigenschaften]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1115
+#: getting_started_in_kicad.adoc:1129
 msgid ""
 "Place the pin by clicking on the location you would like it to go, right "
 "below the 'MYCONN3' label."
@@ -2855,7 +2855,7 @@ msgstr ""
 "soll, direkt unter dem Bezeichner 'MYCONN3'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1119
+#: getting_started_in_kicad.adoc:1133
 msgid ""
 "Repeat the place-pin steps, this time 'Pin name' should be 'INPUT', 'Pin "
 "number' should be '2', and 'Electrical Type' should be 'Passive'."
@@ -2864,7 +2864,7 @@ msgstr ""
 "'Pinnummer 2', der 'Elektrischer Typ' ist 'Passive'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1125
+#: getting_started_in_kicad.adoc:1139
 msgid ""
 "Repeat the place-pin steps, this time 'Pin name' should be 'GND', 'Pin "
 "number' should be '3', and 'Electrical Type' should be 'Passive'.  Arrange "
@@ -2878,7 +2878,7 @@ msgstr ""
 "liegen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1133
+#: getting_started_in_kicad.adoc:1147
 #, fuzzy
 #| msgid ""
 #| "Next, draw the contour of the component. Click on the 'Add rectangle' "
@@ -2903,12 +2903,12 @@ msgstr ""
 "rechte Ecke des Rechtecks erreicht ist."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1135
+#: getting_started_in_kicad.adoc:1149
 msgid "image:images/gsik_myconn3_l.png[gsik_myconn3_l_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1140
+#: getting_started_in_kicad.adoc:1154
 msgid ""
 "Save the component in your library __myLib.lib__. Click on the 'New Library' "
 "icon image:images/icons/new_library.png[new_library_png], navigate into "
@@ -2922,7 +2922,7 @@ msgstr ""
 "Bibliothek unter dem Namen __myLib.lib__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1143
+#: getting_started_in_kicad.adoc:1157
 msgid ""
 "Go to *Preferences* -> *Component Libraries* and add both _tutorial1/library/"
 "_ in 'User defined search path' and _myLib.lib in_ 'Component library files'."
@@ -2932,7 +2932,7 @@ msgstr ""
 "_myLib.lib_ zu den 'Bauteilebibliotheksdateien'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1149
+#: getting_started_in_kicad.adoc:1163
 msgid ""
 "Click on the 'Select working library' icon image:images/icons/library."
 "png[library_png]. In the Select Library window click on _myLib_ and click "
@@ -2946,7 +2946,7 @@ msgstr ""
 "lib__ zu lesen sein."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1158
+#: getting_started_in_kicad.adoc:1172
 msgid ""
 "Click on the 'Update current component in current library' icon image:images/"
 "icons/save_part_in_mem.png[save_part_in_mem_png] in the top toolbar. Save "
@@ -2965,7 +2965,7 @@ msgstr ""
 "enthalten welche im Fenstertitel benannt ist."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1162
+#: getting_started_in_kicad.adoc:1176
 msgid ""
 "You can now close the Component library editor window. You will return to "
 "the schematic editor window. Your new component will now be available to you "
@@ -2976,7 +2976,7 @@ msgstr ""
 "__myLib__ auswählbar."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1167
+#: getting_started_in_kicad.adoc:1181
 msgid ""
 "You can make any library _file.lib_ file available to you by adding it to "
 "the library path. From __Eeschema__, go to *Preferences* -> *Library* and "
@@ -2990,13 +2990,13 @@ msgstr ""
 "lib_ zu den 'Bauteilebibliotheksdateien'."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1169
+#: getting_started_in_kicad.adoc:1183
 #, no-wrap
 msgid "Export, import and modify library components"
 msgstr "Export, Import und Verändern von Bauteilkomponenten"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1175
+#: getting_started_in_kicad.adoc:1189
 msgid ""
 "Instead of creating a library component from scratch it is sometimes easier "
 "to start from one already made and modify it. In this section we will see "
@@ -3010,7 +3010,7 @@ msgstr ""
 "verändert."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1183
+#: getting_started_in_kicad.adoc:1197
 msgid ""
 "From KiCad, start __Eeschema__, click on the 'Library Editor' icon image:"
 "images/icons/libedit.png[libedit_png], click on the 'Select working library' "
@@ -3028,7 +3028,7 @@ msgstr ""
 "png[import_cmp_from_lib_png] und importieren 'RELAY_2RT'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1187
+#: getting_started_in_kicad.adoc:1201
 msgid ""
 "Click on the 'Export component' icon image:images/icons/export."
 "png[export_png], navigate into the _library/_ folder and save the new "
@@ -3039,7 +3039,7 @@ msgstr ""
 "Bibliothek unter dem Namen _myOwnLib.lib_."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1193
+#: getting_started_in_kicad.adoc:1207
 msgid ""
 "You can make this component and the whole library _myOwnLib.lib_ available "
 "to you by adding it to the library path. From __Eeschema__, go to "
@@ -3053,7 +3053,7 @@ msgstr ""
 "lib_ zu den 'Bauteilebibliotheksdateien'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1199
+#: getting_started_in_kicad.adoc:1213
 msgid ""
 "Click on the 'Select working library' icon image:images/icons/library."
 "png[library_png]. In the Select Library window click on _myOwnLib_ and click "
@@ -3067,7 +3067,7 @@ msgstr ""
 "myOwnLib.lib__ zu lesen sein."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1203
+#: getting_started_in_kicad.adoc:1217
 msgid ""
 "Click on the 'Load component to edit from the current lib' icon image:images/"
 "icons/import_cmp_from_lib.png[import_cmp_from_lib_png] and import the "
@@ -3078,7 +3078,7 @@ msgstr ""
 "png[import_cmp_from_lib_png] und importieren RELAY_2RT."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1206
+#: getting_started_in_kicad.adoc:1220
 msgid ""
 "You can now modify the component as you like. Hover over the label "
 "'RELAY_2RT', press the e key and rename it 'MY_RELAY_2RT'."
@@ -3088,7 +3088,7 @@ msgstr ""
 "und benennen diesen in 'MY_RELAY_2RT' um."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1213
+#: getting_started_in_kicad.adoc:1227
 msgid ""
 "Click on 'Update current component in current library' icon image:images/"
 "icons/save_part_in_mem.png[save_part_in_mem_png] in the top toolbar. Save "
@@ -3102,14 +3102,14 @@ msgstr ""
 "save_library.png[save_library_png] in der oberen Toolbar."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1215
+#: getting_started_in_kicad.adoc:1229
 #, no-wrap
 msgid "Make schematic components with quicklib"
 msgstr "Erstellen von Schaltplansymbolen mit quicklib"
 
 # The anchor to MYCONN3 isn't correct.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1220
+#: getting_started_in_kicad.adoc:1234
 msgid ""
 "This section presents an alternative way of creating the schematic component "
 "for MYCONN3 (see <<myconn3,MYCONN3>> above) using the Internet tool "
@@ -3120,14 +3120,14 @@ msgstr ""
 "Benutzung des Internet Tools __quicklab__ gezeigt."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1223
+#: getting_started_in_kicad.adoc:1237
 msgid ""
 "Head to the _quicklib_ web page: http://kicad.rohrbacher.net/quicklib.php"
 msgstr ""
 "Öffnen Sie die _quicklab_ Webseite: http://kicad.rohrbacher.net/quicklib.php"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1226
+#: getting_started_in_kicad.adoc:1240
 msgid ""
 "Fill out the page with the following information: Component name: MYCONN3 "
 "Reference Prefix: J Pin Layout Style: SIL Pin Count, N: 3"
@@ -3137,7 +3137,7 @@ msgstr ""
 
 # Typo: input vs. Input
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1230
+#: getting_started_in_kicad.adoc:1244
 msgid ""
 "Click on the 'Assign Pins' icon. Fill out the page with the following "
 "information: Pin 1: VCC Pin 2: input Pin 3: GND.  Type : Passive for all 3 "
@@ -3149,7 +3149,7 @@ msgstr ""
 
 # 'Preview it' -> 'Preview' on upstream
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1234
+#: getting_started_in_kicad.adoc:1248
 msgid ""
 "Click on the icon 'Preview it' and, if you are satisfied, click on the "
 "'Build Library Component'. Download the file and rename it __tutorial1/"
@@ -3160,7 +3160,7 @@ msgstr ""
 "Sie diese unter __tutorial1/library/myQuickLib.lib.__. Sie sind fertig!"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1240
+#: getting_started_in_kicad.adoc:1254
 msgid ""
 "Have a look at it using KiCad. From the KiCad project manager, start "
 "__Eeschema__, click on the 'Library Editor' icon image:images/icons/libedit."
@@ -3175,12 +3175,12 @@ msgstr ""
 "und öffnen den Ordner _tutorial1/library/_ und öffnen _myQuickLib.lib_."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1242
+#: getting_started_in_kicad.adoc:1256
 msgid "image:images/gsik_myconn3_quicklib.png[gsik_myconn3_quicklib_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1248
+#: getting_started_in_kicad.adoc:1262
 msgid ""
 "You can make this component and the whole library _myQuickLib.lib_ available "
 "to you by adding it to the KiCad library path. From __Eeschema__, go to "
@@ -3194,7 +3194,7 @@ msgstr ""
 "und _myQuickLib.lib_ zu den Bauteilebibliotheksdateien."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1252
+#: getting_started_in_kicad.adoc:1266
 msgid ""
 "As you might guess, this method of creating library components can be quite "
 "effective when you want to create components with a large pin count."
@@ -3204,13 +3204,13 @@ msgstr ""
 "erstellen wollen."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1254
+#: getting_started_in_kicad.adoc:1268
 #, no-wrap
 msgid "Make a high pin count schematic component"
 msgstr "Erstellen eines Bauteils mit zahlreichen Pins"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1261
+#: getting_started_in_kicad.adoc:1275
 msgid ""
 "In the section titled _Make Schematic Components in quicklib_ we saw how to "
 "make a schematic component using the _quicklib_ web-based tool.  However, "
@@ -3225,7 +3225,7 @@ msgstr ""
 "keine besonders schwierige Aufgabe in KiCad."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1267
+#: getting_started_in_kicad.adoc:1281
 msgid ""
 "Suppose that you want to create a schematic component for a device with 50 "
 "pins. It is common practise to draw it using multiple low pin-count "
@@ -3238,7 +3238,7 @@ msgstr ""
 "Diese Komponentendarstellung ermöglicht einen einfachen Pin Anschluss."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1272
+#: getting_started_in_kicad.adoc:1286
 msgid ""
 "The best way to create our component is to use _quicklib_ to generate two 25-"
 "pin components separately, re-number their pins using a Python script and "
@@ -3251,7 +3251,7 @@ msgstr ""
 "einziges DEF und ENDEFF Bauteil zu mergen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1278
+#: getting_started_in_kicad.adoc:1292
 msgid ""
 "You will find an example of a simple Python script below that can be used in "
 "conjunction with an _in.txt_ file and an _out.txt_ file to re-number the "
@@ -3264,14 +3264,14 @@ msgstr ""
 "Dies wird auf alle Zeilen in der Datei __in.txt__ angewendet."
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:1279
+#: getting_started_in_kicad.adoc:1293
 #, no-wrap
 msgid "Simple script"
 msgstr "Einfaches Skript"
 
 # No need to translate.
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1302
+#: getting_started_in_kicad.adoc:1316
 #, no-wrap
 msgid ""
 "#!/usr/bin/env python\n"
@@ -3297,7 +3297,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1308
+#: getting_started_in_kicad.adoc:1322
 msgid ""
 "While merging the two components into one, it is necessary to use the "
 "Library Editor from Eeschema to move the first component so that the second "
@@ -3310,14 +3310,14 @@ msgstr ""
 "Beispiel einer finalen *.lib Datei und deren Darstellung in __Eeschema__."
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:1309
+#: getting_started_in_kicad.adoc:1323
 #, no-wrap
 msgid "Contents of a *.lib file"
 msgstr "Inhalt einer *.lib Datei"
 
 # No translation needed.
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1321
+#: getting_started_in_kicad.adoc:1335
 #, no-wrap
 msgid ""
 "EESchema-LIBRARY Version 2.3\n"
@@ -3334,14 +3334,14 @@ msgstr ""
 
 # No translation needed.
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1323
+#: getting_started_in_kicad.adoc:1337
 #, no-wrap
 msgid "...\n"
 msgstr ""
 
 # No translation needed.
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1328
+#: getting_started_in_kicad.adoc:1342
 #, no-wrap
 msgid ""
 "X PIN49 49 750 -500 300 L 50 50 1 1 I\n"
@@ -3351,13 +3351,13 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1331
+#: getting_started_in_kicad.adoc:1345
 msgid "image:images/gsik_high_number_pins.png[gsik_high_number_pins_png]"
 msgstr ""
 
 # ._  -> _.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1336
+#: getting_started_in_kicad.adoc:1350
 msgid ""
 "The Python script presented here is a very powerful tool for manipulating "
 "both pin numbers and pin labels. Mind, however, that all its power comes for "
@@ -3370,13 +3370,13 @@ msgstr ""
 "gskinner.com/RegExr/_."
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1338
+#: getting_started_in_kicad.adoc:1352
 #, no-wrap
 msgid "Make component footprints"
 msgstr "Erstellen eines Footprints"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1344
+#: getting_started_in_kicad.adoc:1358
 msgid ""
 "Unlike other EDA software tools, which have one type of library that "
 "contains both the schematic symbol and the footprint variations, KiCad _."
@@ -3390,7 +3390,7 @@ msgstr ""
 "um die Zuordnung von Footprints zu Schaltplansymbolen erstellen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1347
+#: getting_started_in_kicad.adoc:1361
 msgid ""
 "As for _.lib_ files, _.kicad_mod_ library files are text files that can "
 "contain anything from one to several parts."
@@ -3399,7 +3399,7 @@ msgstr ""
 "einzelne oder mehrere Elemente enthalten können."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1351
+#: getting_started_in_kicad.adoc:1365
 msgid ""
 "There is an extensive footprint library with KiCad, however on occasion you "
 "might find that the footprint you need is not in the KiCad library.  Here "
@@ -3411,13 +3411,13 @@ msgstr ""
 "PCB Footprint in KiCad zu erstellen:"
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1353
+#: getting_started_in_kicad.adoc:1367
 #, no-wrap
 msgid "Using Footprint Editor"
 msgstr "Benutzen des Footprint Editors"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1359
+#: getting_started_in_kicad.adoc:1373
 msgid ""
 "From the KiCad project manager start the _Pcbnew_ tool. Click on the 'Open "
 "Footprint Editor' icon image:images/icons/edit_module.png[edit_module_png] "
@@ -3429,7 +3429,7 @@ msgstr ""
 "Editor'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1371
+#: getting_started_in_kicad.adoc:1385
 msgid ""
 "We are going to save the new footprint 'MYCONN3' in the new footprint "
 "library 'myfootprint'.  Create a new folder _myfootprint.pretty_ in the "
@@ -3454,7 +3454,7 @@ msgstr ""
 "Bibliothek 'myfootprint'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1380
+#: getting_started_in_kicad.adoc:1394
 msgid ""
 "Click on the 'New Footprint' icon image:images/icons/new_footprint."
 "png[new_footprint_png] on the top toolbar.  Type 'MYCONN3' as the 'footprint "
@@ -3473,7 +3473,7 @@ msgstr ""
 "'Darstellung' auf 'Nicht sichtbar'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1385
+#: getting_started_in_kicad.adoc:1399
 msgid ""
 "Select the 'Add Pads' icon image:images/icons/pad.png[pad_png] on the right "
 "toolbar. Click on the working sheet to place the pad. Right click on the new "
@@ -3485,14 +3485,14 @@ msgstr ""
 "editieren'. Alternativ können Sie die Taste 'e' betätigen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1387
+#: getting_started_in_kicad.adoc:1401
 msgid "image:images/pad_properties.png[Pad Properties]"
 msgstr "image:images/de/pad_properties.png[Pad Eigenschaften]"
 
 # Some statements are not complained to current upstream status!
 # Shape Size X -> Size X ...
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1391
+#: getting_started_in_kicad.adoc:1405
 msgid ""
 "Set the 'Pad Num' to '1', 'Pad Shape' to 'Rect', 'Pad Type' to 'SMD', 'Shape "
 "Size X' to '0.4', and 'Shape Size Y' to '0.8'. Click OK.  Click on 'Add "
@@ -3504,7 +3504,7 @@ msgstr ""
 "Pads."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1395
+#: getting_started_in_kicad.adoc:1409
 msgid ""
 "If you want to change the grid size, *Right click* -> **Grid Select**. Be "
 "sure to select the appropriate grid size before laying down the components."
@@ -3515,7 +3515,7 @@ msgstr ""
 
 # The referenzed picture is missing.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1398
+#: getting_started_in_kicad.adoc:1412
 msgid ""
 "Move the 'MYCONN3' label and the 'SMD' label out of the way so that it looks "
 "like the image shown above."
@@ -3524,7 +3524,7 @@ msgstr ""
 "aussieht wie oberhalb zu sehen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1405
+#: getting_started_in_kicad.adoc:1419
 msgid ""
 "When placing pads it is often necessary to measure relative distances. Place "
 "the cursor where you want the relative coordinate point _(0,0)_ to be and "
@@ -3540,7 +3540,7 @@ msgstr ""
 "neuen Nullpunkt zu setzen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1410
+#: getting_started_in_kicad.adoc:1424
 msgid ""
 "Now add a footprint contour. Click on the 'Add graphic line or polygon' "
 "button image:images/icons/add_polygon.png[add_polygon_png] in the right "
@@ -3552,7 +3552,7 @@ msgstr ""
 "Bauteil herum."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1414
+#: getting_started_in_kicad.adoc:1428
 msgid ""
 "Click on the 'Save Footprint in Active Library' icon image:images/icons/"
 "save_library.png[save_library_png] on the top toolbar, using the default "
@@ -3563,13 +3563,13 @@ msgstr ""
 "behalten Sie den Namen MYCONN3 bei."
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1416
+#: getting_started_in_kicad.adoc:1430
 #, no-wrap
 msgid "Note about portability of KiCad project files"
 msgstr "Informationen über die Portabilität von KiCad Projektdateien"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1420
+#: getting_started_in_kicad.adoc:1434
 msgid ""
 "What files do you need to send to someone so that they can fully load and "
 "use your KiCad project?"
@@ -3578,7 +3578,7 @@ msgstr ""
 "Projekt laden und benutzen kann?"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1427
+#: getting_started_in_kicad.adoc:1441
 msgid ""
 "When you have a KiCad project to share with somebody, it is important that "
 "the schematic file __.sch__, the board file __.kicad_pcb__, the project file "
@@ -3596,7 +3596,7 @@ msgstr ""
 "zu verändern."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1439
+#: getting_started_in_kicad.adoc:1453
 msgid ""
 "With KiCad schematics, people need the _.lib_ files that contain the "
 "symbols. Those library files need to be loaded in the _Eeschema_ "
@@ -3624,7 +3624,7 @@ msgstr ""
 
 # *Pcbnew* -> *File* -> *Archive* -> *Footprints* -> **Create footprint archive**   --> seems outdated!
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1447
+#: getting_started_in_kicad.adoc:1461
 msgid ""
 "If someone sends you a _.kicad_pcb_ file with footprints you would like to "
 "use in another board, you can open the Footprint Editor, load a footprint "
@@ -3644,7 +3644,7 @@ msgstr ""
 "eine neue _.kicad_mod_ Datei mit allen Footprints der Platine."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1453
+#: getting_started_in_kicad.adoc:1467
 msgid ""
 "Bottom line, if the PCB is the only thing you want to distribute, then the "
 "board file _.kicad_pcb_ is enough. However, if you want to give people the "
@@ -3660,7 +3660,7 @@ msgstr ""
 
 # No need to translate.
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1471
+#: getting_started_in_kicad.adoc:1485
 #, no-wrap
 msgid ""
 "tutorial1/\n"
@@ -3682,13 +3682,13 @@ msgid ""
 msgstr ""
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1474
+#: getting_started_in_kicad.adoc:1488
 #, no-wrap
 msgid "More about KiCad documentation"
 msgstr "Mehr KiCad Dokumentation"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1479
+#: getting_started_in_kicad.adoc:1493
 msgid ""
 "This has been a quick guide on most of the features in KiCad. For more "
 "detailed instructions consult the help files which you can access through "
@@ -3700,7 +3700,7 @@ msgstr ""
 "jeweils auf *Hilfe* -> **[Modul]-Benutzerhandbuch**."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1482
+#: getting_started_in_kicad.adoc:1496
 msgid ""
 "KiCad comes with a pretty good set of multi-language manuals for all its "
 "four software components."
@@ -3709,13 +3709,13 @@ msgstr ""
 "vier Software Komponenten."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1484
+#: getting_started_in_kicad.adoc:1498
 msgid "The English version of all KiCad manuals are distributed with KiCad."
 msgstr ""
 "Die englischen Versionen von allen KiCad Modulen wird mit KiCad verteilt."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1490
+#: getting_started_in_kicad.adoc:1504
 msgid ""
 "In addition to its manuals, KiCad is distributed with this tutorial, which "
 "has been translated into other languages. All the different versions of this "
@@ -3731,7 +3731,7 @@ msgstr ""
 "Plattform verteilt werden."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1493
+#: getting_started_in_kicad.adoc:1507
 msgid ""
 "For example, on Linux the typical locations are in the following "
 "directories, depending on your exact distribution:"
@@ -3741,7 +3741,7 @@ msgstr ""
 
 # No need for translation.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1496
+#: getting_started_in_kicad.adoc:1510
 #, no-wrap
 msgid ""
 " /usr/share/doc/kicad/help/en/\n"
@@ -3751,35 +3751,35 @@ msgstr ""
 " /usr/local/share/doc/kicad/help/de\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1498
+#: getting_started_in_kicad.adoc:1512
 msgid "On Windows it is in:"
 msgstr "Unter Windows ist dies Anleitungen zu finden unter:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1500
+#: getting_started_in_kicad.adoc:1514
 #, no-wrap
 msgid " <installation directory>/share/doc/kicad/help/en\n"
 msgstr " <installation directory>/share/doc/kicad/help/de\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1502
+#: getting_started_in_kicad.adoc:1516
 msgid "On OS X:"
 msgstr "In OS X:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1504
+#: getting_started_in_kicad.adoc:1518
 #, no-wrap
 msgid " /Library/Application Support/kicad/help/en\n"
 msgstr " /Library/Application Support/kicad/help/de\n"
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1506
+#: getting_started_in_kicad.adoc:1520
 #, no-wrap
 msgid "KiCad documentation on the Web"
 msgstr "KiCad Dokumentation im Internet"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1509
+#: getting_started_in_kicad.adoc:1523
 msgid ""
 "Latest KiCad documentations are available in multiple languages on the Web."
 msgstr ""
@@ -3788,7 +3788,7 @@ msgstr ""
 
 # No need for translation.
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1511
+#: getting_started_in_kicad.adoc:1525
 msgid "http://kicad-pcb.org/help/documentation/"
 msgstr ""
 

--- a/src/getting_started_in_kicad/po/es.po
+++ b/src/getting_started_in_kicad/po/es.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Getting Started in KiCad\n"
-"POT-Creation-Date: 2016-01-06 23:55+0100\n"
+"POT-Creation-Date: 2016-01-07 20:18+0100\n"
 "PO-Revision-Date: 2015-12-23 16:28+0100\n"
 "Last-Translator: Antonio Morales <antonio1010.mr@gmail.com>\n"
 "Language-Team: Español <es@li.org>\n"
@@ -729,7 +729,7 @@ msgstr ""
 "botón central del ratón (rueda) para desplazarse horizontal y verticalmente."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:304
+#: getting_started_in_kicad.adoc:306
 #, fuzzy
 #| msgid ""
 #| "Hover the mouse over the component 'R' and press the r key. Notice how "
@@ -743,7 +743,7 @@ msgstr ""
 "el componente se gira."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:306
+#: getting_started_in_kicad.adoc:312
 msgid ""
 "If your mouse was also over the _Field Reference_ ('R') or the _Field Value_ "
 "('R?'), a menu will appear. You will see these 'Clarify Selection' menu "
@@ -753,7 +753,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:312
+#: getting_started_in_kicad.adoc:318
 msgid ""
 "Right click in the middle of the component and select *Edit Component* -> "
 "**Value**. You can achieve the same result by hovering over the component "
@@ -768,12 +768,12 @@ msgstr ""
 "muestra las teclas de acceso directo para todas las acciones disponibles."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:314
+#: getting_started_in_kicad.adoc:320
 msgid "image:images/edit_component_dropdown.png[Edit component menu]"
 msgstr "image:images/edit_component_dropdown.png[Edit component menu]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:317
+#: getting_started_in_kicad.adoc:323
 msgid ""
 "The Component value window will appear. Replace the current value 'R' with "
 "'1k'. Click OK."
@@ -782,7 +782,7 @@ msgstr ""
 "con '1k'. Haga clic en Aceptar."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:320
+#: getting_started_in_kicad.adoc:326
 msgid ""
 "Do not change the Reference field (R?), this will be done automatically "
 "later on. The value inside the resistor should now be '1k'."
@@ -791,12 +791,12 @@ msgstr ""
 "adelante. El valor dentro de la resistencia ahora debería ser '1k'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:322
+#: getting_started_in_kicad.adoc:328
 msgid "image:images/resistor_value.png[Resistor Value]"
 msgstr "image:images/resistor_value.png[Resistor Value]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:325
+#: getting_started_in_kicad.adoc:331
 msgid ""
 "To place another resistor, simply click where you want the resistor to "
 "appear. The Component Selection window will appear again."
@@ -806,7 +806,7 @@ msgstr ""
 "nuevo."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:328
+#: getting_started_in_kicad.adoc:334
 msgid ""
 "The resistor you previously chose is now in your history list, appearing as "
 "'R'. Click OK and place the component."
@@ -816,12 +816,12 @@ msgstr ""
 "componente."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:330
+#: getting_started_in_kicad.adoc:336
 msgid "image:images/component_history.png[Component history]"
 msgstr "image:images/component_history.png[Component history]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:335
+#: getting_started_in_kicad.adoc:341
 msgid ""
 "In case you make a mistake and want to delete a component, right click on "
 "the component and click 'Delete Component'. This will remove the component "
@@ -834,7 +834,7 @@ msgstr ""
 "el componente que desea eliminar y pulsar la tecla del."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:339
+#: getting_started_in_kicad.adoc:345
 msgid ""
 "You can edit any default shortcut key by going to *Preferences* -> *Hotkeys* "
 "-> **Edit hotkeys**. Any modification will be saved immediately."
@@ -844,7 +844,7 @@ msgstr ""
 "modificación se guardará inmediatamente."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:343
+#: getting_started_in_kicad.adoc:349
 msgid ""
 "You can also duplicate a component already on your schematic sheet by "
 "hovering over it and pressing the c key. Click where you want to place the "
@@ -855,7 +855,7 @@ msgstr ""
 "colocar el nuevo componente duplicado."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:349
+#: getting_started_in_kicad.adoc:355
 msgid ""
 "Right click on the second resistor. Select 'Drag Component'.  Reposition the "
 "component and left click to drop. The same functionality can be achieved by "
@@ -869,7 +869,7 @@ msgstr ""
 "y la tecla y voltearán el componente sobre el eje correspondiente.."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:354
+#: getting_started_in_kicad.adoc:360
 #, no-wrap
 msgid ""
 "*Right-Click* -> *Move component* (equivalent to the m key\n"
@@ -883,7 +883,7 @@ msgstr ""
 "conectados. Se verá posteriormente el porqué de este caso.\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:358
+#: getting_started_in_kicad.adoc:364
 msgid ""
 "Edit the second resistor by hovering over it and pressing the v key.  "
 "Replace 'R' with '100'. You can undo any of your editing actions with the "
@@ -894,7 +894,7 @@ msgstr ""
 "con las teclas ctrl+z."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:364
+#: getting_started_in_kicad.adoc:370
 msgid ""
 "Change the grid size. You have probably noticed that on the schematic sheet "
 "all components are snapped onto a large pitch grid. You can easily change "
@@ -908,7 +908,7 @@ msgstr ""
 "de 50,0 mils (milésimas de pulgada) para la hoja del esquema__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:366
+#: getting_started_in_kicad.adoc:374
 msgid ""
 "We are going to add a component from a library that isn't configured in the "
 "default project. In the menu, choose *Preferences* -> **Component "
@@ -916,7 +916,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:368
+#: getting_started_in_kicad.adoc:380
 msgid ""
 "You need to find where the official KiCad libraries are installed on your "
 "computer. Look for a `library` directory containing a hundred of `.dcm` and "
@@ -926,7 +926,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:372
+#: getting_started_in_kicad.adoc:384
 #, fuzzy
 #| msgid ""
 #| "Repeat the add-component steps, this time choosing the 'device' library "
@@ -940,7 +940,7 @@ msgstr ""
 "'device' y tomando un componente 'LED' de ésta."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:377
+#: getting_started_in_kicad.adoc:389
 msgid ""
 "Hover the mouse over the microcontroller component. Press the y key or the x "
 "key on the keyboard. Notice how the component is flipped over its x axis or "
@@ -952,7 +952,7 @@ msgstr ""
 "orientación original."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:380
+#: getting_started_in_kicad.adoc:392
 msgid ""
 "Repeat the add-component steps, this time choosing the 'device' library and "
 "picking the 'LED' component from it."
@@ -961,19 +961,19 @@ msgstr ""
 "'device' y tomando un componente 'LED' de ésta."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:382
+#: getting_started_in_kicad.adoc:394
 msgid "Organise all components on your schematic sheet as shown below."
 msgstr ""
 "Organice todos los componentes en su esquema con la distribución que se "
 "muestra debajo."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:384
+#: getting_started_in_kicad.adoc:396
 msgid "image:images/gsik_tutorial1_010.png[gsik_tutorial1_010_png]"
 msgstr "image:images/gsik_tutorial1_010.png[gsik_tutorial1_010_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:390
+#: getting_started_in_kicad.adoc:402
 msgid ""
 "We now need to create the schematic component 'MYCONN3' for our 3-pin "
 "connector. You can jump to the section titled <<make-schematic-components-in-"
@@ -987,7 +987,7 @@ msgstr ""
 "y regresar a esta sección para continuar con el diseño."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:393
+#: getting_started_in_kicad.adoc:405
 msgid ""
 "You can now place the freshly made component. Press the 'a' key and pick the "
 "'MYCONN3' component in the 'myLib' library."
@@ -996,7 +996,7 @@ msgstr ""
 "y tome el componente 'MYCONN3' de la biblioteca 'mylib'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:399
+#: getting_started_in_kicad.adoc:411
 msgid ""
 "The component identifier 'J?' will appear under the 'MYCONN3' label.  If you "
 "want to change its position, right click on 'J?' and click on 'Move "
@@ -1012,12 +1012,12 @@ msgstr ""
 "veces como necesite."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:401
+#: getting_started_in_kicad.adoc:413
 msgid "image:images/gsik_myconn3_s.png[gsik_myconn3_s_png]"
 msgstr "image:images/gsik_myconn3_s.png[gsik_myconn3_s_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:407
+#: getting_started_in_kicad.adoc:419
 msgid ""
 "It is time to place the power and ground symbols. Click on the 'Place a "
 "power port' button image:images/icons/add_power.png[add_power_png] on the "
@@ -1031,7 +1031,7 @@ msgstr ""
 "y seleccione 'VCC' de la biblioteca 'power'. Haga clic en OK."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:413
+#: getting_started_in_kicad.adoc:425
 msgid ""
 "Click above the pin of the 1k resistor to place the VCC part. Click on the "
 "area above the microcontroller 'VDD'. In the 'Component Selection history' "
@@ -1045,7 +1045,7 @@ msgstr ""
 "del pin VCC de 'MYCONN3'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:418
+#: getting_started_in_kicad.adoc:430
 msgid ""
 "Repeat the add-pin steps but this time select the GND part. Place a GND part "
 "under the GND pin of 'MYCONN3'. Place another GND symbol on the right of the "
@@ -1057,12 +1057,12 @@ msgstr ""
 "pin VSS del microcontrolador. El esquema debería paracerse a este:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:420
+#: getting_started_in_kicad.adoc:432
 msgid "image:images/gsik_tutorial1_020.png[gsik_tutorial1_020_png]"
 msgstr "image:images/gsik_tutorial1_020.png[gsik_tutorial1_020_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:424
+#: getting_started_in_kicad.adoc:436
 msgid ""
 "Next, we will wire all our components. Click on the 'Place wire' icon image:"
 "images/icons/add_line.png[Place wire] on the right toolbar."
@@ -1072,7 +1072,7 @@ msgstr ""
 "herramientas derecha."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:429
+#: getting_started_in_kicad.adoc:441
 msgid ""
 "Be careful not to pick 'Place a bus', which appears directly beneath this "
 "button but has thicker lines. The section <<bus-connections-in-kicad,Bus "
@@ -1083,7 +1083,7 @@ msgstr ""
 "kicad,Conexiones de bus en KiCad>> explicará como usar los buses."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:433
+#: getting_started_in_kicad.adoc:445
 msgid ""
 "Click on the little circle at the end of pin 7 of the microcontroller and "
 "then click on the little circle on pin 2 of the LED.  You can zoom in while "
@@ -1094,7 +1094,7 @@ msgstr ""
 "aproximarse con el zoom mientras que está realizando la conexión."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:438
+#: getting_started_in_kicad.adoc:450
 msgid ""
 "If you want to reposition wired components, it is important to use the g key "
 "(grab) option and not the m key (move) option. Using the grab option will "
@@ -1107,12 +1107,12 @@ msgstr ""
 "recuerde cómo mover un componente."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:440
+#: getting_started_in_kicad.adoc:452
 msgid "image:images/gsik_tutorial1_030.png[gsik_tutorial1_030_png]"
 msgstr "image:images/gsik_tutorial1_030.png[gsik_tutorial1_030_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:446
+#: getting_started_in_kicad.adoc:458
 msgid ""
 "Repeat this process and wire up all the other components as shown below. To "
 "terminate a wire just double-click. When wiring up the VCC and GND symbols, "
@@ -1125,12 +1125,12 @@ msgstr ""
 "y el centro de la parte superior del símbolo GND. Vea la siguiente imagen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:448
+#: getting_started_in_kicad.adoc:460
 msgid "image:images/gsik_tutorial1_040.png[gsik_tutorial1_040_png]"
 msgstr "image:images/gsik_tutorial1_040.png[gsik_tutorial1_040_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:453
+#: getting_started_in_kicad.adoc:465
 msgid ""
 "We will now consider an alternative way of making a connection using labels. "
 "Pick a net labelling tool by clicking on the 'Place net name' icon image:"
@@ -1143,7 +1143,7 @@ msgstr ""
 "herramientas de la derecha. También puede utilizar la tecla l."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:456
+#: getting_started_in_kicad.adoc:468
 msgid ""
 "Click in the middle of the wire connected to pin 6 of the microcontroller. "
 "Name this label 'INPUT'."
@@ -1152,7 +1152,7 @@ msgstr ""
 "Nombre esta etiqueta como \"INPUT\"."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:465
+#: getting_started_in_kicad.adoc:477
 msgid ""
 "Follow the same procedure and place another label on line on the right of "
 "the 100 ohm resistor. Also name it 'INPUT'. The two labels, having the same "
@@ -1172,7 +1172,7 @@ msgstr ""
 "del componente."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:471
+#: getting_started_in_kicad.adoc:483
 msgid ""
 "Labels can also be used to simply label wires for informative purposes. "
 "Place a label on pin 7 of the PIC. Enter the name 'uCtoLED'.  Name the wire "
@@ -1185,7 +1185,7 @@ msgstr ""
 "'LEDtoR'. Nombre el hilo entre 'MYCONN3' y la resistencia como \"INPUTtoR '."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:474
+#: getting_started_in_kicad.adoc:486
 msgid ""
 "You do not have to label the VCC and GND lines because the labels are "
 "implied from the power objects they are connected to."
@@ -1195,17 +1195,17 @@ msgstr ""
 "están conectadas."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:476
+#: getting_started_in_kicad.adoc:488
 msgid "Below you can see what the final result should look like."
 msgstr "Abajo puede ver como debería ser su resultado final."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:478
+#: getting_started_in_kicad.adoc:490
 msgid "image:images/gsik_tutorial1_050.png[gsik_tutorial1_050_png]"
 msgstr "image:images/gsik_tutorial1_050.png[gsik_tutorial1_050_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:484
+#: getting_started_in_kicad.adoc:496
 msgid ""
 "Let's now deal with unconnected wires. Any pin or wire that is not connected "
 "will generate a warning when checked by KiCad. To avoid these warnings you "
@@ -1219,7 +1219,7 @@ msgstr ""
 "conectar como desconectado."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:489
+#: getting_started_in_kicad.adoc:501
 msgid ""
 "Click on the 'Place no connect flag' icon image:images/icons/noconn."
 "png[noconn_png] on the right toolbar. Click on pins 2, 3, 4 and 5. An X will "
@@ -1231,12 +1231,12 @@ msgstr ""
 "conexión es intencional."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:491
+#: getting_started_in_kicad.adoc:503
 msgid "image:images/gsik_tutorial1_060.png[gsik_tutorial1_060_png]"
 msgstr "image:images/gsik_tutorial1_060.png[gsik_tutorial1_060_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:498
+#: getting_started_in_kicad.adoc:510
 msgid ""
 "Some components have power pins that are invisible. You can make them "
 "visible by clicking on the 'Show hidden pins' icon image:images/icons/"
@@ -1252,7 +1252,7 @@ msgstr ""
 "alimentación ocultos."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:504
+#: getting_started_in_kicad.adoc:516
 msgid ""
 "It is now necessary to add a 'Power Flag' to indicate to KiCad that power "
 "comes in from somewhere. Press the a key, select 'List All', double click on "
@@ -1266,12 +1266,12 @@ msgstr ""
 "continuación."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:506
+#: getting_started_in_kicad.adoc:518
 msgid "image:images/gsik_tutorial1_070.png[gsik_tutorial1_070_png]"
 msgstr "image:images/gsik_tutorial1_070.png[gsik_tutorial1_070_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:509
+#: getting_started_in_kicad.adoc:521
 msgid ""
 "This will avoid the classic schematic checking warning: Warning Pin power_in "
 "not driven (Net xx)"
@@ -1280,7 +1280,7 @@ msgstr ""
 "Warning Pin power_in not driven (Net xx)"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:513
+#: getting_started_in_kicad.adoc:525
 msgid ""
 "Sometimes it is good to write comments here and there. To add comments on "
 "the schematic use the 'Place graphic text (comment)' icon image:images/icons/"
@@ -1292,7 +1292,7 @@ msgstr ""
 "derecha."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:518
+#: getting_started_in_kicad.adoc:531
 #, fuzzy
 #| msgid ""
 #| "All components now need to have unique identifiers. In fact, many of our "
@@ -1312,7 +1312,7 @@ msgstr ""
 "png[annotate_png]."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:525
+#: getting_started_in_kicad.adoc:538
 msgid ""
 "In the Annotate Schematic window, select 'Use the entire schematic' and "
 "click on the 'Annotation' button. Click OK in the confirmation message and "
@@ -1327,7 +1327,7 @@ msgstr ""
 "ejemplo, se les ha llamado 'R1', 'R2', 'U1', 'D1' y 'J1'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:535
+#: getting_started_in_kicad.adoc:547
 #, fuzzy
 #| msgid ""
 #| "We will now check our schematic for errors. Click on the 'Perform "
@@ -1358,7 +1358,7 @@ msgstr ""
 "de nuevo para recibir más información acerca de los errores."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:537
+#: getting_started_in_kicad.adoc:551
 msgid ""
 "If you have a warning with \"No default editor found you must choose it\", "
 "try setting the path to `c:\\windows\\notepad.exe` (windows) or `/usr/bin/"
@@ -1366,7 +1366,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:542
+#: getting_started_in_kicad.adoc:556
 #, fuzzy
 #| msgid ""
 #| "The schematic is now finished. We can now create a Netlist file to which "
@@ -1387,7 +1387,7 @@ msgstr ""
 "el nombre de archivo predeterminado."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:547
+#: getting_started_in_kicad.adoc:561
 msgid ""
 "After generating the Netlist file, click on the 'Run Cvpcb' icon image:"
 "images/icons/cvpcb.png[cvpcb_png] on the top toolbar. If a missing file "
@@ -1399,7 +1399,7 @@ msgstr ""
 "simplemente ignórela y haga clic en Aceptar."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:553
+#: getting_started_in_kicad.adoc:567
 msgid ""
 "_Cvpcb_ allows you to link all the components in your schematic with "
 "footprints in the KiCad library. The pane on the center shows all the "
@@ -1414,12 +1414,12 @@ msgstr ""
 "\"LED: LED-5MM 'y haga doble clic en él."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:555
+#: getting_started_in_kicad.adoc:569
 msgid "image:images/icons/cvpcb.png[cvpcb_png]"
 msgstr "image:images/icons/cvpcb.png[cvpcb_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:563
+#: getting_started_in_kicad.adoc:577
 msgid ""
 "It is possible that the pane on the right shows only a selected subgroup of "
 "available footprints. This is because KiCad is trying to suggest to you a "
@@ -1438,7 +1438,7 @@ msgstr ""
 "activar o desactivar estos filtros."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:567
+#: getting_started_in_kicad.adoc:581
 msgid ""
 "For 'IC1' select the 'Housings_DIP:DIP-8_W7.62mm' footprint.  For 'J1' "
 "select the 'Connect:Banana_Jack_3Pin' footprint.  For 'R1' and 'R2' select "
@@ -1449,7 +1449,7 @@ msgstr ""
 "la huella 'Discret:R1'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:578
+#: getting_started_in_kicad.adoc:592
 msgid ""
 "If you are interested in knowing what the footprint you are choosing looks "
 "like, you have two options. You can click on the 'View selected footprint' "
@@ -1470,7 +1470,7 @@ msgstr ""
 "asegurarse de que las dimensiones coinciden."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:587
+#: getting_started_in_kicad.adoc:601
 msgid ""
 "You are done. You can now update your netlist file with all the associated "
 "footprints. Click on *File* -> **Save As**. The default name 'tutorial1.net' "
@@ -1490,7 +1490,7 @@ msgstr ""
 "documento."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:591
+#: getting_started_in_kicad.adoc:605
 msgid ""
 "You can close _Cvpcb_ and go back to the _Eeschema_ schematic editor. Save "
 "the project by clicking on *File* -> **Save Whole Schematic Project**. Close "
@@ -1501,12 +1501,12 @@ msgstr ""
 "Proyecto**. Cierre el editor de esquemas."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:593
+#: getting_started_in_kicad.adoc:607
 msgid "Switch to the KiCad project manager."
 msgstr "Cambie al gestor del proyecto de KiCad."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:597
+#: getting_started_in_kicad.adoc:611
 msgid ""
 "The netlist file describes all components and their respective pin "
 "connections. The netlist file is actually a text file that you can easily "
@@ -1517,7 +1517,7 @@ msgstr ""
 "se puede inspeccionar, editar o realizar scripts."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:600
+#: getting_started_in_kicad.adoc:614
 msgid ""
 "Library files (__*.lib__) are text files too and they are also easily "
 "editable or scriptable."
@@ -1526,7 +1526,7 @@ msgstr ""
 "por tanto fácilmente editables o analizables mediante scripts."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:607
+#: getting_started_in_kicad.adoc:621
 msgid ""
 "To create a Bill Of Materials (BOM), go to the _Eeschema_ schematic editor "
 "and click on the 'Bill of materials' icon image:images/icons/bom."
@@ -1542,7 +1542,7 @@ msgstr ""
 "seleccionamos __bom2csv.xsl__."
 
 #. type: delimited block =
-#: getting_started_in_kicad.adoc:612
+#: getting_started_in_kicad.adoc:626
 msgid ""
 "The *.xsl file is located in __plugins__ directory of the KiCad "
 "installation, which is located at: /usr/lib/kicad/plugins/."
@@ -1551,47 +1551,47 @@ msgstr ""
 "KiCad, que se encuentra en: /usr/lib/kicad/plugins/."
 
 #. type: delimited block =
-#: getting_started_in_kicad.adoc:614
+#: getting_started_in_kicad.adoc:628
 msgid "Or get the file via:"
 msgstr "O consega el archivo a través de:"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:616
+#: getting_started_in_kicad.adoc:630
 #, no-wrap
 msgid "wget https://raw.githubusercontent.com/KiCad/kicad-source-mirror/master/eeschema/plugins/bom2csv.xsl\n"
 msgstr "wget https://raw.githubusercontent.com/KiCad/kicad-source-mirror/master/eeschema/plugins/bom2csv.xsl\n"
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:619
+#: getting_started_in_kicad.adoc:633
 #, no-wrap
 msgid "KiCad automatically generates the command, for example:"
 msgstr "KiCad genera automáticamente el comando, por ejemplo:"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:622
+#: getting_started_in_kicad.adoc:636
 #, no-wrap
 msgid "xsltproc -o \"%O\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 msgstr "xsltproc -o \"%O\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:624
+#: getting_started_in_kicad.adoc:638
 #, no-wrap
 msgid "You may want to add the extension, so change this command line to:"
 msgstr "Es posible que desee añadir la extensión, cambie esta línea de comandos a:"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:627
+#: getting_started_in_kicad.adoc:641
 #, no-wrap
 msgid "xsltproc -o \"%O.csv\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 msgstr "xsltproc -o \"%O.csv\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:630
+#: getting_started_in_kicad.adoc:644
 msgid "Press Help button for more info."
 msgstr "Pulse el botón Ayuda para obtener más información."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:634
+#: getting_started_in_kicad.adoc:648
 msgid ""
 "Now press 'Generate'. The file (same name as your project) is located in "
 "your project folder.  Open the **.csv* file with LibreOffice Calc or Excel. "
@@ -1603,7 +1603,7 @@ msgstr ""
 "Aceptar."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:638
+#: getting_started_in_kicad.adoc:652
 msgid ""
 "You are now ready to move to the PCB layout part, which is presented in the "
 "next section. However, before moving on let's take a quick look at how to "
@@ -1615,13 +1615,13 @@ msgstr ""
 "buses."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:640
+#: getting_started_in_kicad.adoc:654
 #, no-wrap
 msgid "Bus connections in KiCad"
 msgstr "Conexiones mediante buses en KiCad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:646
+#: getting_started_in_kicad.adoc:660
 msgid ""
 "Sometimes you might need to connect several sequential pins of component A "
 "with some other sequential pins of component B. In this case you have two "
@@ -1634,7 +1634,7 @@ msgstr ""
 "el uso de una conexión mediante un bus. Veamos cómo hacerlo."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:653
+#: getting_started_in_kicad.adoc:667
 msgid ""
 "Let us suppose that you have three 4-pin connectors that you want to connect "
 "together pin to pin. Use the label option (press the l key) to label pin 4 "
@@ -1650,7 +1650,7 @@ msgstr ""
 "automáticamente 'a2'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:657
+#: getting_started_in_kicad.adoc:671
 msgid ""
 "Press the Ins Key two more times. The Ins key corresponds to the action "
 "'Repeat last item' and it is an infinitely useful command that can make your "
@@ -1661,7 +1661,7 @@ msgstr ""
 "su vida mucho más fácil."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:668
+#: getting_started_in_kicad.adoc:682
 msgid ""
 "Repeat the same labelling action on the two other connectors CONN_2 and "
 "CONN_3 and you are done. If you proceed and make a PCB you will see that the "
@@ -1683,7 +1683,7 @@ msgstr ""
 "ningún efecto sobre la PCB."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:672
+#: getting_started_in_kicad.adoc:686
 msgid ""
 "It should be pointed out that the short wire attached to the pins in Figure "
 "2 is not strictly necessary. In fact, the labels could have been applied "
@@ -1694,7 +1694,7 @@ msgstr ""
 "directamente a los pines."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:679
+#: getting_started_in_kicad.adoc:693
 msgid ""
 "Let's take it one step further and suppose that you have a fourth connector "
 "named CONN_4 and, for whatever reason, its labelling happens to be a little "
@@ -1711,7 +1711,7 @@ msgstr ""
 "una etiqueta por bus."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:686
+#: getting_started_in_kicad.adoc:700
 msgid ""
 "Connect and label CONN_4 using the labelling method explained before. Name "
 "the pins b1, b2, b3 and b4. Connect the pin to a series of 'Wire to bus "
@@ -1726,7 +1726,7 @@ msgstr ""
 "image:images/icons/add_bus.png[add_bus_png]. Vea la Figura 4."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:689
+#: getting_started_in_kicad.adoc:703
 msgid ""
 "Put a label (press the l key option) on the bus of CONN_4 and name it "
 "'b[1..4]'."
@@ -1735,7 +1735,7 @@ msgstr ""
 "'b[1..4]'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:692
+#: getting_started_in_kicad.adoc:706
 msgid ""
 "Put a label (press the l key option) on the previous a bus and name it "
 "'a[1..4]'."
@@ -1744,7 +1744,7 @@ msgstr ""
 "y nombrela como 'a[1..4]'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:695
+#: getting_started_in_kicad.adoc:709
 msgid ""
 "What we can now do is connect bus a[1..4] with bus b[1..4] using a bus line "
 "with the button image:images/icons/add_bus.png[add_bus_png]."
@@ -1754,7 +1754,7 @@ msgstr ""
 "png[add_bus_png]."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:699
+#: getting_started_in_kicad.adoc:713
 msgid ""
 "By connecting the two buses together, pin a1 will be automatically connected "
 "to pin b1, a2 will be connected to b2 and so on. Figure 4 shows what the "
@@ -1765,7 +1765,7 @@ msgstr ""
 "figura 4 muestra como sería el resultado final."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:704
+#: getting_started_in_kicad.adoc:718
 msgid ""
 "The 'Repeat last item' option accessible via the Ins key can be successfully "
 "used to repeat period item insertions. For instance, the short wires "
@@ -1778,7 +1778,7 @@ msgstr ""
 "Figura 3 y la Figura 4 se han colocado con esta opción."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:708
+#: getting_started_in_kicad.adoc:722
 msgid ""
 "The 'Repeat last item' option accessible via the Ins key has also been "
 "extensively used to place the many series of 'Wire to bus entry' using the "
@@ -1790,18 +1790,18 @@ msgstr ""
 "add_line2bus.png[add_line2bus_png]."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:710
+#: getting_started_in_kicad.adoc:724
 msgid "image:images/gsik_bus_connection.png[gsik_bus_connection_png]"
 msgstr "image:images/gsik_bus_connection.png[gsik_bus_connection_png]"
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:712
+#: getting_started_in_kicad.adoc:726
 #, no-wrap
 msgid "Layout printed circuit boards"
 msgstr "Diseño de la placa de circuito impreso"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:716
+#: getting_started_in_kicad.adoc:730
 msgid ""
 "It is now time to use the netlist file you generated to lay out the PCB.  "
 "This is done with the _Pcbnew_ tool."
@@ -1810,13 +1810,13 @@ msgstr ""
 "diseñar la PCB. Esto se hace con la herramienta _Pcbnew_."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:718
+#: getting_started_in_kicad.adoc:732
 #, no-wrap
 msgid "Using Pcbnew"
 msgstr "Usando Pcbnew"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:724
+#: getting_started_in_kicad.adoc:738
 msgid ""
 "From the KiCad project manager, click on the 'Pcbnew' icon image:images/"
 "icons/pcbnew.png[pcbnew_png]. The 'Pcbnew' window will open. If you get an "
@@ -1829,7 +1829,7 @@ msgstr ""
 "y le pregunta si desea crearlo, simplemente haga clic en Sí."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:728
+#: getting_started_in_kicad.adoc:742
 msgid ""
 "Begin by entering some schematic information. Click on the 'Page settings' "
 "icon image:images/icons/sheetset.png[sheetset_png] on the top toolbar. Set "
@@ -1841,7 +1841,7 @@ msgstr ""
 "'título' como 'Tutorial1'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:737
+#: getting_started_in_kicad.adoc:751
 msgid ""
 "It is a good idea to start by setting the *clearance* and the *minimum track "
 "width* to those required by your PCB manufacturer. In general you can set "
@@ -1861,12 +1861,12 @@ msgstr ""
 "mostradas estan en mm."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:739
+#: getting_started_in_kicad.adoc:753
 msgid "image:images/design_rules.png[Design Rules Window]"
 msgstr "image:images/design_rules.png[Design Rules Window]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:743
+#: getting_started_in_kicad.adoc:757
 msgid ""
 "Click on the 'Global Design Rules' tab and set 'Min track width' to 0.25'. "
 "Click the OK button to commit your changes and close the Design Rules Editor "
@@ -1877,7 +1877,7 @@ msgstr ""
 "cierre la ventana del Editor de Reglas de Diseño."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:749
+#: getting_started_in_kicad.adoc:763
 msgid ""
 "Now we will import the netlist file. Click on the 'Read Netlist' icon image:"
 "images/icons/netlist.png[netlist_png] on the top toolbar. Click on the "
@@ -1891,7 +1891,7 @@ msgstr ""
 "clic en 'Leer netlist actual'. Luego haga clic en el botón \"Cerrar\"."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:752
+#: getting_started_in_kicad.adoc:766
 msgid ""
 "All components should now be visible in the top left hand corner just above "
 "the page. Scroll up if you cannot see them."
@@ -1901,7 +1901,7 @@ msgstr ""
 "puedes verlos."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:756
+#: getting_started_in_kicad.adoc:770
 msgid ""
 "Select all components with the mouse and move them to the middle of the "
 "board. If necessary you can zoom in and out while you move the components."
@@ -1911,7 +1911,7 @@ msgstr ""
 "componentes."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:762
+#: getting_started_in_kicad.adoc:776
 msgid ""
 "All components are connected via a thin group of wires called __ratsnest__. "
 "Make sure that the 'Hide board ratsnest' button image:images/icons/"
@@ -1924,7 +1924,7 @@ msgstr ""
 "esta manera se puede ver el ratsnest uniendo todos los componentes."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:765
+#: getting_started_in_kicad.adoc:779
 msgid ""
 "The tool-tip is backwards; pressing this button actually displays the "
 "ratsnest."
@@ -1933,7 +1933,7 @@ msgstr ""
 "muestra el ratsnest."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:769
+#: getting_started_in_kicad.adoc:783
 msgid ""
 "You can move each component by hovering over it and pressing the g key. "
 "Click where you want to place them. Move all components around until you "
@@ -1944,7 +1944,7 @@ msgstr ""
 "se minimice el número de cruces de hilos ratsnest."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:774
+#: getting_started_in_kicad.adoc:788
 msgid ""
 "If instead of grabbing the components (with the g key ) you move them around "
 "using the m key you will later note that you lose the track connection (the "
@@ -1957,12 +1957,12 @@ msgstr ""
 "siempre la opción de la tecla g."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:776
+#: getting_started_in_kicad.adoc:790
 msgid "image:images/gsik_tutorial1_080.png[gsik_tutorial1_080_png]"
 msgstr "image:images/gsik_tutorial1_080.png[gsik_tutorial1_080_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:783
+#: getting_started_in_kicad.adoc:797
 msgid ""
 "If the ratsnest disappears or the screen gets messy, right click and click "
 "'Redraw view'. Note how one pin of the 100 ohm resistor is connected to pin "
@@ -1978,7 +1978,7 @@ msgstr ""
 "esquema resulte mucho menos desordenado."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:791
+#: getting_started_in_kicad.adoc:805
 msgid ""
 "Now we will define the edge of the PCB. Select 'Edge.Cuts' from the drop "
 "down menu in the top toolbar. Click on the 'Add graphic line or polygon' "
@@ -1996,7 +1996,7 @@ msgstr ""
 "el borde de la placa."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:795
+#: getting_started_in_kicad.adoc:809
 msgid ""
 "Next, connect up all the wires except GND. In fact, we will connect all GND "
 "connections in one go using a ground plane placed on the bottom copper "
@@ -2007,7 +2007,7 @@ msgstr ""
 "situado en capa de cobre de la parte inferior de la placa (llamada __B.Cu__)."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:799
+#: getting_started_in_kicad.adoc:813
 msgid ""
 "Now we must choose which copper layer we want to work on. Select 'F.Cu "
 "(PgUp)' in the drag down menu on the top toolbar. This is the front top "
@@ -2018,12 +2018,12 @@ msgstr ""
 "superior. Esta es la capa de cobre superior."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:801
+#: getting_started_in_kicad.adoc:815
 msgid "image:images/select_top_copper.png[Select the Front top copper layer]"
 msgstr "image:images/select_top_copper.png[Select the Front top copper layer]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:807
+#: getting_started_in_kicad.adoc:821
 msgid ""
 "If you decide, for instance, to do a 4 layer PCB instead, go to *Design "
 "Rules* -> *Layers Setup* and change 'Copper Layers' to 4. In the 'Layers' "
@@ -2039,7 +2039,7 @@ msgstr ""
 "predefinidas'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:815
+#: getting_started_in_kicad.adoc:829
 msgid ""
 "Click on the 'Add Tracks and vias' icon image:images/icons/add_tracks."
 "png[add_tracks_png] on the right toolbar. Click on pin 1 of 'J1' and run a "
@@ -2057,12 +2057,12 @@ msgstr ""
 "que por defecto sólo hay un tamaño de pista definido."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:817
+#: getting_started_in_kicad.adoc:831
 msgid "image:images/pcbnew_1.png[pcbnew_1_png]"
 msgstr "image:images/pcbnew_1.png[pcbnew_1_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:823
+#: getting_started_in_kicad.adoc:837
 msgid ""
 "If you would like to add more track widths go to: *Design Rules* -> *Design "
 "Rules* -> *Global Design Rules* tab and at the bottom right of this window "
@@ -2078,12 +2078,12 @@ msgstr ""
 "siguiente ejemplo (medidas en pulgadas)."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:825
+#: getting_started_in_kicad.adoc:839
 msgid "image:images/custom_tracks_width.png[custom_tracks_width_png]"
 msgstr "image:images/custom_tracks_width.png[custom_tracks_width_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:832
+#: getting_started_in_kicad.adoc:846
 msgid ""
 "Alternatively, you can add a Net Class in which you specify a set of "
 "options. Go to *Design Rules* -> *Design Rules* -> *Net Classes Editor* and "
@@ -2101,7 +2101,7 @@ msgstr ""
 "flechas)."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:836
+#: getting_started_in_kicad.adoc:850
 msgid ""
 "If you want to change the grid size, *Right click* -> **Grid Select**. Be "
 "sure to select the appropriate grid size before or after laying down the "
@@ -2113,7 +2113,7 @@ msgstr ""
 "con las pistas."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:839
+#: getting_started_in_kicad.adoc:853
 msgid ""
 "Repeat this process until all wires, except pin 3 of J1, are connected. Your "
 "board should look like the example below."
@@ -2122,12 +2122,12 @@ msgstr ""
 "están conectados. Su placa debe ser similar al siguiente ejemplo."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:841
+#: getting_started_in_kicad.adoc:855
 msgid "image:images/gsik_tutorial1_090.png[gsik_tutorial1_090_png]"
 msgstr "image:images/gsik_tutorial1_090.png[gsik_tutorial1_090_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:849
+#: getting_started_in_kicad.adoc:863
 msgid ""
 "Let's now run a track on the other copper side of the PCB. Select 'B.Cu' in "
 "the drag down menu on the top toolbar. Click on the 'Add tracks and vias' "
@@ -2144,7 +2144,7 @@ msgstr ""
 "del masa. Observe cómo ha cambiado el color de la pista."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:856
+#: getting_started_in_kicad.adoc:870
 #, no-wrap
 msgid ""
 "**Go from pin A to pin B by changing layer**. It is possible to\n"
@@ -2162,13 +2162,13 @@ msgstr ""
 "pista.\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:858
+#: getting_started_in_kicad.adoc:872
 #, no-wrap
 msgid "image:images/place_a_via.png[place_a_via_png]\n"
 msgstr "image:images/place_a_via.png[place_a_via_png]\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:864
+#: getting_started_in_kicad.adoc:878
 msgid ""
 "When you want to inspect a particular connection you can click on the 'Net "
 "highlight' icon image:images/icons/net_highlight.png[net_highlight_png] on "
@@ -2181,7 +2181,7 @@ msgstr ""
 "pista en sí y todos los pads conectados a ella deben quedar resaltados."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:872
+#: getting_started_in_kicad.adoc:886
 msgid ""
 "Now we will make a ground plane that will be connected to all GND pins. "
 "Click on the 'Add Zones' icon image:images/icons/add_zone.png[add_zone_png] "
@@ -2198,7 +2198,7 @@ msgstr ""
 "'Thermal relief' y 'Orientar bordes en Zona' a 'H,V' y haga clic en OK."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:877
+#: getting_started_in_kicad.adoc:891
 msgid ""
 "Trace around the outline of the board by clicking each corner in rotation. "
 "Double-click to finish your rectangle. Right click inside the area you have "
@@ -2211,12 +2211,12 @@ msgstr ""
 "rellenarse con verde y ser algo parecido a esto:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:879
+#: getting_started_in_kicad.adoc:893
 msgid "image:images/gsik_tutorial1_100.png[gsik_tutorial1_100_png]"
 msgstr "image:images/gsik_tutorial1_100.png[gsik_tutorial1_100_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:885
+#: getting_started_in_kicad.adoc:899
 msgid ""
 "Run the design rules checker by clicking on the 'Perform Design Rules Check' "
 "icon image:images/icons/drc.png[drc_png] on the top toolbar.  Click on "
@@ -2231,7 +2231,7 @@ msgstr ""
 "Control del DRC."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:888
+#: getting_started_in_kicad.adoc:902
 msgid ""
 "Save your file by clicking on *File* -> **Save**. To admire your board in "
 "3D, click on *View* -> **3D Viewer**."
@@ -2240,17 +2240,17 @@ msgstr ""
 "su placa en 3D, haga clic en *Vista* -> **Visor 3D**."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:890
+#: getting_started_in_kicad.adoc:904
 msgid "image:images/pcbnew_3d_viewer.png[pcbnew_3d_viewer_png]"
 msgstr "image:images/pcbnew_3d_viewer.png[pcbnew_3d_viewer_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:892
+#: getting_started_in_kicad.adoc:906
 msgid "You can drag your mouse around to rotate the PCB."
 msgstr "Puede arrastrar el ratón para rotar la PCB."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:895
+#: getting_started_in_kicad.adoc:909
 msgid ""
 "Your board is complete. To send it off to a manufacturer you will need to "
 "generate all Gerber files."
@@ -2259,13 +2259,13 @@ msgstr ""
 "todos los archivos Gerber."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:897
+#: getting_started_in_kicad.adoc:911
 #, no-wrap
 msgid "Generate Gerber files"
 msgstr "Generar archivos Gerber"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:902
+#: getting_started_in_kicad.adoc:916
 msgid ""
 "Once your PCB is complete, you can generate Gerber files for each layer and "
 "send them to your favourite PCB manufacturer, who will make the board for "
@@ -2276,7 +2276,7 @@ msgstr ""
 "usted."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:906
+#: getting_started_in_kicad.adoc:920
 msgid ""
 "From KiCad, open the _Pcbnew_ software tool and load your board file by "
 "clicking on the icon image:images/icons/open_document.png[open_document_png]."
@@ -2286,7 +2286,7 @@ msgstr ""
 "png[open_document_png]."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:910
+#: getting_started_in_kicad.adoc:924
 msgid ""
 "Click on *File* -> **Plot**. Select 'Gerber' as the 'Plot Format' and select "
 "the folder in which to put all Gerber files.  Proceed by clicking on the "
@@ -2297,7 +2297,7 @@ msgstr ""
 "Gerber. Continúe haciendo clic en el botón 'Trazar'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:913
+#: getting_started_in_kicad.adoc:927
 msgid ""
 "These are the layers you need to select for making a typical 2-layer PCB:"
 msgstr ""
@@ -2305,7 +2305,7 @@ msgstr ""
 "capas típica:"
 
 #. type: delimited block |
-#: getting_started_in_kicad.adoc:924
+#: getting_started_in_kicad.adoc:938
 #, no-wrap
 msgid ""
 "|Layer |KiCad Layer Name |Old KiCad Layer Name |Default Gerber Extension\n"
@@ -2327,13 +2327,13 @@ msgstr ""
 "|Bordes |Edge.Cuts |Edges_Pcb |.GBR |.GM1\n"
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:927
+#: getting_started_in_kicad.adoc:941
 #, no-wrap
 msgid "Using GerbView"
 msgstr "Usando GerbView"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:936
+#: getting_started_in_kicad.adoc:950
 msgid ""
 "To view all your Gerber files go to the KiCad project manager and click on "
 "the 'GerbView' icon.  On the drag down menu select 'Layer 1'. Click on "
@@ -2349,7 +2349,7 @@ msgstr ""
 "encima del otro."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:939
+#: getting_started_in_kicad.adoc:953
 msgid ""
 "Use the menu on the right to select/deselect which layer to show.  Carefully "
 "inspect each layer before sending them for production."
@@ -2358,7 +2358,7 @@ msgstr ""
 "mostrar. Inspeccione cuidadosamente cada capa antes de enviarlos a producir."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:942
+#: getting_started_in_kicad.adoc:956
 msgid ""
 "To generate the drill file, from _Pcbnew_ go again for the *File* -> *Plot* "
 "option. Default settings should be fine."
@@ -2367,13 +2367,13 @@ msgstr ""
 "*Archivo* -> *Trazar*. Los ajustes por defecto deberían estar bien."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:944
+#: getting_started_in_kicad.adoc:958
 #, no-wrap
 msgid "Automatically route with FreeRouter"
 msgstr "Trazado automático con FreeRouter"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:952
+#: getting_started_in_kicad.adoc:966
 msgid ""
 "Routing a board by hand is quick and fun, however, for a board with lots of "
 "components you might want to use an autorouter. Remember that you should "
@@ -2389,7 +2389,7 @@ msgstr ""
 "vamos a utilizar es FreeRouter de __freerouting.net__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:957
+#: getting_started_in_kicad.adoc:971
 msgid ""
 "Freerouter is a open source java application, and it is needed to build by "
 "yourself to use with KiCad.  Source code of Freerouter can be found on this "
@@ -2400,7 +2400,7 @@ msgstr ""
 "se puede encontrar en este sitio: https://github.com/nikropht/FreeRouting"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:963
+#: getting_started_in_kicad.adoc:977
 msgid ""
 "From _Pcbnew_ click on *File* -> *Export* -> *Specctra DSN* or click on "
 "*Tools* -> *FreeRoute* -> **Export a Specctra Design (*.dsn) file** and save "
@@ -2414,7 +2414,7 @@ msgstr ""
 "carguelo."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:968
+#: getting_started_in_kicad.adoc:982
 msgid ""
 "The *Tools* -> *FreeRoute* dialog has a nice help button that opens a file "
 "viewer with a little document inside named **Freerouter Guidelines**. Please "
@@ -2426,7 +2426,7 @@ msgstr ""
 "para utilizar FreeRoute eficazmente."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:974
+#: getting_started_in_kicad.adoc:988
 msgid ""
 "FreeRouter has some features that KiCad does not currently have, both for "
 "manual routing and for automatic routing. FreeRouter operates in two main "
@@ -2440,7 +2440,7 @@ msgstr ""
 "detener en cualquier momento cuando lo considere necesario."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:982
+#: getting_started_in_kicad.adoc:996
 msgid ""
 "You can start the automatic routing by clicking on the 'Autorouter' button "
 "on the top bar. The bottom bar gives you information about the on-going "
@@ -2458,7 +2458,7 @@ msgstr ""
 "líneas cruzadas en el ratsnest."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:987
+#: getting_started_in_kicad.adoc:1001
 msgid ""
 "Making a left-click on the mouse can stop the automatic routing and "
 "automatically start the optimisation process. Another left-click will stop "
@@ -2471,7 +2471,7 @@ msgstr ""
 "detenerlo, es mejor dejar que FreeRouter termine su trabajo."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:991
+#: getting_started_in_kicad.adoc:1005
 msgid ""
 "Click on the *File* -> *Export Specctra Session File* menu and save the "
 "board file with the _.ses_ extension. You do not really need to save the "
@@ -2482,7 +2482,7 @@ msgstr ""
 "reglas FreeRouter."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:996
+#: getting_started_in_kicad.adoc:1010
 msgid ""
 "Back to __Pcbnew__. You can import your freshly routed board by clicking on "
 "the link *Tools* -> *FreeRoute* and then on the icon 'Back Import the "
@@ -2493,7 +2493,7 @@ msgstr ""
 "sesión Spectra (.ses)' y seleccionando el archivo _.ses_."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1001
+#: getting_started_in_kicad.adoc:1015
 msgid ""
 "If there is any routed trace that you do not like, you can delete it and re-"
 "route it again, using the del key and the routing tool, which is the 'Add "
@@ -2506,13 +2506,13 @@ msgstr ""
 "icon] en la barra de herramientas de la derecha."
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1003
+#: getting_started_in_kicad.adoc:1017
 #, no-wrap
 msgid "Forward annotation in KiCad"
 msgstr "Anotado hacia adelante en KiCad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1009
+#: getting_started_in_kicad.adoc:1023
 msgid ""
 "Once you have completed your electronic schematic, the footprint assignment, "
 "the board layout and generated the Gerber files, you are ready to send "
@@ -2524,7 +2524,7 @@ msgstr ""
 "en realidad."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1017
+#: getting_started_in_kicad.adoc:1031
 msgid ""
 "Often, this linear work-flow turns out to be not so uni-directional. For "
 "instance, when you have to modify/extend a board for which you or others "
@@ -2542,19 +2542,19 @@ msgstr ""
 "siguiente modo:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1020
+#: getting_started_in_kicad.adoc:1034
 msgid ""
 "Let's suppose that you want to replace a hypothetical connector CON1 with "
 "CON2."
 msgstr "Supongamos que desea reemplazar el conector CON1 por CON2."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1022
+#: getting_started_in_kicad.adoc:1036
 msgid "You already have a completed schematic and a fully routed PCB."
 msgstr "Ya tiene un esquema completo y un PCB totalmente trazada."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1028
+#: getting_started_in_kicad.adoc:1042
 msgid ""
 "From KiCad, start __Eeschema__, make your modifications by deleting CON1 and "
 "adding CON2. Save your schematic project with the icon image:images/icons/"
@@ -2567,7 +2567,7 @@ msgstr ""
 "images/icons/netlist.png[netlist_png] en la barra de herramientas superior."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1031
+#: getting_started_in_kicad.adoc:1045
 msgid ""
 "Click on 'Netlist' then on 'save'. Save to the default file name.  You have "
 "to rewrite the old one."
@@ -2576,7 +2576,7 @@ msgstr ""
 "archivo predeterminado. Tiene que volver a escribir el antiguo."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1037
+#: getting_started_in_kicad.adoc:1051
 msgid ""
 "Now assign a footprint to CON2. Click on the 'Run Cvpcb' icon image:images/"
 "icons/cvpcb.png[cvpcb] on the top toolbar. Assign the footprint to the new "
@@ -2589,7 +2589,7 @@ msgstr ""
 "tienen las huellas previamente asignadas. Cerrar __Cvpcb__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1040
+#: getting_started_in_kicad.adoc:1054
 msgid ""
 "Back in the schematic editor, save the project by clicking on 'File' -> "
 "'Save Whole Schematic Project'. Close the schematic editor."
@@ -2599,7 +2599,7 @@ msgstr ""
 "esquemas."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1043
+#: getting_started_in_kicad.adoc:1057
 msgid ""
 "From the KiCad project manager, click on the 'Pcbnew' icon. The 'Pcbnew' "
 "window will open."
@@ -2608,7 +2608,7 @@ msgstr ""
 "ventana 'Pcbnew' se abrirá."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1047
+#: getting_started_in_kicad.adoc:1061
 msgid ""
 "The old, already routed, board should automatically open. Let's import the "
 "new netlist file. Click on the 'Read Netlist' icon image:images/icons/"
@@ -2619,7 +2619,7 @@ msgstr ""
 "icons/netlist.png[netlist_png] en la barra de herramientas superior."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1051
+#: getting_started_in_kicad.adoc:1065
 msgid ""
 "Click on the 'Browse Netlist Files' button, select the netlist file in the "
 "file selection dialogue, and click on 'Read Current Netlist'.  Then click "
@@ -2630,7 +2630,7 @@ msgstr ""
 "actual'. Luego haga clic en el botón \"Cerrar\"."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1056
+#: getting_started_in_kicad.adoc:1070
 msgid ""
 "At this point you should be able to see a layout with all previous "
 "components already routed. On the top left corner you should see all "
@@ -2643,7 +2643,7 @@ msgstr ""
 "ratón. Mueva el componente al centro de la placa."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1059
+#: getting_started_in_kicad.adoc:1073
 msgid ""
 "Place CON2 and route it. Once done, save and proceed with the Gerber file "
 "generation as usual."
@@ -2652,7 +2652,7 @@ msgstr ""
 "con la generación de archivos Gerber, como de costumbre."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1067
+#: getting_started_in_kicad.adoc:1081
 msgid ""
 "The process described here can easily be repeated as many times as you need. "
 "Beside the Forward Annotation method described above, there is another "
@@ -2670,13 +2670,13 @@ msgstr ""
 "tanto no se describe aquí."
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1069
+#: getting_started_in_kicad.adoc:1083
 #, no-wrap
 msgid "Make schematic components in KiCad"
 msgstr "Realizar símbolos de componentes en KiCad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1076
+#: getting_started_in_kicad.adoc:1090
 msgid ""
 "Sometimes a component that you want to place on your schematic is not in the "
 "KiCad libraries. This is quite normal and there is no reason to worry. In "
@@ -2691,12 +2691,12 @@ msgstr ""
 "para KiCad en Internet. Por ejemplo desde aquí:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1078
+#: getting_started_in_kicad.adoc:1092
 msgid "http://per.launay.free.fr/kicad/kicad_php/composant.php"
 msgstr "http://per.launay.free.fr/kicad/kicad_php/composant.php"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1083
+#: getting_started_in_kicad.adoc:1097
 msgid ""
 "In KiCad, a component is a piece of text that starts with a 'DEF' and ends "
 "with 'ENDDEF'. One or more components are normally placed in a library file "
@@ -2710,13 +2710,13 @@ msgstr ""
 "comandos cortar y pegar."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1085
+#: getting_started_in_kicad.adoc:1099
 #, no-wrap
 msgid "Using Component Library Editor"
 msgstr "Usando el editor de bibliotecas de componentes"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1091
+#: getting_started_in_kicad.adoc:1105
 msgid ""
 "We can use the _Component Library Editor_ (part of __Eeschema__)  to make "
 "new components. In our project folder 'tutorial1' let's create a folder "
@@ -2730,7 +2730,7 @@ msgstr ""
 "como hayamos creado nuestro nuevo componente."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1106
+#: getting_started_in_kicad.adoc:1120
 msgid ""
 "Now we can start creating our new component. From KiCad, start __Eeschema__, "
 "click on the 'Library Editor' icon image:images/icons/libedit."
@@ -2757,7 +2757,7 @@ msgstr ""
 "la hoja del editor de partes justo debajo de la etiqueta \"MYCONN3 '."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1110
+#: getting_started_in_kicad.adoc:1124
 msgid ""
 "In the Pin Properties window that appears, set the pin name to 'VCC', set "
 "the pin number to '1', and the 'Electrical type' to 'Passive' then click OK."
@@ -2767,12 +2767,12 @@ msgstr ""
 "'Pasivo'. Haga clic en Aceptar."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1112
+#: getting_started_in_kicad.adoc:1126
 msgid "image:images/pin_properties.png[Pin Properties]"
 msgstr "image:images/pin_properties.png[Pin Properties]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1115
+#: getting_started_in_kicad.adoc:1129
 msgid ""
 "Place the pin by clicking on the location you would like it to go, right "
 "below the 'MYCONN3' label."
@@ -2781,7 +2781,7 @@ msgstr ""
 "de la etiqueta 'MYCONN3'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1119
+#: getting_started_in_kicad.adoc:1133
 msgid ""
 "Repeat the place-pin steps, this time 'Pin name' should be 'INPUT', 'Pin "
 "number' should be '2', and 'Electrical Type' should be 'Passive'."
@@ -2790,7 +2790,7 @@ msgstr ""
 "Pin' debe ser '2', y 'Tipo Electrico' a 'Pasivo'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1125
+#: getting_started_in_kicad.adoc:1139
 msgid ""
 "Repeat the place-pin steps, this time 'Pin name' should be 'GND', 'Pin "
 "number' should be '3', and 'Electrical Type' should be 'Passive'.  Arrange "
@@ -2803,7 +2803,7 @@ msgstr ""
 "centro de la página (donde las líneas azules se cruzan)."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1133
+#: getting_started_in_kicad.adoc:1147
 #, fuzzy
 #| msgid ""
 #| "Next, draw the contour of the component. Click on the 'Add rectangle' "
@@ -2827,12 +2827,12 @@ msgstr ""
 "derecha del rectángulo."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1135
+#: getting_started_in_kicad.adoc:1149
 msgid "image:images/gsik_myconn3_l.png[gsik_myconn3_l_png]"
 msgstr "image:images/gsik_myconn3_l.png[gsik_myconn3_l_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1140
+#: getting_started_in_kicad.adoc:1154
 msgid ""
 "Save the component in your library __myLib.lib__. Click on the 'New Library' "
 "icon image:images/icons/new_library.png[new_library_png], navigate into "
@@ -2845,7 +2845,7 @@ msgstr ""
 "archivo de biblioteca con el nombre __myLib.lib__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1143
+#: getting_started_in_kicad.adoc:1157
 msgid ""
 "Go to *Preferences* -> *Component Libraries* and add both _tutorial1/library/"
 "_ in 'User defined search path' and _myLib.lib in_ 'Component library files'."
@@ -2855,7 +2855,7 @@ msgstr ""
 "'archivos de la biblioteca de componentes'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1149
+#: getting_started_in_kicad.adoc:1163
 msgid ""
 "Click on the 'Select working library' icon image:images/icons/library."
 "png[library_png]. In the Select Library window click on _myLib_ and click "
@@ -2868,7 +2868,7 @@ msgstr ""
 "indica la biblioteca actualmente en uso, que ahora debe ser __myLib__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1158
+#: getting_started_in_kicad.adoc:1172
 msgid ""
 "Click on the 'Update current component in current library' icon image:images/"
 "icons/save_part_in_mem.png[save_part_in_mem_png] in the top toolbar. Save "
@@ -2888,7 +2888,7 @@ msgstr ""
 "barra de título de la ventana."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1162
+#: getting_started_in_kicad.adoc:1176
 msgid ""
 "You can now close the Component library editor window. You will return to "
 "the schematic editor window. Your new component will now be available to you "
@@ -2899,7 +2899,7 @@ msgstr ""
 "disponible en la biblioteca __myLib__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1167
+#: getting_started_in_kicad.adoc:1181
 msgid ""
 "You can make any library _file.lib_ file available to you by adding it to "
 "the library path. From __Eeschema__, go to *Preferences* -> *Library* and "
@@ -2913,13 +2913,13 @@ msgstr ""
 "biblioteca de componentes\"."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1169
+#: getting_started_in_kicad.adoc:1183
 #, no-wrap
 msgid "Export, import and modify library components"
 msgstr "Exportar, importar y modificar componentes de la biblioteca"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1175
+#: getting_started_in_kicad.adoc:1189
 msgid ""
 "Instead of creating a library component from scratch it is sometimes easier "
 "to start from one already made and modify it. In this section we will see "
@@ -2932,7 +2932,7 @@ msgstr ""
 "propia biblioteca _myOwnLib.lib_ y luego modificarlo."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1183
+#: getting_started_in_kicad.adoc:1197
 msgid ""
 "From KiCad, start __Eeschema__, click on the 'Library Editor' icon image:"
 "images/icons/libedit.png[libedit_png], click on the 'Select working library' "
@@ -2950,7 +2950,7 @@ msgstr ""
 "'RELAY_2RT'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1187
+#: getting_started_in_kicad.adoc:1201
 msgid ""
 "Click on the 'Export component' icon image:images/icons/export."
 "png[export_png], navigate into the _library/_ folder and save the new "
@@ -2961,7 +2961,7 @@ msgstr ""
 "archivo de biblioteca con el nombre _myOwnLib.lib._"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1193
+#: getting_started_in_kicad.adoc:1207
 msgid ""
 "You can make this component and the whole library _myOwnLib.lib_ available "
 "to you by adding it to the library path. From __Eeschema__, go to "
@@ -2975,7 +2975,7 @@ msgstr ""
 "bibliotecas de componentes'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1199
+#: getting_started_in_kicad.adoc:1213
 msgid ""
 "Click on the 'Select working library' icon image:images/icons/library."
 "png[library_png]. In the Select Library window click on _myOwnLib_ and click "
@@ -2988,7 +2988,7 @@ msgstr ""
 "ventana indica la biblioteca actualmente en uso, debe ser __myOwnLib__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1203
+#: getting_started_in_kicad.adoc:1217
 msgid ""
 "Click on the 'Load component to edit from the current lib' icon image:images/"
 "icons/import_cmp_from_lib.png[import_cmp_from_lib_png] and import the "
@@ -2999,7 +2999,7 @@ msgstr ""
 "e importe el componente 'RELAY_2RT'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1206
+#: getting_started_in_kicad.adoc:1220
 msgid ""
 "You can now modify the component as you like. Hover over the label "
 "'RELAY_2RT', press the e key and rename it 'MY_RELAY_2RT'."
@@ -3009,7 +3009,7 @@ msgstr ""
 "'MY_RELAY_2RT'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1213
+#: getting_started_in_kicad.adoc:1227
 msgid ""
 "Click on 'Update current component in current library' icon image:images/"
 "icons/save_part_in_mem.png[save_part_in_mem_png] in the top toolbar. Save "
@@ -3023,13 +3023,13 @@ msgstr ""
 "png[save_library_png] en la barra de herramientas superior."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1215
+#: getting_started_in_kicad.adoc:1229
 #, no-wrap
 msgid "Make schematic components with quicklib"
 msgstr "Hacer símbolos de componentes con quicklib"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1220
+#: getting_started_in_kicad.adoc:1234
 msgid ""
 "This section presents an alternative way of creating the schematic component "
 "for MYCONN3 (see <<myconn3,MYCONN3>> above) using the Internet tool "
@@ -3040,14 +3040,14 @@ msgstr ""
 "herramienta de Internet __quicklib__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1223
+#: getting_started_in_kicad.adoc:1237
 msgid ""
 "Head to the _quicklib_ web page: http://kicad.rohrbacher.net/quicklib.php"
 msgstr ""
 "Vaya a la página web de _quicklib_: http://kicad.rohrbacher.net/quicklib.php"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1226
+#: getting_started_in_kicad.adoc:1240
 msgid ""
 "Fill out the page with the following information: Component name: MYCONN3 "
 "Reference Prefix: J Pin Layout Style: SIL Pin Count, N: 3"
@@ -3056,7 +3056,7 @@ msgstr ""
 "Reference Prefix: J, Pin Layout Style: SIL, Pin Count, N: 3"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1230
+#: getting_started_in_kicad.adoc:1244
 msgid ""
 "Click on the 'Assign Pins' icon. Fill out the page with the following "
 "information: Pin 1: VCC Pin 2: input Pin 3: GND.  Type : Passive for all 3 "
@@ -3067,7 +3067,7 @@ msgstr ""
 "pines."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1234
+#: getting_started_in_kicad.adoc:1248
 msgid ""
 "Click on the icon 'Preview it' and, if you are satisfied, click on the "
 "'Build Library Component'. Download the file and rename it __tutorial1/"
@@ -3078,7 +3078,7 @@ msgstr ""
 "el nombre por __tutorial1/library/myQuickLib.lib.__. ¡Ya está listo!"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1240
+#: getting_started_in_kicad.adoc:1254
 msgid ""
 "Have a look at it using KiCad. From the KiCad project manager, start "
 "__Eeschema__, click on the 'Library Editor' icon image:images/icons/libedit."
@@ -3093,12 +3093,12 @@ msgstr ""
 "library/_ y seleccione _myQuickLib.lib._"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1242
+#: getting_started_in_kicad.adoc:1256
 msgid "image:images/gsik_myconn3_quicklib.png[gsik_myconn3_quicklib_png]"
 msgstr "image:images/gsik_myconn3_quicklib.png[gsik_myconn3_quicklib_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1248
+#: getting_started_in_kicad.adoc:1262
 msgid ""
 "You can make this component and the whole library _myQuickLib.lib_ available "
 "to you by adding it to the KiCad library path. From __Eeschema__, go to "
@@ -3112,7 +3112,7 @@ msgstr ""
 "biblioteca de componentes'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1252
+#: getting_started_in_kicad.adoc:1266
 msgid ""
 "As you might guess, this method of creating library components can be quite "
 "effective when you want to create components with a large pin count."
@@ -3122,13 +3122,13 @@ msgstr ""
 "pines."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1254
+#: getting_started_in_kicad.adoc:1268
 #, no-wrap
 msgid "Make a high pin count schematic component"
 msgstr "Realizar símbolos de componentes con gran número de pines"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1261
+#: getting_started_in_kicad.adoc:1275
 msgid ""
 "In the section titled _Make Schematic Components in quicklib_ we saw how to "
 "make a schematic component using the _quicklib_ web-based tool.  However, "
@@ -3143,7 +3143,7 @@ msgstr ""
 "KiCad, esto no es muy complicado."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1267
+#: getting_started_in_kicad.adoc:1281
 msgid ""
 "Suppose that you want to create a schematic component for a device with 50 "
 "pins. It is common practise to draw it using multiple low pin-count "
@@ -3156,7 +3156,7 @@ msgstr ""
 "fácil conexión de los pines."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1272
+#: getting_started_in_kicad.adoc:1286
 msgid ""
 "The best way to create our component is to use _quicklib_ to generate two 25-"
 "pin components separately, re-number their pins using a Python script and "
@@ -3170,7 +3170,7 @@ msgstr ""
 "estructura DEF y ENDDEF."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1278
+#: getting_started_in_kicad.adoc:1292
 msgid ""
 "You will find an example of a simple Python script below that can be used in "
 "conjunction with an _in.txt_ file and an _out.txt_ file to re-number the "
@@ -3184,13 +3184,13 @@ msgstr ""
 "el archivo __in.txt__."
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:1279
+#: getting_started_in_kicad.adoc:1293
 #, no-wrap
 msgid "Simple script"
 msgstr "Script"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1302
+#: getting_started_in_kicad.adoc:1316
 #, no-wrap
 msgid ""
 "#!/usr/bin/env python\n"
@@ -3236,7 +3236,7 @@ msgstr ""
 "# http://kicad.rohrbacher.net/quicklib.php\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1308
+#: getting_started_in_kicad.adoc:1322
 msgid ""
 "While merging the two components into one, it is necessary to use the "
 "Library Editor from Eeschema to move the first component so that the second "
@@ -3249,13 +3249,13 @@ msgstr ""
 "archivo .lib final y su representación en __Eeschema__."
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:1309
+#: getting_started_in_kicad.adoc:1323
 #, no-wrap
 msgid "Contents of a *.lib file"
 msgstr "Contenido del fichero *.lib"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1321
+#: getting_started_in_kicad.adoc:1335
 #, no-wrap
 msgid ""
 "EESchema-LIBRARY Version 2.3\n"
@@ -3281,13 +3281,13 @@ msgstr ""
 "X PIN1 1 -2550 600 300 R 50 50 1 1 I\n"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1323
+#: getting_started_in_kicad.adoc:1337
 #, no-wrap
 msgid "...\n"
 msgstr "...\n"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1328
+#: getting_started_in_kicad.adoc:1342
 #, no-wrap
 msgid ""
 "X PIN49 49 750 -500 300 L 50 50 1 1 I\n"
@@ -3301,12 +3301,12 @@ msgstr ""
 "#End Library\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1331
+#: getting_started_in_kicad.adoc:1345
 msgid "image:images/gsik_high_number_pins.png[gsik_high_number_pins_png]"
 msgstr "image:images/gsik_high_number_pins.png[gsik_high_number_pins_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1336
+#: getting_started_in_kicad.adoc:1350
 msgid ""
 "The Python script presented here is a very powerful tool for manipulating "
 "both pin numbers and pin labels. Mind, however, that all its power comes for "
@@ -3319,13 +3319,13 @@ msgstr ""
 "embargo increíblemente útil: _http: //gskinner.com/RegExr/._"
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1338
+#: getting_started_in_kicad.adoc:1352
 #, no-wrap
 msgid "Make component footprints"
 msgstr "Realizar huellas de componentes"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1344
+#: getting_started_in_kicad.adoc:1358
 msgid ""
 "Unlike other EDA software tools, which have one type of library that "
 "contains both the schematic symbol and the footprint variations, KiCad _."
@@ -3339,7 +3339,7 @@ msgstr ""
 "a los símbolos."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1347
+#: getting_started_in_kicad.adoc:1361
 msgid ""
 "As for _.lib_ files, _.kicad_mod_ library files are text files that can "
 "contain anything from one to several parts."
@@ -3349,7 +3349,7 @@ msgstr ""
 "varias partes."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1351
+#: getting_started_in_kicad.adoc:1365
 msgid ""
 "There is an extensive footprint library with KiCad, however on occasion you "
 "might find that the footprint you need is not in the KiCad library.  Here "
@@ -3360,13 +3360,13 @@ msgstr ""
 "Estos son los pasos para crear una nueva huella para PCB en KiCad:"
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1353
+#: getting_started_in_kicad.adoc:1367
 #, no-wrap
 msgid "Using Footprint Editor"
 msgstr "Usando el editor de huellas"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1359
+#: getting_started_in_kicad.adoc:1373
 msgid ""
 "From the KiCad project manager start the _Pcbnew_ tool. Click on the 'Open "
 "Footprint Editor' icon image:images/icons/edit_module.png[edit_module_png] "
@@ -3378,7 +3378,7 @@ msgstr ""
 "'Editor de Huellas'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1371
+#: getting_started_in_kicad.adoc:1385
 msgid ""
 "We are going to save the new footprint 'MYCONN3' in the new footprint "
 "library 'myfootprint'.  Create a new folder _myfootprint.pretty_ in the "
@@ -3401,7 +3401,7 @@ msgstr ""
 "herramientas superior. Seleccione la biblioteca 'myfootprint'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1380
+#: getting_started_in_kicad.adoc:1394
 msgid ""
 "Click on the 'New Footprint' icon image:images/icons/new_footprint."
 "png[new_footprint_png] on the top toolbar.  Type 'MYCONN3' as the 'footprint "
@@ -3419,7 +3419,7 @@ msgstr ""
 "por 'SMD'. Establezca el valor de 'Display' a 'invisible'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1385
+#: getting_started_in_kicad.adoc:1399
 msgid ""
 "Select the 'Add Pads' icon image:images/icons/pad.png[pad_png] on the right "
 "toolbar. Click on the working sheet to place the pad. Right click on the new "
@@ -3431,12 +3431,12 @@ msgstr ""
 "Pad'. De lo contrario, puede utilizar la tecla de acceso directo e."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1387
+#: getting_started_in_kicad.adoc:1401
 msgid "image:images/pad_properties.png[Pad Properties]"
 msgstr "image:images/pad_properties.png[Pad Properties]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1391
+#: getting_started_in_kicad.adoc:1405
 msgid ""
 "Set the 'Pad Num' to '1', 'Pad Shape' to 'Rect', 'Pad Type' to 'SMD', 'Shape "
 "Size X' to '0.4', and 'Shape Size Y' to '0.8'. Click OK.  Click on 'Add "
@@ -3447,7 +3447,7 @@ msgstr ""
 "clic de nuevo en 'Añadir Pads' y coloque dos pads más."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1395
+#: getting_started_in_kicad.adoc:1409
 msgid ""
 "If you want to change the grid size, *Right click* -> **Grid Select**. Be "
 "sure to select the appropriate grid size before laying down the components."
@@ -3457,7 +3457,7 @@ msgstr ""
 "de que se situar los componentes."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1398
+#: getting_started_in_kicad.adoc:1412
 msgid ""
 "Move the 'MYCONN3' label and the 'SMD' label out of the way so that it looks "
 "like the image shown above."
@@ -3466,7 +3466,7 @@ msgstr ""
 "se mostrada arriba."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1405
+#: getting_started_in_kicad.adoc:1419
 msgid ""
 "When placing pads it is often necessary to measure relative distances. Place "
 "the cursor where you want the relative coordinate point _(0,0)_ to be and "
@@ -3482,7 +3482,7 @@ msgstr ""
 "nuevo origen."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1410
+#: getting_started_in_kicad.adoc:1424
 msgid ""
 "Now add a footprint contour. Click on the 'Add graphic line or polygon' "
 "button image:images/icons/add_polygon.png[add_polygon_png] in the right "
@@ -3494,7 +3494,7 @@ msgstr ""
 "del componente."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1414
+#: getting_started_in_kicad.adoc:1428
 msgid ""
 "Click on the 'Save Footprint in Active Library' icon image:images/icons/"
 "save_library.png[save_library_png] on the top toolbar, using the default "
@@ -3505,13 +3505,13 @@ msgstr ""
 "superior, utilizando el nombre predeterminado MYCONN3."
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1416
+#: getting_started_in_kicad.adoc:1430
 #, no-wrap
 msgid "Note about portability of KiCad project files"
 msgstr "Notas sobre portabilidad de los proyectos en KiCad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1420
+#: getting_started_in_kicad.adoc:1434
 msgid ""
 "What files do you need to send to someone so that they can fully load and "
 "use your KiCad project?"
@@ -3520,7 +3520,7 @@ msgstr ""
 "utilizar su proyecto en KiCad?"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1427
+#: getting_started_in_kicad.adoc:1441
 msgid ""
 "When you have a KiCad project to share with somebody, it is important that "
 "the schematic file __.sch__, the board file __.kicad_pcb__, the project file "
@@ -3537,7 +3537,7 @@ msgstr ""
 "total libertad para modificar el esquema y la placa."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1439
+#: getting_started_in_kicad.adoc:1453
 msgid ""
 "With KiCad schematics, people need the _.lib_ files that contain the "
 "symbols. Those library files need to be loaded in the _Eeschema_ "
@@ -3563,7 +3563,7 @@ msgstr ""
 "para que esas huellas aparezcan en __Cvpcb__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1447
+#: getting_started_in_kicad.adoc:1461
 msgid ""
 "If someone sends you a _.kicad_pcb_ file with footprints you would like to "
 "use in another board, you can open the Footprint Editor, load a footprint "
@@ -3582,7 +3582,7 @@ msgstr ""
 "kicad_mod_ con todas las huellas de la placa."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1453
+#: getting_started_in_kicad.adoc:1467
 msgid ""
 "Bottom line, if the PCB is the only thing you want to distribute, then the "
 "board file _.kicad_pcb_ is enough. However, if you want to give people the "
@@ -3597,7 +3597,7 @@ msgstr ""
 "siguiente directorio del proyecto:"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1471
+#: getting_started_in_kicad.adoc:1485
 #, no-wrap
 msgid ""
 "tutorial1/\n"
@@ -3635,13 +3635,13 @@ msgstr ""
 "    \\-- ...\n"
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1474
+#: getting_started_in_kicad.adoc:1488
 #, no-wrap
 msgid "More about KiCad documentation"
 msgstr "Mas sobre la documentación de KiCad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1479
+#: getting_started_in_kicad.adoc:1493
 msgid ""
 "This has been a quick guide on most of the features in KiCad. For more "
 "detailed instructions consult the help files which you can access through "
@@ -3653,7 +3653,7 @@ msgstr ""
 "**Manual**."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1482
+#: getting_started_in_kicad.adoc:1496
 msgid ""
 "KiCad comes with a pretty good set of multi-language manuals for all its "
 "four software components."
@@ -3662,13 +3662,13 @@ msgstr ""
 "cuatro componentes de software."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1484
+#: getting_started_in_kicad.adoc:1498
 msgid "The English version of all KiCad manuals are distributed with KiCad."
 msgstr ""
 "La versión en Inglés de todos los manuales KiCad se distribuyen con KiCad."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1490
+#: getting_started_in_kicad.adoc:1504
 msgid ""
 "In addition to its manuals, KiCad is distributed with this tutorial, which "
 "has been translated into other languages. All the different versions of this "
@@ -3683,7 +3683,7 @@ msgstr ""
 "KiCad en su plataforma determinada."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1493
+#: getting_started_in_kicad.adoc:1507
 msgid ""
 "For example, on Linux the typical locations are in the following "
 "directories, depending on your exact distribution:"
@@ -3692,7 +3692,7 @@ msgstr ""
 "directorios, dependiendo de su distribución exacta:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1496
+#: getting_started_in_kicad.adoc:1510
 #, no-wrap
 msgid ""
 " /usr/share/doc/kicad/help/en/\n"
@@ -3702,35 +3702,35 @@ msgstr ""
 " /usr/local/share/doc/kicad/help/en\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1498
+#: getting_started_in_kicad.adoc:1512
 msgid "On Windows it is in:"
 msgstr "En Windows se encuentran en:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1500
+#: getting_started_in_kicad.adoc:1514
 #, no-wrap
 msgid " <installation directory>/share/doc/kicad/help/en\n"
 msgstr " <directorio de instalación>/share/doc/kicad/help/en\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1502
+#: getting_started_in_kicad.adoc:1516
 msgid "On OS X:"
 msgstr "En OS X:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1504
+#: getting_started_in_kicad.adoc:1518
 #, no-wrap
 msgid " /Library/Application Support/kicad/help/en\n"
 msgstr " /Library/Application Support/kicad/help/en\n"
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1506
+#: getting_started_in_kicad.adoc:1520
 #, no-wrap
 msgid "KiCad documentation on the Web"
 msgstr "Documentación de KiCad en la Web"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1509
+#: getting_started_in_kicad.adoc:1523
 msgid ""
 "Latest KiCad documentations are available in multiple languages on the Web."
 msgstr ""
@@ -3738,7 +3738,7 @@ msgstr ""
 "idiomas en la Web."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1511
+#: getting_started_in_kicad.adoc:1525
 msgid "http://kicad-pcb.org/help/documentation/"
 msgstr "http://kicad-pcb.org/help/documentation/"
 

--- a/src/getting_started_in_kicad/po/fr.po
+++ b/src/getting_started_in_kicad/po/fr.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-01-06 23:55+0100\n"
+"POT-Creation-Date: 2016-01-07 20:18+0100\n"
 "PO-Revision-Date: 2015-12-05 07:06+0100\n"
 "Last-Translator: Marc BERLIOUX\n"
 "Language-Team: French <kde-i18n-doc@kde.org>\n"
@@ -738,7 +738,7 @@ msgstr ""
 "déplacer horizontalement ou verticalement."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:304
+#: getting_started_in_kicad.adoc:306
 #, fuzzy
 #| msgid ""
 #| "Hover the mouse over the component 'R' and press the r key. Notice how "
@@ -752,7 +752,7 @@ msgstr ""
 "clavier. Constatez la rotation du composant."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:306
+#: getting_started_in_kicad.adoc:312
 msgid ""
 "If your mouse was also over the _Field Reference_ ('R') or the _Field Value_ "
 "('R?'), a menu will appear. You will see these 'Clarify Selection' menu "
@@ -762,7 +762,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:312
+#: getting_started_in_kicad.adoc:318
 msgid ""
 "Right click in the middle of the component and select *Edit Component* -> "
 "**Value**. You can achieve the same result by hovering over the component "
@@ -776,12 +776,12 @@ msgstr ""
 "suivant avec pour chaque action son raccourci clavier."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:314
+#: getting_started_in_kicad.adoc:320
 msgid "image:images/edit_component_dropdown.png[Edit component menu]"
 msgstr "image:images/edit_component_dropdown.png[Edit component menu]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:317
+#: getting_started_in_kicad.adoc:323
 msgid ""
 "The Component value window will appear. Replace the current value 'R' with "
 "'1k'. Click OK."
@@ -790,7 +790,7 @@ msgstr ""
 "de R par 1k."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:320
+#: getting_started_in_kicad.adoc:326
 msgid ""
 "Do not change the Reference field (R?), this will be done automatically "
 "later on. The value inside the resistor should now be '1k'."
@@ -799,12 +799,12 @@ msgstr ""
 "valeur de la résistance devrait maintenant être '1k'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:322
+#: getting_started_in_kicad.adoc:328
 msgid "image:images/resistor_value.png[Resistor Value]"
 msgstr "image:images/resistor_value.png[Resistor Value]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:325
+#: getting_started_in_kicad.adoc:331
 msgid ""
 "To place another resistor, simply click where you want the resistor to "
 "appear. The Component Selection window will appear again."
@@ -813,7 +813,7 @@ msgstr ""
 "voir apparaître. La fenêtre 'Sélection Composant' apparaîtra à nouveau."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:328
+#: getting_started_in_kicad.adoc:334
 msgid ""
 "The resistor you previously chose is now in your history list, appearing as "
 "'R'. Click OK and place the component."
@@ -822,12 +822,12 @@ msgstr ""
 "liste 'Historique'. Cliquez sur 'R' puis sur OK et placez le composant. "
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:330
+#: getting_started_in_kicad.adoc:336
 msgid "image:images/component_history.png[Component history]"
 msgstr "image:images/component_history.png[Component history]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:335
+#: getting_started_in_kicad.adoc:341
 msgid ""
 "In case you make a mistake and want to delete a component, right click on "
 "the component and click 'Delete Component'. This will remove the component "
@@ -839,7 +839,7 @@ msgstr ""
 "appuyez sur la touche 'suppr'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:339
+#: getting_started_in_kicad.adoc:345
 msgid ""
 "You can edit any default shortcut key by going to *Preferences* -> *Hotkeys* "
 "-> **Edit hotkeys**. Any modification will be saved immediately."
@@ -849,7 +849,7 @@ msgstr ""
 "sauvegardées immédiatement."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:343
+#: getting_started_in_kicad.adoc:349
 msgid ""
 "You can also duplicate a component already on your schematic sheet by "
 "hovering over it and pressing the c key. Click where you want to place the "
@@ -862,7 +862,7 @@ msgstr ""
 "composant sur la feuille."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:349
+#: getting_started_in_kicad.adoc:355
 msgid ""
 "Right click on the second resistor. Select 'Drag Component'.  Reposition the "
 "component and left click to drop. The same functionality can be achieved by "
@@ -876,7 +876,7 @@ msgstr ""
 "'x' et 'y' servent à faire une symétrie."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:354
+#: getting_started_in_kicad.adoc:360
 #, no-wrap
 msgid ""
 "*Right-Click* -> *Move component* (equivalent to the m key\n"
@@ -886,7 +886,7 @@ msgid ""
 msgstr "*Clic Droit* -> *Déplacer Composant* (équivalent à la touche 'm') est une autre option pour déplacer les éléments, mais il vaut mieux ne s'en servir que pour les labels et les composants non connectés. Nous verrons plus tard pourquoi.\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:358
+#: getting_started_in_kicad.adoc:364
 msgid ""
 "Edit the second resistor by hovering over it and pressing the v key.  "
 "Replace 'R' with '100'. You can undo any of your editing actions with the "
@@ -897,7 +897,7 @@ msgstr ""
 "actions avec CTRL+Z."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:364
+#: getting_started_in_kicad.adoc:370
 msgid ""
 "Change the grid size. You have probably noticed that on the schematic sheet "
 "all components are snapped onto a large pitch grid. You can easily change "
@@ -911,7 +911,7 @@ msgstr ""
 "mils pour les schémas.__"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:366
+#: getting_started_in_kicad.adoc:374
 msgid ""
 "We are going to add a component from a library that isn't configured in the "
 "default project. In the menu, choose *Preferences* -> **Component "
@@ -919,7 +919,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:368
+#: getting_started_in_kicad.adoc:380
 msgid ""
 "You need to find where the official KiCad libraries are installed on your "
 "computer. Look for a `library` directory containing a hundred of `.dcm` and "
@@ -929,7 +929,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:372
+#: getting_started_in_kicad.adoc:384
 #, fuzzy
 #| msgid ""
 #| "Repeat the add-component steps, this time choosing the 'device' library "
@@ -943,7 +943,7 @@ msgstr ""
 "librairie 'device'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:377
+#: getting_started_in_kicad.adoc:389
 msgid ""
 "Hover the mouse over the microcontroller component. Press the y key or the x "
 "key on the keyboard. Notice how the component is flipped over its x axis or "
@@ -954,7 +954,7 @@ msgstr ""
 "Appuyez sur la même touche pour rétablir l'orientation d'origine."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:380
+#: getting_started_in_kicad.adoc:392
 msgid ""
 "Repeat the add-component steps, this time choosing the 'device' library and "
 "picking the 'LED' component from it."
@@ -963,17 +963,17 @@ msgstr ""
 "librairie 'device'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:382
+#: getting_started_in_kicad.adoc:394
 msgid "Organise all components on your schematic sheet as shown below."
 msgstr "Placez tous les composants de votre feuille comme ci-dessous."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:384
+#: getting_started_in_kicad.adoc:396
 msgid "image:images/gsik_tutorial1_010.png[gsik_tutorial1_010_png]"
 msgstr "image:images/gsik_tutorial1_010.png[gsik_tutorial1_010_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:390
+#: getting_started_in_kicad.adoc:402
 msgid ""
 "We now need to create the schematic component 'MYCONN3' for our 3-pin "
 "connector. You can jump to the section titled <<make-schematic-components-in-"
@@ -988,7 +988,7 @@ msgstr ""
 "carte."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:393
+#: getting_started_in_kicad.adoc:405
 msgid ""
 "You can now place the freshly made component. Press the 'a' key and pick the "
 "'MYCONN3' component in the 'myLib' library."
@@ -997,7 +997,7 @@ msgstr ""
 "et prenez le composant 'MYCONN3' dans la librairie 'myLib' ."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:399
+#: getting_started_in_kicad.adoc:411
 msgid ""
 "The component identifier 'J?' will appear under the 'MYCONN3' label.  If you "
 "want to change its position, right click on 'J?' and click on 'Move "
@@ -1012,12 +1012,12 @@ msgstr ""
 "suivante. Les labels peuvent être déplacés autant de fois que nécessaire."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:401
+#: getting_started_in_kicad.adoc:413
 msgid "image:images/gsik_myconn3_s.png[gsik_myconn3_s_png]"
 msgstr "image:images/gsik_myconn3_s.png[gsik_myconn3_s_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:407
+#: getting_started_in_kicad.adoc:419
 msgid ""
 "It is time to place the power and ground symbols. Click on the 'Place a "
 "power port' button image:images/icons/add_power.png[add_power_png] on the "
@@ -1031,7 +1031,7 @@ msgstr ""
 "partir de la librairie 'power'. Valider."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:413
+#: getting_started_in_kicad.adoc:425
 msgid ""
 "Click above the pin of the 1k resistor to place the VCC part. Click on the "
 "area above the microcontroller 'VDD'. In the 'Component Selection history' "
@@ -1044,7 +1044,7 @@ msgstr ""
 "répertoire 'historique' dans la fenêtre 'Sélection Composant'. "
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:418
+#: getting_started_in_kicad.adoc:430
 msgid ""
 "Repeat the add-pin steps but this time select the GND part. Place a GND part "
 "under the GND pin of 'MYCONN3'. Place another GND symbol on the right of the "
@@ -1056,12 +1056,12 @@ msgstr ""
 "schéma devrait se présenter ainsi :"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:420
+#: getting_started_in_kicad.adoc:432
 msgid "image:images/gsik_tutorial1_020.png[gsik_tutorial1_020_png]"
 msgstr "image:images/gsik_tutorial1_020.png[gsik_tutorial1_020_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:424
+#: getting_started_in_kicad.adoc:436
 msgid ""
 "Next, we will wire all our components. Click on the 'Place wire' icon image:"
 "images/icons/add_line.png[Place wire] on the right toolbar."
@@ -1071,7 +1071,7 @@ msgstr ""
 "droite."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:429
+#: getting_started_in_kicad.adoc:441
 msgid ""
 "Be careful not to pick 'Place a bus', which appears directly beneath this "
 "button but has thicker lines. The section <<bus-connections-in-kicad,Bus "
@@ -1082,7 +1082,7 @@ msgstr ""
 "section <<bus-connections-in-kicad,Connexions par bus avec KiCad>>."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:433
+#: getting_started_in_kicad.adoc:445
 msgid ""
 "Click on the little circle at the end of pin 7 of the microcontroller and "
 "then click on the little circle on pin 2 of the LED.  You can zoom in while "
@@ -1093,7 +1093,7 @@ msgstr ""
 "pas à zoomer pendant cette opération."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:438
+#: getting_started_in_kicad.adoc:450
 msgid ""
 "If you want to reposition wired components, it is important to use the g key "
 "(grab) option and not the m key (move) option. Using the grab option will "
@@ -1106,12 +1106,12 @@ msgstr ""
 "avez oublié comment déplacer un composant."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:440
+#: getting_started_in_kicad.adoc:452
 msgid "image:images/gsik_tutorial1_030.png[gsik_tutorial1_030_png]"
 msgstr "image:images/gsik_tutorial1_030.png[gsik_tutorial1_030_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:446
+#: getting_started_in_kicad.adoc:458
 msgid ""
 "Repeat this process and wire up all the other components as shown below. To "
 "terminate a wire just double-click. When wiring up the VCC and GND symbols, "
@@ -1124,12 +1124,12 @@ msgstr ""
 "milieu du symbole GND. Voir l'image ci-dessous."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:448
+#: getting_started_in_kicad.adoc:460
 msgid "image:images/gsik_tutorial1_040.png[gsik_tutorial1_040_png]"
 msgstr "image:images/gsik_tutorial1_040.png[gsik_tutorial1_040_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:453
+#: getting_started_in_kicad.adoc:465
 msgid ""
 "We will now consider an alternative way of making a connection using labels. "
 "Pick a net labelling tool by clicking on the 'Place net name' icon image:"
@@ -1142,7 +1142,7 @@ msgstr ""
 "barre d'outils de droite. Raccourci clavier : touche l."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:456
+#: getting_started_in_kicad.adoc:468
 msgid ""
 "Click in the middle of the wire connected to pin 6 of the microcontroller. "
 "Name this label 'INPUT'."
@@ -1151,7 +1151,7 @@ msgstr ""
 "label 'INPUT'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:465
+#: getting_started_in_kicad.adoc:477
 msgid ""
 "Follow the same procedure and place another label on line on the right of "
 "the 100 ohm resistor. Also name it 'INPUT'. The two labels, having the same "
@@ -1170,7 +1170,7 @@ msgstr ""
 "label. Vous pouvez attacher un label à une broche."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:471
+#: getting_started_in_kicad.adoc:483
 msgid ""
 "Labels can also be used to simply label wires for informative purposes. "
 "Place a label on pin 7 of the PIC. Enter the name 'uCtoLED'.  Name the wire "
@@ -1183,7 +1183,7 @@ msgstr ""
 "'MYCONN3' et le resistor 'INPUTtoR'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:474
+#: getting_started_in_kicad.adoc:486
 msgid ""
 "You do not have to label the VCC and GND lines because the labels are "
 "implied from the power objects they are connected to."
@@ -1192,17 +1192,17 @@ msgstr ""
 "les fils connectés aux symboles d'alimentations sont reliés automatiquement."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:476
+#: getting_started_in_kicad.adoc:488
 msgid "Below you can see what the final result should look like."
 msgstr "Votre schéma devrait maintenant ressembler à celui ci-dessous."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:478
+#: getting_started_in_kicad.adoc:490
 msgid "image:images/gsik_tutorial1_050.png[gsik_tutorial1_050_png]"
 msgstr "image:images/gsik_tutorial1_050.png[gsik_tutorial1_050_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:484
+#: getting_started_in_kicad.adoc:496
 msgid ""
 "Let's now deal with unconnected wires. Any pin or wire that is not connected "
 "will generate a warning when checked by KiCad. To avoid these warnings you "
@@ -1216,7 +1216,7 @@ msgstr ""
 "manuellement chaque absence de connexion."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:489
+#: getting_started_in_kicad.adoc:501
 msgid ""
 "Click on the 'Place no connect flag' icon image:images/icons/noconn."
 "png[noconn_png] on the right toolbar. Click on pins 2, 3, 4 and 5. An X will "
@@ -1228,12 +1228,12 @@ msgstr ""
 "connexion est intentionnelle."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:491
+#: getting_started_in_kicad.adoc:503
 msgid "image:images/gsik_tutorial1_060.png[gsik_tutorial1_060_png]"
 msgstr "image:images/gsik_tutorial1_060.png[gsik_tutorial1_060_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:498
+#: getting_started_in_kicad.adoc:510
 msgid ""
 "Some components have power pins that are invisible. You can make them "
 "visible by clicking on the 'Show hidden pins' icon image:images/icons/"
@@ -1249,7 +1249,7 @@ msgstr ""
 "évitez de créer des broches d'alimentation cachées."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:504
+#: getting_started_in_kicad.adoc:516
 msgid ""
 "It is now necessary to add a 'Power Flag' to indicate to KiCad that power "
 "comes in from somewhere. Press the a key, select 'List All', double click on "
@@ -1263,12 +1263,12 @@ msgstr ""
 "indiqué ci-dessous."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:506
+#: getting_started_in_kicad.adoc:518
 msgid "image:images/gsik_tutorial1_070.png[gsik_tutorial1_070_png]"
 msgstr "image:images/gsik_tutorial1_070.png[gsik_tutorial1_070_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:509
+#: getting_started_in_kicad.adoc:521
 msgid ""
 "This will avoid the classic schematic checking warning: Warning Pin power_in "
 "not driven (Net xx)"
@@ -1277,7 +1277,7 @@ msgstr ""
 "schéma : Warning Pin power_in not driven (Net xx)"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:513
+#: getting_started_in_kicad.adoc:525
 msgid ""
 "Sometimes it is good to write comments here and there. To add comments on "
 "the schematic use the 'Place graphic text (comment)' icon image:images/icons/"
@@ -1288,7 +1288,7 @@ msgstr ""
 "d'outils de droite."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:518
+#: getting_started_in_kicad.adoc:531
 #, fuzzy
 #| msgid ""
 #| "All components now need to have unique identifiers. In fact, many of our "
@@ -1308,7 +1308,7 @@ msgstr ""
 "d'outils du haut."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:525
+#: getting_started_in_kicad.adoc:538
 msgid ""
 "In the Annotate Schematic window, select 'Use the entire schematic' and "
 "click on the 'Annotation' button. Click OK in the confirmation message and "
@@ -1323,7 +1323,7 @@ msgstr ""
 "notre exemple, ils ont été renommés 'R1', 'R2', 'U1', 'D1' et 'J1'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:535
+#: getting_started_in_kicad.adoc:547
 #, fuzzy
 #| msgid ""
 #| "We will now check our schematic for errors. Click on the 'Perform "
@@ -1354,7 +1354,7 @@ msgstr ""
 "nouveau sur 'Exécuter' pour obtenir un rapport plus détaillé."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:537
+#: getting_started_in_kicad.adoc:551
 msgid ""
 "If you have a warning with \"No default editor found you must choose it\", "
 "try setting the path to `c:\\windows\\notepad.exe` (windows) or `/usr/bin/"
@@ -1362,7 +1362,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:542
+#: getting_started_in_kicad.adoc:556
 #, fuzzy
 #| msgid ""
 #| "The schematic is now finished. We can now create a Netlist file to which "
@@ -1383,7 +1383,7 @@ msgstr ""
 "le nom proposé."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:547
+#: getting_started_in_kicad.adoc:561
 msgid ""
 "After generating the Netlist file, click on the 'Run Cvpcb' icon image:"
 "images/icons/cvpcb.png[cvpcb_png] on the top toolbar. If a missing file "
@@ -1395,7 +1395,7 @@ msgstr ""
 "cliquant sur OK."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:553
+#: getting_started_in_kicad.adoc:567
 msgid ""
 "_Cvpcb_ allows you to link all the components in your schematic with "
 "footprints in the KiCad library. The pane on the center shows all the "
@@ -1410,14 +1410,14 @@ msgstr ""
 "Sélectionnez  'LEDs:LED-5MM' par un double-clic."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:555
+#: getting_started_in_kicad.adoc:569
 #, fuzzy
 #| msgid "image:images/cvpcb.png[cvpcb_png]"
 msgid "image:images/icons/cvpcb.png[cvpcb_png]"
 msgstr "image:images/cvpcb.png[cvpcb_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:563
+#: getting_started_in_kicad.adoc:577
 msgid ""
 "It is possible that the pane on the right shows only a selected subgroup of "
 "available footprints. This is because KiCad is trying to suggest to you a "
@@ -1436,7 +1436,7 @@ msgstr ""
 "png[module_library_list_png]."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:567
+#: getting_started_in_kicad.adoc:581
 msgid ""
 "For 'IC1' select the 'Housings_DIP:DIP-8_W7.62mm' footprint.  For 'J1' "
 "select the 'Connect:Banana_Jack_3Pin' footprint.  For 'R1' and 'R2' select "
@@ -1447,7 +1447,7 @@ msgstr ""
 "l'empreinte 'Discret:R1'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:578
+#: getting_started_in_kicad.adoc:592
 msgid ""
 "If you are interested in knowing what the footprint you are choosing looks "
 "like, you have two options. You can click on the 'View selected footprint' "
@@ -1468,7 +1468,7 @@ msgstr ""
 "dimensions correspondent avec celles de votre composant."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:587
+#: getting_started_in_kicad.adoc:601
 msgid ""
 "You are done. You can now update your netlist file with all the associated "
 "footprints. Click on *File* -> **Save As**. The default name 'tutorial1.net' "
@@ -1487,7 +1487,7 @@ msgstr ""
 "loin dans ce document."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:591
+#: getting_started_in_kicad.adoc:605
 msgid ""
 "You can close _Cvpcb_ and go back to the _Eeschema_ schematic editor. Save "
 "the project by clicking on *File* -> **Save Whole Schematic Project**. Close "
@@ -1498,12 +1498,12 @@ msgstr ""
 "projet schématique**. Fermez l'éditeur de schématique."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:593
+#: getting_started_in_kicad.adoc:607
 msgid "Switch to the KiCad project manager."
 msgstr "Basculez vers le manager de projet KiCad."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:597
+#: getting_started_in_kicad.adoc:611
 msgid ""
 "The netlist file describes all components and their respective pin "
 "connections. The netlist file is actually a text file that you can easily "
@@ -1514,7 +1514,7 @@ msgstr ""
 "éditer."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:600
+#: getting_started_in_kicad.adoc:614
 msgid ""
 "Library files (__*.lib__) are text files too and they are also easily "
 "editable or scriptable."
@@ -1523,7 +1523,7 @@ msgstr ""
 "facilement éditables."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:607
+#: getting_started_in_kicad.adoc:621
 msgid ""
 "To create a Bill Of Materials (BOM), go to the _Eeschema_ schematic editor "
 "and click on the 'Bill of materials' icon image:images/icons/bom."
@@ -1539,7 +1539,7 @@ msgstr ""
 "souhaitez utiliser. Dans cet exercice, nous choisissons __bom2csv.xsl__. "
 
 #. type: delimited block =
-#: getting_started_in_kicad.adoc:612
+#: getting_started_in_kicad.adoc:626
 msgid ""
 "The *.xsl file is located in __plugins__ directory of the KiCad "
 "installation, which is located at: /usr/lib/kicad/plugins/."
@@ -1548,47 +1548,47 @@ msgstr ""
 "__plugins__ qui se trouve à l'emplacement : /usr/lib/kicad/plugins/."
 
 #. type: delimited block =
-#: getting_started_in_kicad.adoc:614
+#: getting_started_in_kicad.adoc:628
 msgid "Or get the file via:"
 msgstr "Obtenez également ce fichier en allant à :"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:616
+#: getting_started_in_kicad.adoc:630
 #, no-wrap
 msgid "wget https://raw.githubusercontent.com/KiCad/kicad-source-mirror/master/eeschema/plugins/bom2csv.xsl\n"
 msgstr "wget https://raw.githubusercontent.com/KiCad/kicad-source-mirror/master/eeschema/plugins/bom2csv.xsl\n"
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:619
+#: getting_started_in_kicad.adoc:633
 #, no-wrap
 msgid "KiCad automatically generates the command, for example:"
 msgstr "KiCad génère automatiquement les commandes. Par exemple :"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:622
+#: getting_started_in_kicad.adoc:636
 #, no-wrap
 msgid "xsltproc -o \"%O\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 msgstr "xsltproc -o \"%O\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:624
+#: getting_started_in_kicad.adoc:638
 #, no-wrap
 msgid "You may want to add the extension, so change this command line to:"
 msgstr "Si vous souhaitez ajouter l'extension, remplacer la commande par :"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:627
+#: getting_started_in_kicad.adoc:641
 #, no-wrap
 msgid "xsltproc -o \"%O.csv\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 msgstr "xsltproc -o \"%O.csv\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:630
+#: getting_started_in_kicad.adoc:644
 msgid "Press Help button for more info."
 msgstr "Appuyer sur la touche d'aide pour avoir plus d'informations."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:634
+#: getting_started_in_kicad.adoc:648
 msgid ""
 "Now press 'Generate'. The file (same name as your project) is located in "
 "your project folder.  Open the **.csv* file with LibreOffice Calc or Excel. "
@@ -1599,7 +1599,7 @@ msgstr ""
 "LibreOffice Calc ou Excel. Une fenêtre d'import apparaît, appuyez sur OK."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:638
+#: getting_started_in_kicad.adoc:652
 msgid ""
 "You are now ready to move to the PCB layout part, which is presented in the "
 "next section. However, before moving on let's take a quick look at how to "
@@ -1610,13 +1610,13 @@ msgstr ""
 "broches en utilisant un bus."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:640
+#: getting_started_in_kicad.adoc:654
 #, no-wrap
 msgid "Bus connections in KiCad"
 msgstr "Connexions par bus avec KiCad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:646
+#: getting_started_in_kicad.adoc:660
 msgid ""
 "Sometimes you might need to connect several sequential pins of component A "
 "with some other sequential pins of component B. In this case you have two "
@@ -1629,7 +1629,7 @@ msgstr ""
 "utiliser des connexions de type bus. Voyons comment faire."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:653
+#: getting_started_in_kicad.adoc:667
 msgid ""
 "Let us suppose that you have three 4-pin connectors that you want to connect "
 "together pin to pin. Use the label option (press the l key) to label pin 4 "
@@ -1645,7 +1645,7 @@ msgstr ""
 "'a2'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:657
+#: getting_started_in_kicad.adoc:671
 msgid ""
 "Press the Ins Key two more times. The Ins key corresponds to the action "
 "'Repeat last item' and it is an infinitely useful command that can make your "
@@ -1656,7 +1656,7 @@ msgstr ""
 "rendra la vie bien plus facile."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:668
+#: getting_started_in_kicad.adoc:682
 msgid ""
 "Repeat the same labelling action on the two other connectors CONN_2 and "
 "CONN_3 and you are done. If you proceed and make a PCB you will see that the "
@@ -1678,7 +1678,7 @@ msgstr ""
 "n'aura pas d'impact sur le circuit-imprimé."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:672
+#: getting_started_in_kicad.adoc:686
 msgid ""
 "It should be pointed out that the short wire attached to the pins in Figure "
 "2 is not strictly necessary. In fact, the labels could have been applied "
@@ -1689,7 +1689,7 @@ msgstr ""
 "directement sur les broches."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:679
+#: getting_started_in_kicad.adoc:693
 msgid ""
 "Let's take it one step further and suppose that you have a fourth connector "
 "named CONN_4 and, for whatever reason, its labelling happens to be a little "
@@ -1706,7 +1706,7 @@ msgstr ""
 "par bus."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:686
+#: getting_started_in_kicad.adoc:700
 msgid ""
 "Connect and label CONN_4 using the labelling method explained before. Name "
 "the pins b1, b2, b3 and b4. Connect the pin to a series of 'Wire to bus "
@@ -1721,7 +1721,7 @@ msgstr ""
 "icons/add_bus.png[add_bus_png]. Voir Figure 4."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:689
+#: getting_started_in_kicad.adoc:703
 msgid ""
 "Put a label (press the l key option) on the bus of CONN_4 and name it "
 "'b[1..4]'."
@@ -1729,7 +1729,7 @@ msgstr ""
 "Placez une label (touche l) sur le bus de CONN_4 et appelez le 'b[1..4]'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:692
+#: getting_started_in_kicad.adoc:706
 msgid ""
 "Put a label (press the l key option) on the previous a bus and name it "
 "'a[1..4]'."
@@ -1737,7 +1737,7 @@ msgstr ""
 "Placez une label (touche l) sur le précédent bus a et appelez le 'a[1..4]'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:695
+#: getting_started_in_kicad.adoc:709
 msgid ""
 "What we can now do is connect bus a[1..4] with bus b[1..4] using a bus line "
 "with the button image:images/icons/add_bus.png[add_bus_png]."
@@ -1747,7 +1747,7 @@ msgstr ""
 "png[add_bus_png]."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:699
+#: getting_started_in_kicad.adoc:713
 msgid ""
 "By connecting the two buses together, pin a1 will be automatically connected "
 "to pin b1, a2 will be connected to b2 and so on. Figure 4 shows what the "
@@ -1758,7 +1758,7 @@ msgstr ""
 "résultat final."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:704
+#: getting_started_in_kicad.adoc:718
 msgid ""
 "The 'Repeat last item' option accessible via the Ins key can be successfully "
 "used to repeat period item insertions. For instance, the short wires "
@@ -1771,7 +1771,7 @@ msgstr ""
 "Figure 3 et Figure 4 ont été placés par cette méthode."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:708
+#: getting_started_in_kicad.adoc:722
 msgid ""
 "The 'Repeat last item' option accessible via the Ins key has also been "
 "extensively used to place the many series of 'Wire to bus entry' using the "
@@ -1783,18 +1783,18 @@ msgstr ""
 "add_line2bus.png[add_line2bus_png]."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:710
+#: getting_started_in_kicad.adoc:724
 msgid "image:images/gsik_bus_connection.png[gsik_bus_connection_png]"
 msgstr ""
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:712
+#: getting_started_in_kicad.adoc:726
 #, no-wrap
 msgid "Layout printed circuit boards"
 msgstr "Router le circuit imprimé (PCB)"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:716
+#: getting_started_in_kicad.adoc:730
 msgid ""
 "It is now time to use the netlist file you generated to lay out the PCB.  "
 "This is done with the _Pcbnew_ tool."
@@ -1803,13 +1803,13 @@ msgstr ""
 "le PCB avec _PCBnew_."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:718
+#: getting_started_in_kicad.adoc:732
 #, no-wrap
 msgid "Using Pcbnew"
 msgstr "Utiliser Pcbnew"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:724
+#: getting_started_in_kicad.adoc:738
 msgid ""
 "From the KiCad project manager, click on the 'Pcbnew' icon image:images/"
 "icons/pcbnew.png[pcbnew_png]. The 'Pcbnew' window will open. If you get an "
@@ -1822,7 +1822,7 @@ msgstr ""
 "pas et vous demande si vous souhaitez le créer, cliquez sur Oui."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:728
+#: getting_started_in_kicad.adoc:742
 msgid ""
 "Begin by entering some schematic information. Click on the 'Page settings' "
 "icon image:images/icons/sheetset.png[sheetset_png] on the top toolbar. Set "
@@ -1834,7 +1834,7 @@ msgstr ""
 "'Taille' de la page en 'A4' et saisissez dans 'titre' : 'Tutoriel1'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:737
+#: getting_started_in_kicad.adoc:751
 msgid ""
 "It is a good idea to start by setting the *clearance* and the *minimum track "
 "width* to those required by your PCB manufacturer. In general you can set "
@@ -1854,12 +1854,12 @@ msgstr ""
 "mesures sont en mm."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:739
+#: getting_started_in_kicad.adoc:753
 msgid "image:images/design_rules.png[Design Rules Window]"
 msgstr "image:images/design_rules.png[Design Rules Window]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:743
+#: getting_started_in_kicad.adoc:757
 msgid ""
 "Click on the 'Global Design Rules' tab and set 'Min track width' to 0.25'. "
 "Click the OK button to commit your changes and close the Design Rules Editor "
@@ -1869,7 +1869,7 @@ msgstr ""
 "'0.25'. Valider ces changements en cliquant sur OK. "
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:749
+#: getting_started_in_kicad.adoc:763
 msgid ""
 "Now we will import the netlist file. Click on the 'Read Netlist' icon image:"
 "images/icons/netlist.png[netlist_png] on the top toolbar. Click on the "
@@ -1882,7 +1882,7 @@ msgstr ""
 "cliquez sur 'Lire Netliste Courante'. Cliquer sur 'Fermer' pour terminer."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:752
+#: getting_started_in_kicad.adoc:766
 msgid ""
 "All components should now be visible in the top left hand corner just above "
 "the page. Scroll up if you cannot see them."
@@ -1892,7 +1892,7 @@ msgstr ""
 "voyez pas."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:756
+#: getting_started_in_kicad.adoc:770
 msgid ""
 "Select all components with the mouse and move them to the middle of the "
 "board. If necessary you can zoom in and out while you move the components."
@@ -1902,7 +1902,7 @@ msgstr ""
 "déplacement des composants."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:762
+#: getting_started_in_kicad.adoc:776
 msgid ""
 "All components are connected via a thin group of wires called __ratsnest__. "
 "Make sure that the 'Hide board ratsnest' button image:images/icons/"
@@ -1915,7 +1915,7 @@ msgstr ""
 "voir le chevelu reliant tous les composants entre eux."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:765
+#: getting_started_in_kicad.adoc:779
 msgid ""
 "The tool-tip is backwards; pressing this button actually displays the "
 "ratsnest."
@@ -1924,7 +1924,7 @@ msgstr ""
 "dessus.  "
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:769
+#: getting_started_in_kicad.adoc:783
 msgid ""
 "You can move each component by hovering over it and pressing the g key. "
 "Click where you want to place them. Move all components around until you "
@@ -1936,7 +1936,7 @@ msgstr ""
 "fils."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:774
+#: getting_started_in_kicad.adoc:788
 msgid ""
 "If instead of grabbing the components (with the g key ) you move them around "
 "using the m key you will later note that you lose the track connection (the "
@@ -1949,12 +1949,12 @@ msgstr ""
 "suivent, nous utiliserons systématiquement la touche g."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:776
+#: getting_started_in_kicad.adoc:790
 msgid "image:images/gsik_tutorial1_080.png[gsik_tutorial1_080_png]"
 msgstr "image:images/gsik_tutorial1_080.png[gsik_tutorial1_080_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:783
+#: getting_started_in_kicad.adoc:797
 msgid ""
 "If the ratsnest disappears or the screen gets messy, right click and click "
 "'Redraw view'. Note how one pin of the 100 ohm resistor is connected to pin "
@@ -1971,7 +1971,7 @@ msgstr ""
 
 # green ?
 #. type: Plain text
-#: getting_started_in_kicad.adoc:791
+#: getting_started_in_kicad.adoc:805
 msgid ""
 "Now we will define the edge of the PCB. Select 'Edge.Cuts' from the drop "
 "down menu in the top toolbar. Click on the 'Add graphic line or polygon' "
@@ -1987,7 +1987,7 @@ msgstr ""
 "Tracer le contour de la carte en cliquant à chacun des coins."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:795
+#: getting_started_in_kicad.adoc:809
 msgid ""
 "Next, connect up all the wires except GND. In fact, we will connect all GND "
 "connections in one go using a ground plane placed on the bottom copper "
@@ -1998,7 +1998,7 @@ msgstr ""
 "plan de masse sur la partie cuivre située sous la carte (appelée __B.Cu__)."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:799
+#: getting_started_in_kicad.adoc:813
 msgid ""
 "Now we must choose which copper layer we want to work on. Select 'F.Cu "
 "(PgUp)' in the drag down menu on the top toolbar. This is the front top "
@@ -2009,12 +2009,12 @@ msgstr ""
 "la barre d'outils du haut. C'est la couche de cuivre du dessus du PCB."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:801
+#: getting_started_in_kicad.adoc:815
 msgid "image:images/select_top_copper.png[Select the Front top copper layer]"
 msgstr "image:images/select_top_copper.png[Select the Front top copper layer]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:807
+#: getting_started_in_kicad.adoc:821
 msgid ""
 "If you decide, for instance, to do a 4 layer PCB instead, go to *Design "
 "Rules* -> *Layers Setup* and change 'Copper Layers' to 4. In the 'Layers' "
@@ -2030,7 +2030,7 @@ msgstr ""
 "Couches'. "
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:815
+#: getting_started_in_kicad.adoc:829
 msgid ""
 "Click on the 'Add Tracks and vias' icon image:images/icons/add_tracks."
 "png[add_tracks_png] on the right toolbar. Click on pin 1 of 'J1' and run a "
@@ -2049,12 +2049,12 @@ msgstr ""
 "défini qu'une."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:817
+#: getting_started_in_kicad.adoc:831
 msgid "image:images/pcbnew_1.png[pcbnew_1_png]"
 msgstr "image:images/pcbnew_1.png[pcbnew_1_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:823
+#: getting_started_in_kicad.adoc:837
 msgid ""
 "If you would like to add more track widths go to: *Design Rules* -> *Design "
 "Rules* -> *Global Design Rules* tab and at the bottom right of this window "
@@ -2070,12 +2070,12 @@ msgstr ""
 "l'exemple ci-dessous (en pouces ou inches)."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:825
+#: getting_started_in_kicad.adoc:839
 msgid "image:images/custom_tracks_width.png[custom_tracks_width_png]"
 msgstr "image:images/custom_tracks_width.png[custom_tracks_width_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:832
+#: getting_started_in_kicad.adoc:846
 msgid ""
 "Alternatively, you can add a Net Class in which you specify a set of "
 "options. Go to *Design Rules* -> *Design Rules* -> *Net Classes Editor* and "
@@ -2093,7 +2093,7 @@ msgstr ""
 "les flèches)."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:836
+#: getting_started_in_kicad.adoc:850
 msgid ""
 "If you want to change the grid size, *Right click* -> **Grid Select**. Be "
 "sure to select the appropriate grid size before or after laying down the "
@@ -2105,7 +2105,7 @@ msgstr ""
 
 # erreur ? (fils ou broches ?)
 #. type: Plain text
-#: getting_started_in_kicad.adoc:839
+#: getting_started_in_kicad.adoc:853
 msgid ""
 "Repeat this process until all wires, except pin 3 of J1, are connected. Your "
 "board should look like the example below."
@@ -2115,12 +2115,12 @@ msgstr ""
 "ci-dessous."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:841
+#: getting_started_in_kicad.adoc:855
 msgid "image:images/gsik_tutorial1_090.png[gsik_tutorial1_090_png]"
 msgstr "image:images/gsik_tutorial1_090.png[gsik_tutorial1_090_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:849
+#: getting_started_in_kicad.adoc:863
 msgid ""
 "Let's now run a track on the other copper side of the PCB. Select 'B.Cu' in "
 "the drag down menu on the top toolbar. Click on the 'Add tracks and vias' "
@@ -2137,7 +2137,7 @@ msgstr ""
 "changement de couleur de la piste."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:856
+#: getting_started_in_kicad.adoc:870
 #, no-wrap
 msgid ""
 "**Go from pin A to pin B by changing layer**. It is possible to\n"
@@ -2156,13 +2156,13 @@ msgstr ""
 "poursuivre le tracé de la piste.\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:858
+#: getting_started_in_kicad.adoc:872
 #, no-wrap
 msgid "image:images/place_a_via.png[place_a_via_png]\n"
 msgstr "image:images/place_a_via.png[place_a_via_png]\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:864
+#: getting_started_in_kicad.adoc:878
 msgid ""
 "When you want to inspect a particular connection you can click on the 'Net "
 "highlight' icon image:images/icons/net_highlight.png[net_highlight_png] on "
@@ -2176,7 +2176,7 @@ msgstr ""
 
 # choix du net ? Oubli ?
 #. type: Plain text
-#: getting_started_in_kicad.adoc:872
+#: getting_started_in_kicad.adoc:886
 msgid ""
 "Now we will make a ground plane that will be connected to all GND pins. "
 "Click on the 'Add Zones' icon image:images/icons/add_zone.png[add_zone_png] "
@@ -2196,7 +2196,7 @@ msgstr ""
 
 # Il est parfois nécessaire de s'y prendre à 2 fois pour accéder à la commande Zones. Oubli ou incompréhension de ma part ?
 #. type: Plain text
-#: getting_started_in_kicad.adoc:877
+#: getting_started_in_kicad.adoc:891
 msgid ""
 "Trace around the outline of the board by clicking each corner in rotation. "
 "Double-click to finish your rectangle. Right click inside the area you have "
@@ -2211,12 +2211,12 @@ msgstr ""
 "devrait se remplir de vert et ressemblez à ceci :"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:879
+#: getting_started_in_kicad.adoc:893
 msgid "image:images/gsik_tutorial1_100.png[gsik_tutorial1_100_png]"
 msgstr "image:images/gsik_tutorial1_100.png[gsik_tutorial1_100_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:885
+#: getting_started_in_kicad.adoc:899
 msgid ""
 "Run the design rules checker by clicking on the 'Perform Design Rules Check' "
 "icon image:images/icons/drc.png[drc_png] on the top toolbar.  Click on "
@@ -2231,7 +2231,7 @@ msgstr ""
 "dialogue."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:888
+#: getting_started_in_kicad.adoc:902
 msgid ""
 "Save your file by clicking on *File* -> **Save**. To admire your board in "
 "3D, click on *View* -> **3D Viewer**."
@@ -2240,19 +2240,19 @@ msgstr ""
 "admirer votre carte en 3D, cliquez sur *Affichage* -> **3D Visualisateur**."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:890
+#: getting_started_in_kicad.adoc:904
 msgid "image:images/pcbnew_3d_viewer.png[pcbnew_3d_viewer_png]"
 msgstr "image:images/pcbnew_3d_viewer.png[pcbnew_3d_viewer_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:892
+#: getting_started_in_kicad.adoc:906
 msgid "You can drag your mouse around to rotate the PCB."
 msgstr ""
 "Pour faire tourner le PCB, maintenez le bouton gauche de la souris appuyé "
 "puis la déplacer."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:895
+#: getting_started_in_kicad.adoc:909
 msgid ""
 "Your board is complete. To send it off to a manufacturer you will need to "
 "generate all Gerber files."
@@ -2261,13 +2261,13 @@ msgstr ""
 "faudra générer les fichiers Gerber."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:897
+#: getting_started_in_kicad.adoc:911
 #, no-wrap
 msgid "Generate Gerber files"
 msgstr "Générer les fichiers Gerber"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:902
+#: getting_started_in_kicad.adoc:916
 msgid ""
 "Once your PCB is complete, you can generate Gerber files for each layer and "
 "send them to your favourite PCB manufacturer, who will make the board for "
@@ -2278,7 +2278,7 @@ msgstr ""
 "fabriquera la carte pour vous."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:906
+#: getting_started_in_kicad.adoc:920
 msgid ""
 "From KiCad, open the _Pcbnew_ software tool and load your board file by "
 "clicking on the icon image:images/icons/open_document.png[open_document_png]."
@@ -2286,7 +2286,7 @@ msgstr ""
 "A partir de KiCad, ouvrez _Pcbnew_ et chargez le fichier de votre carte."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:910
+#: getting_started_in_kicad.adoc:924
 msgid ""
 "Click on *File* -> **Plot**. Select 'Gerber' as the 'Plot Format' and select "
 "the folder in which to put all Gerber files.  Proceed by clicking on the "
@@ -2297,7 +2297,7 @@ msgstr ""
 "déposés. Cliquez sur le bouton 'Tracer' pour l'exécution."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:913
+#: getting_started_in_kicad.adoc:927
 msgid ""
 "These are the layers you need to select for making a typical 2-layer PCB:"
 msgstr ""
@@ -2305,7 +2305,7 @@ msgstr ""
 "fabriquer un PCB double-face :"
 
 #. type: delimited block |
-#: getting_started_in_kicad.adoc:924
+#: getting_started_in_kicad.adoc:938
 #, no-wrap
 msgid ""
 "|Layer |KiCad Layer Name |Old KiCad Layer Name |Default Gerber Extension\n"
@@ -2319,13 +2319,13 @@ msgid ""
 msgstr ""
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:927
+#: getting_started_in_kicad.adoc:941
 #, no-wrap
 msgid "Using GerbView"
 msgstr "Utiliser GerbView"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:936
+#: getting_started_in_kicad.adoc:950
 msgid ""
 "To view all your Gerber files go to the KiCad project manager and click on "
 "the 'GerbView' icon.  On the drag down menu select 'Layer 1'. Click on "
@@ -2341,7 +2341,7 @@ msgstr ""
 "dessus des autres. "
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:939
+#: getting_started_in_kicad.adoc:953
 msgid ""
 "Use the menu on the right to select/deselect which layer to show.  Carefully "
 "inspect each layer before sending them for production."
@@ -2350,7 +2350,7 @@ msgstr ""
 "Inspectez minutieusement chaque couche avant de lancer la production."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:942
+#: getting_started_in_kicad.adoc:956
 msgid ""
 "To generate the drill file, from _Pcbnew_ go again for the *File* -> *Plot* "
 "option. Default settings should be fine."
@@ -2360,13 +2360,13 @@ msgstr ""
 "réglages par défaut devraient être satisfaisants."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:944
+#: getting_started_in_kicad.adoc:958
 #, no-wrap
 msgid "Automatically route with FreeRouter"
 msgstr "Routage automatique avec FreeRouter"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:952
+#: getting_started_in_kicad.adoc:966
 msgid ""
 "Routing a board by hand is quick and fun, however, for a board with lots of "
 "components you might want to use an autorouter. Remember that you should "
@@ -2383,7 +2383,7 @@ msgstr ""
 "__freerouting.net__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:957
+#: getting_started_in_kicad.adoc:971
 msgid ""
 "Freerouter is a open source java application, and it is needed to build by "
 "yourself to use with KiCad.  Source code of Freerouter can be found on this "
@@ -2394,7 +2394,7 @@ msgstr ""
 "https://github.com/nikropht/FreeRouting"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:963
+#: getting_started_in_kicad.adoc:977
 msgid ""
 "From _Pcbnew_ click on *File* -> *Export* -> *Specctra DSN* or click on "
 "*Tools* -> *FreeRoute* -> **Export a Specctra Design (*.dsn) file** and save "
@@ -2407,7 +2407,7 @@ msgstr ""
 "bouton 'Open Your Own Design', retrouvez  votre fichier _dsn_ et chargez le."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:968
+#: getting_started_in_kicad.adoc:982
 msgid ""
 "The *Tools* -> *FreeRoute* dialog has a nice help button that opens a file "
 "viewer with a little document inside named **Freerouter Guidelines**. Please "
@@ -2419,7 +2419,7 @@ msgstr ""
 "efficacement."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:974
+#: getting_started_in_kicad.adoc:988
 msgid ""
 "FreeRouter has some features that KiCad does not currently have, both for "
 "manual routing and for automatic routing. FreeRouter operates in two main "
@@ -2433,7 +2433,7 @@ msgstr ""
 "toutefois, vous pouvez l'arrêtez à tout moment au cas où."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:982
+#: getting_started_in_kicad.adoc:996
 msgid ""
 "You can start the automatic routing by clicking on the 'Autorouter' button "
 "on the top bar. The bottom bar gives you information about the on-going "
@@ -2451,7 +2451,7 @@ msgstr ""
 "nombre de lignes croisées dans le chevelu."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:987
+#: getting_started_in_kicad.adoc:1001
 msgid ""
 "Making a left-click on the mouse can stop the automatic routing and "
 "automatically start the optimisation process. Another left-click will stop "
@@ -2465,7 +2465,7 @@ msgstr ""
 "son travail."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:991
+#: getting_started_in_kicad.adoc:1005
 msgid ""
 "Click on the *File* -> *Export Specctra Session File* menu and save the "
 "board file with the _.ses_ extension. You do not really need to save the "
@@ -2476,7 +2476,7 @@ msgstr ""
 "besoin de sauver le fichiers de règles de FreeRouter."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:996
+#: getting_started_in_kicad.adoc:1010
 msgid ""
 "Back to __Pcbnew__. You can import your freshly routed board by clicking on "
 "the link *Tools* -> *FreeRoute* and then on the icon 'Back Import the "
@@ -2488,7 +2488,7 @@ msgstr ""
 "ses_."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1001
+#: getting_started_in_kicad.adoc:1015
 msgid ""
 "If there is any routed trace that you do not like, you can delete it and re-"
 "route it again, using the del key and the routing tool, which is the 'Add "
@@ -2501,13 +2501,13 @@ msgstr ""
 "icon] de la barre d'outils de droite."
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1003
+#: getting_started_in_kicad.adoc:1017
 #, no-wrap
 msgid "Forward annotation in KiCad"
 msgstr "Les Annotations dans KiCad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1009
+#: getting_started_in_kicad.adoc:1023
 msgid ""
 "Once you have completed your electronic schematic, the footprint assignment, "
 "the board layout and generated the Gerber files, you are ready to send "
@@ -2519,7 +2519,7 @@ msgstr ""
 "circuit devienne réalité."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1017
+#: getting_started_in_kicad.adoc:1031
 msgid ""
 "Often, this linear work-flow turns out to be not so uni-directional. For "
 "instance, when you have to modify/extend a board for which you or others "
@@ -2536,7 +2536,7 @@ msgstr ""
 "pas, c'est d'avoir à rerouter le circuit entier. Voici comment procéder :"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1020
+#: getting_started_in_kicad.adoc:1034
 msgid ""
 "Let's suppose that you want to replace a hypothetical connector CON1 with "
 "CON2."
@@ -2545,12 +2545,12 @@ msgstr ""
 "CON2."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1022
+#: getting_started_in_kicad.adoc:1036
 msgid "You already have a completed schematic and a fully routed PCB."
 msgstr "Vous avez déjà terminé le schéma et routé le circuit."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1028
+#: getting_started_in_kicad.adoc:1042
 msgid ""
 "From KiCad, start __Eeschema__, make your modifications by deleting CON1 and "
 "adding CON2. Save your schematic project with the icon image:images/icons/"
@@ -2564,7 +2564,7 @@ msgstr ""
 "png[netlist_png] de la barre d'outils du haut."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1031
+#: getting_started_in_kicad.adoc:1045
 msgid ""
 "Click on 'Netlist' then on 'save'. Save to the default file name.  You have "
 "to rewrite the old one."
@@ -2573,7 +2573,7 @@ msgstr ""
 "écrasez l'ancien fichier."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1037
+#: getting_started_in_kicad.adoc:1051
 msgid ""
 "Now assign a footprint to CON2. Click on the 'Run Cvpcb' icon image:images/"
 "icons/cvpcb.png[cvpcb] on the top toolbar. Assign the footprint to the new "
@@ -2587,7 +2587,7 @@ msgstr ""
 "__CvPcb__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1040
+#: getting_started_in_kicad.adoc:1054
 msgid ""
 "Back in the schematic editor, save the project by clicking on 'File' -> "
 "'Save Whole Schematic Project'. Close the schematic editor."
@@ -2596,7 +2596,7 @@ msgstr ""
 "'Fichier' -> 'Sauvez le projet schématique', puis fermez 'EESchema'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1043
+#: getting_started_in_kicad.adoc:1057
 msgid ""
 "From the KiCad project manager, click on the 'Pcbnew' icon. The 'Pcbnew' "
 "window will open."
@@ -2605,7 +2605,7 @@ msgstr ""
 "'Pcbnew' doit s'ouvrir."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1047
+#: getting_started_in_kicad.adoc:1061
 msgid ""
 "The old, already routed, board should automatically open. Let's import the "
 "new netlist file. Click on the 'Read Netlist' icon image:images/icons/"
@@ -2616,7 +2616,7 @@ msgstr ""
 "netlist.png[netlist_png] de la barre d'outils du haut."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1051
+#: getting_started_in_kicad.adoc:1065
 msgid ""
 "Click on the 'Browse Netlist Files' button, select the netlist file in the "
 "file selection dialogue, and click on 'Read Current Netlist'.  Then click "
@@ -2627,7 +2627,7 @@ msgstr ""
 "Puis cliquez sur le bouton 'Fermer'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1056
+#: getting_started_in_kicad.adoc:1070
 msgid ""
 "At this point you should be able to see a layout with all previous "
 "components already routed. On the top left corner you should see all "
@@ -2640,7 +2640,7 @@ msgstr ""
 "circuit."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1059
+#: getting_started_in_kicad.adoc:1073
 msgid ""
 "Place CON2 and route it. Once done, save and proceed with the Gerber file "
 "generation as usual."
@@ -2649,7 +2649,7 @@ msgstr ""
 "des fichiers Gerber comme précédemment."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1067
+#: getting_started_in_kicad.adoc:1081
 msgid ""
 "The process described here can easily be repeated as many times as you need. "
 "Beside the Forward Annotation method described above, there is another "
@@ -2667,13 +2667,13 @@ msgstr ""
 "très utile et n'est pas décrite ici."
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1069
+#: getting_started_in_kicad.adoc:1083
 #, no-wrap
 msgid "Make schematic components in KiCad"
 msgstr "Créer un symbole de composant avec KiCad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1076
+#: getting_started_in_kicad.adoc:1090
 msgid ""
 "Sometimes a component that you want to place on your schematic is not in the "
 "KiCad libraries. This is quite normal and there is no reason to worry. In "
@@ -2687,12 +2687,12 @@ msgstr ""
 "un nouveau symbole de composant avec KiCad."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1078
+#: getting_started_in_kicad.adoc:1092
 msgid "http://per.launay.free.fr/kicad/kicad_php/composant.php"
 msgstr "http://per.launay.free.fr/kicad/kicad_php/composant.php"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1083
+#: getting_started_in_kicad.adoc:1097
 msgid ""
 "In KiCad, a component is a piece of text that starts with a 'DEF' and ends "
 "with 'ENDDEF'. One or more components are normally placed in a library file "
@@ -2706,13 +2706,13 @@ msgstr ""
 "utiliser les commandes copier et coller."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1085
+#: getting_started_in_kicad.adoc:1099
 #, no-wrap
 msgid "Using Component Library Editor"
 msgstr "Utiliser l'Editeur des Librairies Schématiques"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1091
+#: getting_started_in_kicad.adoc:1105
 msgid ""
 "We can use the _Component Library Editor_ (part of __Eeschema__)  to make "
 "new components. In our project folder 'tutorial1' let's create a folder "
@@ -2726,7 +2726,7 @@ msgstr ""
 "créé notre nouveau composant."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1106
+#: getting_started_in_kicad.adoc:1120
 msgid ""
 "Now we can start creating our new component. From KiCad, start __Eeschema__, "
 "click on the 'Library Editor' icon image:images/icons/libedit."
@@ -2753,7 +2753,7 @@ msgstr ""
 "en dessous de l'étiquette 'MYCONN3'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1110
+#: getting_started_in_kicad.adoc:1124
 msgid ""
 "In the Pin Properties window that appears, set the pin name to 'VCC', set "
 "the pin number to '1', and the 'Electrical type' to 'Passive' then click OK."
@@ -2763,12 +2763,12 @@ msgstr ""
 "ensuite sur OK."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1112
+#: getting_started_in_kicad.adoc:1126
 msgid "image:images/pin_properties.png[Pin Properties]"
 msgstr "image:images/pin_properties.png[Pin Properties]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1115
+#: getting_started_in_kicad.adoc:1129
 msgid ""
 "Place the pin by clicking on the location you would like it to go, right "
 "below the 'MYCONN3' label."
@@ -2777,7 +2777,7 @@ msgstr ""
 "apparaisse, à droite et en dessous de l'étiquette 'MYCONN3'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1119
+#: getting_started_in_kicad.adoc:1133
 msgid ""
 "Repeat the place-pin steps, this time 'Pin name' should be 'INPUT', 'Pin "
 "number' should be '2', and 'Electrical Type' should be 'Passive'."
@@ -2786,7 +2786,7 @@ msgstr ""
 "'2' à 'Numéro de pin' et 'Passive' à 'type électrique'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1125
+#: getting_started_in_kicad.adoc:1139
 msgid ""
 "Repeat the place-pin steps, this time 'Pin name' should be 'GND', 'Pin "
 "number' should be '3', and 'Electrical Type' should be 'Passive'.  Arrange "
@@ -2799,7 +2799,7 @@ msgstr ""
 "page (à l'intersection des lignes bleues)."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1133
+#: getting_started_in_kicad.adoc:1147
 #, fuzzy
 #| msgid ""
 #| "Next, draw the contour of the component. Click on the 'Add rectangle' "
@@ -2823,12 +2823,12 @@ msgstr ""
 "à l'endroit où vous souhaitez placer le coin inférieur droit."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1135
+#: getting_started_in_kicad.adoc:1149
 msgid "image:images/gsik_myconn3_l.png[gsik_myconn3_l_png]"
 msgstr "image:images/gsik_myconn3_l.png[gsik_myconn3_l_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1140
+#: getting_started_in_kicad.adoc:1154
 msgid ""
 "Save the component in your library __myLib.lib__. Click on the 'New Library' "
 "icon image:images/icons/new_library.png[new_library_png], navigate into "
@@ -2841,7 +2841,7 @@ msgstr ""
 "lui donnant le nom __myLib.lib__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1143
+#: getting_started_in_kicad.adoc:1157
 msgid ""
 "Go to *Preferences* -> *Component Libraries* and add both _tutorial1/library/"
 "_ in 'User defined search path' and _myLib.lib in_ 'Component library files'."
@@ -2851,7 +2851,7 @@ msgstr ""
 "et _myLib.lib_ dans 'Fichiers Librairies de Composants'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1149
+#: getting_started_in_kicad.adoc:1163
 msgid ""
 "Click on the 'Select working library' icon image:images/icons/library."
 "png[library_png]. In the Select Library window click on _myLib_ and click "
@@ -2865,7 +2865,7 @@ msgstr ""
 "maintenant __myLib__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1158
+#: getting_started_in_kicad.adoc:1172
 msgid ""
 "Click on the 'Update current component in current library' icon image:images/"
 "icons/save_part_in_mem.png[save_part_in_mem_png] in the top toolbar. Save "
@@ -2883,7 +2883,7 @@ msgstr ""
 "fenêtre."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1162
+#: getting_started_in_kicad.adoc:1176
 msgid ""
 "You can now close the Component library editor window. You will return to "
 "the schematic editor window. Your new component will now be available to you "
@@ -2894,7 +2894,7 @@ msgstr ""
 "maintenant disponible à partir de la librairie __myLib__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1167
+#: getting_started_in_kicad.adoc:1181
 msgid ""
 "You can make any library _file.lib_ file available to you by adding it to "
 "the library path. From __Eeschema__, go to *Preferences* -> *Library* and "
@@ -2908,13 +2908,13 @@ msgstr ""
 "dans 'Fichiers Librairies de Composants'."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1169
+#: getting_started_in_kicad.adoc:1183
 #, no-wrap
 msgid "Export, import and modify library components"
 msgstr "Exporter, Importer et modifier une librairie"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1175
+#: getting_started_in_kicad.adoc:1189
 msgid ""
 "Instead of creating a library component from scratch it is sometimes easier "
 "to start from one already made and modify it. In this section we will see "
@@ -2928,7 +2928,7 @@ msgstr ""
 "_myOwnLib.lib_ et ensuite le modifier."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1183
+#: getting_started_in_kicad.adoc:1197
 msgid ""
 "From KiCad, start __Eeschema__, click on the 'Library Editor' icon image:"
 "images/icons/libedit.png[libedit_png], click on the 'Select working library' "
@@ -2946,7 +2946,7 @@ msgstr ""
 "'RELAY_2RT'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1187
+#: getting_started_in_kicad.adoc:1201
 msgid ""
 "Click on the 'Export component' icon image:images/icons/export."
 "png[export_png], navigate into the _library/_ folder and save the new "
@@ -2957,7 +2957,7 @@ msgstr ""
 "librairie sous le nom _myOwnLib.lib._"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1193
+#: getting_started_in_kicad.adoc:1207
 msgid ""
 "You can make this component and the whole library _myOwnLib.lib_ available "
 "to you by adding it to the library path. From __Eeschema__, go to "
@@ -2971,7 +2971,7 @@ msgstr ""
 "librairies de Composants'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1199
+#: getting_started_in_kicad.adoc:1213
 msgid ""
 "Click on the 'Select working library' icon image:images/icons/library."
 "png[library_png]. In the Select Library window click on _myOwnLib_ and click "
@@ -2985,7 +2985,7 @@ msgstr ""
 "maintenant __myOwnLib__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1203
+#: getting_started_in_kicad.adoc:1217
 msgid ""
 "Click on the 'Load component to edit from the current lib' icon image:images/"
 "icons/import_cmp_from_lib.png[import_cmp_from_lib_png] and import the "
@@ -2996,7 +2996,7 @@ msgstr ""
 "png[import_cmp_from_lib_png] et importez 'RELAY_2RT'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1206
+#: getting_started_in_kicad.adoc:1220
 msgid ""
 "You can now modify the component as you like. Hover over the label "
 "'RELAY_2RT', press the e key and rename it 'MY_RELAY_2RT'."
@@ -3006,7 +3006,7 @@ msgstr ""
 "'MY_RELAY_2RT'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1213
+#: getting_started_in_kicad.adoc:1227
 msgid ""
 "Click on 'Update current component in current library' icon image:images/"
 "icons/save_part_in_mem.png[save_part_in_mem_png] in the top toolbar. Save "
@@ -3020,13 +3020,13 @@ msgstr ""
 "png[save_library_png] de la barre d'outils du haut."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1215
+#: getting_started_in_kicad.adoc:1229
 #, no-wrap
 msgid "Make schematic components with quicklib"
 msgstr "Créer un symbole de composant avec QuickLib"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1220
+#: getting_started_in_kicad.adoc:1234
 msgid ""
 "This section presents an alternative way of creating the schematic component "
 "for MYCONN3 (see <<myconn3,MYCONN3>> above) using the Internet tool "
@@ -3037,7 +3037,7 @@ msgstr ""
 "l'outil en ligne __quicklib__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1223
+#: getting_started_in_kicad.adoc:1237
 msgid ""
 "Head to the _quicklib_ web page: http://kicad.rohrbacher.net/quicklib.php"
 msgstr ""
@@ -3045,7 +3045,7 @@ msgstr ""
 "quicklib.php"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1226
+#: getting_started_in_kicad.adoc:1240
 msgid ""
 "Fill out the page with the following information: Component name: MYCONN3 "
 "Reference Prefix: J Pin Layout Style: SIL Pin Count, N: 3"
@@ -3054,7 +3054,7 @@ msgstr ""
 "MYCONN3, Reference Prefix: J, Pin Layout Style: SIL, Pin Count N: 3"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1230
+#: getting_started_in_kicad.adoc:1244
 msgid ""
 "Click on the 'Assign Pins' icon. Fill out the page with the following "
 "information: Pin 1: VCC Pin 2: input Pin 3: GND.  Type : Passive for all 3 "
@@ -3065,7 +3065,7 @@ msgstr ""
 "Passive pour les 3 pins."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1234
+#: getting_started_in_kicad.adoc:1248
 msgid ""
 "Click on the icon 'Preview it' and, if you are satisfied, click on the "
 "'Build Library Component'. Download the file and rename it __tutorial1/"
@@ -3076,7 +3076,7 @@ msgstr ""
 "library/myQuickLib.lib.__. C'est terminé !"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1240
+#: getting_started_in_kicad.adoc:1254
 msgid ""
 "Have a look at it using KiCad. From the KiCad project manager, start "
 "__Eeschema__, click on the 'Library Editor' icon image:images/icons/libedit."
@@ -3091,12 +3091,12 @@ msgstr ""
 "_tutorial1/library/_ et choisissez _myQuickLib.lib_."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1242
+#: getting_started_in_kicad.adoc:1256
 msgid "image:images/gsik_myconn3_quicklib.png[gsik_myconn3_quicklib_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1248
+#: getting_started_in_kicad.adoc:1262
 msgid ""
 "You can make this component and the whole library _myQuickLib.lib_ available "
 "to you by adding it to the KiCad library path. From __Eeschema__, go to "
@@ -3110,7 +3110,7 @@ msgstr ""
 "'Fichiers librairies de Composants'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1252
+#: getting_started_in_kicad.adoc:1266
 msgid ""
 "As you might guess, this method of creating library components can be quite "
 "effective when you want to create components with a large pin count."
@@ -3120,13 +3120,13 @@ msgstr ""
 "pattes."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1254
+#: getting_started_in_kicad.adoc:1268
 #, no-wrap
 msgid "Make a high pin count schematic component"
 msgstr "Créer un symbole de composant avec un grand nombre de broches"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1261
+#: getting_started_in_kicad.adoc:1275
 msgid ""
 "In the section titled _Make Schematic Components in quicklib_ we saw how to "
 "make a schematic component using the _quicklib_ web-based tool.  However, "
@@ -3141,7 +3141,7 @@ msgstr ""
 "opération très compliquée."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1267
+#: getting_started_in_kicad.adoc:1281
 msgid ""
 "Suppose that you want to create a schematic component for a device with 50 "
 "pins. It is common practise to draw it using multiple low pin-count "
@@ -3155,7 +3155,7 @@ msgstr ""
 "broches."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1272
+#: getting_started_in_kicad.adoc:1286
 msgid ""
 "The best way to create our component is to use _quicklib_ to generate two 25-"
 "pin components separately, re-number their pins using a Python script and "
@@ -3168,7 +3168,7 @@ msgstr ""
 "pour n'en faire qu'un à l'intérieur des balises DEF et ENDDEF."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1278
+#: getting_started_in_kicad.adoc:1292
 msgid ""
 "You will find an example of a simple Python script below that can be used in "
 "conjunction with an _in.txt_ file and an _out.txt_ file to re-number the "
@@ -3182,13 +3182,13 @@ msgstr ""
 "_in.txt_."
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:1279
+#: getting_started_in_kicad.adoc:1293
 #, no-wrap
 msgid "Simple script"
 msgstr ""
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1302
+#: getting_started_in_kicad.adoc:1316
 #, no-wrap
 msgid ""
 "#!/usr/bin/env python\n"
@@ -3214,7 +3214,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1308
+#: getting_started_in_kicad.adoc:1322
 msgid ""
 "While merging the two components into one, it is necessary to use the "
 "Library Editor from Eeschema to move the first component so that the second "
@@ -3228,13 +3228,13 @@ msgstr ""
 "_Eeschema_."
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:1309
+#: getting_started_in_kicad.adoc:1323
 #, no-wrap
 msgid "Contents of a *.lib file"
 msgstr "Contenu d'un fichier *.lib"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1321
+#: getting_started_in_kicad.adoc:1335
 #, no-wrap
 msgid ""
 "EESchema-LIBRARY Version 2.3\n"
@@ -3250,13 +3250,13 @@ msgid ""
 msgstr ""
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1323
+#: getting_started_in_kicad.adoc:1337
 #, no-wrap
 msgid "...\n"
 msgstr ""
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1328
+#: getting_started_in_kicad.adoc:1342
 #, no-wrap
 msgid ""
 "X PIN49 49 750 -500 300 L 50 50 1 1 I\n"
@@ -3266,12 +3266,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1331
+#: getting_started_in_kicad.adoc:1345
 msgid "image:images/gsik_high_number_pins.png[gsik_high_number_pins_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1336
+#: getting_started_in_kicad.adoc:1350
 msgid ""
 "The Python script presented here is a very powerful tool for manipulating "
 "both pin numbers and pin labels. Mind, however, that all its power comes for "
@@ -3284,13 +3284,13 @@ msgstr ""
 "syntaxe ésothérique : _http://gskinner.com/RegExr/._"
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1338
+#: getting_started_in_kicad.adoc:1352
 #, no-wrap
 msgid "Make component footprints"
 msgstr "Créer une empreinte de composant"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1344
+#: getting_started_in_kicad.adoc:1358
 msgid ""
 "Unlike other EDA software tools, which have one type of library that "
 "contains both the schematic symbol and the footprint variations, KiCad _."
@@ -3304,7 +3304,7 @@ msgstr ""
 "pour effectuer l'association."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1347
+#: getting_started_in_kicad.adoc:1361
 msgid ""
 "As for _.lib_ files, _.kicad_mod_ library files are text files that can "
 "contain anything from one to several parts."
@@ -3313,7 +3313,7 @@ msgstr ""
 "type texte,  qui peuvent contenir un ou plusieurs composants."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1351
+#: getting_started_in_kicad.adoc:1365
 msgid ""
 "There is an extensive footprint library with KiCad, however on occasion you "
 "might find that the footprint you need is not in the KiCad library.  Here "
@@ -3324,13 +3324,13 @@ msgstr ""
 "créer de nouvelles :"
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1353
+#: getting_started_in_kicad.adoc:1367
 #, no-wrap
 msgid "Using Footprint Editor"
 msgstr "Utiliser l'Editeur d'Empreintes"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1359
+#: getting_started_in_kicad.adoc:1373
 msgid ""
 "From the KiCad project manager start the _Pcbnew_ tool. Click on the 'Open "
 "Footprint Editor' icon image:images/icons/edit_module.png[edit_module_png] "
@@ -3341,7 +3341,7 @@ msgstr ""
 "png[edit_module_png] dans la barre d'outils du haut."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1371
+#: getting_started_in_kicad.adoc:1385
 msgid ""
 "We are going to save the new footprint 'MYCONN3' in the new footprint "
 "library 'myfootprint'.  Create a new folder _myfootprint.pretty_ in the "
@@ -3365,7 +3365,7 @@ msgstr ""
 "Sélectionnez la librairie 'monempreinte'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1380
+#: getting_started_in_kicad.adoc:1394
 msgid ""
 "Click on the 'New Footprint' icon image:images/icons/new_footprint."
 "png[new_footprint_png] on the top toolbar.  Type 'MYCONN3' as the 'footprint "
@@ -3383,7 +3383,7 @@ msgstr ""
 "renommez-la 'CMS'. Sélectionnez 'Invisible' dans 'Affichage'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1385
+#: getting_started_in_kicad.adoc:1399
 msgid ""
 "Select the 'Add Pads' icon image:images/icons/pad.png[pad_png] on the right "
 "toolbar. Click on the working sheet to place the pad. Right click on the new "
@@ -3396,12 +3396,12 @@ msgstr ""
 "raccourci e."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1387
+#: getting_started_in_kicad.adoc:1401
 msgid "image:images/pad_properties.png[Pad Properties]"
 msgstr "image:images/pad_properties.png[Pad Properties]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1391
+#: getting_started_in_kicad.adoc:1405
 msgid ""
 "Set the 'Pad Num' to '1', 'Pad Shape' to 'Rect', 'Pad Type' to 'SMD', 'Shape "
 "Size X' to '0.4', and 'Shape Size Y' to '0.8'. Click OK.  Click on 'Add "
@@ -3413,7 +3413,7 @@ msgstr ""
 "supplémentaires."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1395
+#: getting_started_in_kicad.adoc:1409
 msgid ""
 "If you want to change the grid size, *Right click* -> **Grid Select**. Be "
 "sure to select the appropriate grid size before laying down the components."
@@ -3423,7 +3423,7 @@ msgstr ""
 "du composant."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1398
+#: getting_started_in_kicad.adoc:1412
 msgid ""
 "Move the 'MYCONN3' label and the 'SMD' label out of the way so that it looks "
 "like the image shown above."
@@ -3432,7 +3432,7 @@ msgstr ""
 "ci-dessus."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1405
+#: getting_started_in_kicad.adoc:1419
 msgid ""
 "When placing pads it is often necessary to measure relative distances. Place "
 "the cursor where you want the relative coordinate point _(0,0)_ to be and "
@@ -3448,7 +3448,7 @@ msgstr ""
 "que vous souhaitez définir une nouvelle origine."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1410
+#: getting_started_in_kicad.adoc:1424
 msgid ""
 "Now add a footprint contour. Click on the 'Add graphic line or polygon' "
 "button image:images/icons/add_polygon.png[add_polygon_png] in the right "
@@ -3460,7 +3460,7 @@ msgstr ""
 "du connecteur autour de l'empreinte."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1414
+#: getting_started_in_kicad.adoc:1428
 msgid ""
 "Click on the 'Save Footprint in Active Library' icon image:images/icons/"
 "save_library.png[save_library_png] on the top toolbar, using the default "
@@ -3471,13 +3471,13 @@ msgstr ""
 "Utiliser le nom MYCONN3 proposé par défaut."
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1416
+#: getting_started_in_kicad.adoc:1430
 #, no-wrap
 msgid "Note about portability of KiCad project files"
 msgstr "Portabilité des fichiers d'un projet KiCad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1420
+#: getting_started_in_kicad.adoc:1434
 msgid ""
 "What files do you need to send to someone so that they can fully load and "
 "use your KiCad project?"
@@ -3486,7 +3486,7 @@ msgstr ""
 "projet KiCad ?"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1427
+#: getting_started_in_kicad.adoc:1441
 msgid ""
 "When you have a KiCad project to share with somebody, it is important that "
 "the schematic file __.sch__, the board file __.kicad_pcb__, the project file "
@@ -3503,7 +3503,7 @@ msgstr ""
 "possible à d'autres de modifier le schéma et le circuit."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1439
+#: getting_started_in_kicad.adoc:1453
 msgid ""
 "With KiCad schematics, people need the _.lib_ files that contain the "
 "symbols. Those library files need to be loaded in the _Eeschema_ "
@@ -3526,7 +3526,7 @@ msgstr ""
 "fournis et présents dans les Préférences de Pcbnew."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1447
+#: getting_started_in_kicad.adoc:1461
 msgid ""
 "If someone sends you a _.kicad_pcb_ file with footprints you would like to "
 "use in another board, you can open the Footprint Editor, load a footprint "
@@ -3546,7 +3546,7 @@ msgstr ""
 "empreintes."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1453
+#: getting_started_in_kicad.adoc:1467
 msgid ""
 "Bottom line, if the PCB is the only thing you want to distribute, then the "
 "board file _.kicad_pcb_ is enough. However, if you want to give people the "
@@ -3561,7 +3561,7 @@ msgstr ""
 "compressé dans un _.zip_ :"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1471
+#: getting_started_in_kicad.adoc:1485
 #, no-wrap
 msgid ""
 "tutorial1/\n"
@@ -3583,13 +3583,13 @@ msgid ""
 msgstr ""
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1474
+#: getting_started_in_kicad.adoc:1488
 #, no-wrap
 msgid "More about KiCad documentation"
 msgstr "Documentation complémentaire à propos de KiCad "
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1479
+#: getting_started_in_kicad.adoc:1493
 msgid ""
 "This has been a quick guide on most of the features in KiCad. For more "
 "detailed instructions consult the help files which you can access through "
@@ -3601,7 +3601,7 @@ msgstr ""
 "Cliquez sur *Aide* -> **Documentation de (Eeschema par exemple)**."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1482
+#: getting_started_in_kicad.adoc:1496
 msgid ""
 "KiCad comes with a pretty good set of multi-language manuals for all its "
 "four software components."
@@ -3610,13 +3610,13 @@ msgstr ""
 "pour ses 4 composantes logicielles."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1484
+#: getting_started_in_kicad.adoc:1498
 msgid "The English version of all KiCad manuals are distributed with KiCad."
 msgstr ""
 "Les versions anglaises de tous les manuels KiCad sont distribuées avec KiCad."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1490
+#: getting_started_in_kicad.adoc:1504
 msgid ""
 "In addition to its manuals, KiCad is distributed with this tutorial, which "
 "has been translated into other languages. All the different versions of this "
@@ -3630,7 +3630,7 @@ msgstr ""
 "les manuels devraient se trouver avec votre version de KiCad. "
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1493
+#: getting_started_in_kicad.adoc:1507
 msgid ""
 "For example, on Linux the typical locations are in the following "
 "directories, depending on your exact distribution:"
@@ -3639,7 +3639,7 @@ msgstr ""
 "dessous : (cela peut cependant dépendre de votre distribution)"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1496
+#: getting_started_in_kicad.adoc:1510
 #, no-wrap
 msgid ""
 " /usr/share/doc/kicad/help/en/\n"
@@ -3649,36 +3649,36 @@ msgstr ""
 " /usr/local/share/doc/kicad/help/en\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1498
+#: getting_started_in_kicad.adoc:1512
 msgid "On Windows it is in:"
 msgstr "Sous Windows :"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1500
+#: getting_started_in_kicad.adoc:1514
 #, fuzzy, no-wrap
 #| msgid " <installation directiory>/share/doc/kicad/help/en\n"
 msgid " <installation directory>/share/doc/kicad/help/en\n"
 msgstr " <installation directiory>/share/doc/kicad/help/en\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1502
+#: getting_started_in_kicad.adoc:1516
 msgid "On OS X:"
 msgstr "Sous OS X:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1504
+#: getting_started_in_kicad.adoc:1518
 #, no-wrap
 msgid " /Library/Application Support/kicad/help/en\n"
 msgstr " /Library/Application Support/kicad/help/en\n"
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1506
+#: getting_started_in_kicad.adoc:1520
 #, no-wrap
 msgid "KiCad documentation on the Web"
 msgstr "La documentation de KiCad sur l'internet"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1509
+#: getting_started_in_kicad.adoc:1523
 msgid ""
 "Latest KiCad documentations are available in multiple languages on the Web."
 msgstr ""
@@ -3686,7 +3686,7 @@ msgstr ""
 "langues sur l'internet."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1511
+#: getting_started_in_kicad.adoc:1525
 msgid "http://kicad-pcb.org/help/documentation/"
 msgstr "http://kicad-pcb.org/help/documentation/"
 

--- a/src/getting_started_in_kicad/po/it.po
+++ b/src/getting_started_in_kicad/po/it.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.1\n"
-"POT-Creation-Date: 2016-01-06 23:13+0100\n"
+"POT-Creation-Date: 2016-01-07 20:18+0100\n"
 "PO-Revision-Date: 2016-01-06 23:53+0100\n"
 "Last-Translator: Marco Ciampa <ciampix@libero.it>\n"
 "Language-Team: Italian <it@li.org>\n"
@@ -734,25 +734,33 @@ msgstr ""
 "orizzontalmente e verticalmente."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:304
+#: getting_started_in_kicad.adoc:306
 msgid ""
 "Try to hover the mouse over the component 'R' and press the r key. The "
 "component should rotate. You do not need to actually click on the component "
 "to rotate it."
-msgstr "Provare a posizionarsi con il puntatore del mouse sopra il componente 'R' e premere il tasto r. Il componente dovrebbe ruotare. Non è necessario fare clic sul componente per ruotarlo."
+msgstr ""
+"Provare a posizionarsi con il puntatore del mouse sopra il componente 'R' e "
+"premere il tasto r. Il componente dovrebbe ruotare. Non è necessario fare "
+"clic sul componente per ruotarlo."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:306
+#: getting_started_in_kicad.adoc:312
 msgid ""
 "If your mouse was also over the _Field Reference_ ('R') or the _Field Value_ "
 "('R?'), a menu will appear. You will see these 'Clarify Selection' menu "
 "often in KiCad, they allow working on objects that are on top of each other. "
 "In this case, tell KiCad you want to perform the action on the 'Component ..."
 "R...'."
-msgstr "Se il proprio mouse era anche sopra il _campo riferimento_ ('R') o il _campo valore_ ('R?'), apparirà un menu. Si osserveranno spesso questi menu 'Specifica selezione' in KiCad; essi permettono di lavorare su oggetti posizionati sopra altri. In questo caso, indicare a KiCad che si desidera eseguire l'azione sul 'Componente ...R...'."
+msgstr ""
+"Se il proprio mouse era anche sopra il _campo riferimento_ ('R') o il _campo "
+"valore_ ('R?'), apparirà un menu. Si osserveranno spesso questi menu "
+"'Specifica selezione' in KiCad; essi permettono di lavorare su oggetti "
+"posizionati sopra altri. In questo caso, indicare a KiCad che si desidera "
+"eseguire l'azione sul 'Componente ...R...'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:312
+#: getting_started_in_kicad.adoc:318
 msgid ""
 "Right click in the middle of the component and select *Edit Component* -> "
 "**Value**. You can achieve the same result by hovering over the component "
@@ -768,12 +776,12 @@ msgstr ""
 "disponibili."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:314
+#: getting_started_in_kicad.adoc:320
 msgid "image:images/edit_component_dropdown.png[Edit component menu]"
 msgstr "image:images/it/edit_component_dropdown.png[Menu modifica componente]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:317
+#: getting_started_in_kicad.adoc:323
 msgid ""
 "The Component value window will appear. Replace the current value 'R' with "
 "'1k'. Click OK."
@@ -782,7 +790,7 @@ msgstr ""
 "corrente 'R' con '1k'. Fare clic su OK."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:320
+#: getting_started_in_kicad.adoc:326
 msgid ""
 "Do not change the Reference field (R?), this will be done automatically "
 "later on. The value inside the resistor should now be '1k'."
@@ -792,12 +800,12 @@ msgstr ""
 "ora '1k'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:322
+#: getting_started_in_kicad.adoc:328
 msgid "image:images/resistor_value.png[Resistor Value]"
 msgstr "image:images/resistor_value.png[Valore resistenza]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:325
+#: getting_started_in_kicad.adoc:331
 msgid ""
 "To place another resistor, simply click where you want the resistor to "
 "appear. The Component Selection window will appear again."
@@ -806,7 +814,7 @@ msgstr ""
 "questa appaia. La finestra di selezione del componente apparirà nuovamente."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:328
+#: getting_started_in_kicad.adoc:334
 msgid ""
 "The resistor you previously chose is now in your history list, appearing as "
 "'R'. Click OK and place the component."
@@ -815,12 +823,12 @@ msgstr ""
 "cronologia, elencata come 'R'. Fare clic su OK e inserire il componente."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:330
+#: getting_started_in_kicad.adoc:336
 msgid "image:images/component_history.png[Component history]"
 msgstr "image:images/it/component_history.png[Cronologia componente]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:335
+#: getting_started_in_kicad.adoc:341
 msgid ""
 "In case you make a mistake and want to delete a component, right click on "
 "the component and click 'Delete Component'. This will remove the component "
@@ -834,7 +842,7 @@ msgstr ""
 "il tasto 'Canc'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:339
+#: getting_started_in_kicad.adoc:345
 msgid ""
 "You can edit any default shortcut key by going to *Preferences* -> *Hotkeys* "
 "-> **Edit hotkeys**. Any modification will be saved immediately."
@@ -844,7 +852,7 @@ msgstr ""
 "Qualsiasi modifica verrà salvata immediatamente."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:343
+#: getting_started_in_kicad.adoc:349
 msgid ""
 "You can also duplicate a component already on your schematic sheet by "
 "hovering over it and pressing the c key. Click where you want to place the "
@@ -855,7 +863,7 @@ msgstr ""
 "clic dove si vuole per piazzare il componente duplicato."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:349
+#: getting_started_in_kicad.adoc:355
 msgid ""
 "Right click on the second resistor. Select 'Drag Component'.  Reposition the "
 "component and left click to drop. The same functionality can be achieved by "
@@ -869,7 +877,7 @@ msgstr ""
 "componente. Il tasto x e y invertono il componente. "
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:354
+#: getting_started_in_kicad.adoc:360
 #, no-wrap
 msgid ""
 "*Right-Click* -> *Move component* (equivalent to the m key\n"
@@ -883,7 +891,7 @@ msgstr ""
 "connessi. Vedremo più avanti il perché.\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:358
+#: getting_started_in_kicad.adoc:364
 msgid ""
 "Edit the second resistor by hovering over it and pressing the v key.  "
 "Replace 'R' with '100'. You can undo any of your editing actions with the "
@@ -894,7 +902,7 @@ msgstr ""
 "qualsiasi operazione di modifica con la combinazione di tasti ctrl+z."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:364
+#: getting_started_in_kicad.adoc:370
 msgid ""
 "Change the grid size. You have probably noticed that on the schematic sheet "
 "all components are snapped onto a large pitch grid. You can easily change "
@@ -909,33 +917,46 @@ msgstr ""
 "elettrico__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:366
+#: getting_started_in_kicad.adoc:374
 msgid ""
 "We are going to add a component from a library that isn't configured in the "
 "default project. In the menu, choose *Preferences* -> **Component "
 "Libraries** and click the **Add** button for **Component library files**."
-msgstr "Stiamo per aggiungere un componente da una libreria che non è configurata nel progetto predefinito. Nel menu, scegliere *Preferenze* -> **Librerie componenti** e fare clic sul pulsante **Aggiungi** di **File librerie componenti**."
+msgstr ""
+"Stiamo per aggiungere un componente da una libreria che non è configurata "
+"nel progetto predefinito. Nel menu, scegliere *Preferenze* -> **Librerie "
+"componenti** e fare clic sul pulsante **Aggiungi** di **File librerie "
+"componenti**."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:368
+#: getting_started_in_kicad.adoc:380
 msgid ""
 "You need to find where the official KiCad libraries are installed on your "
 "computer. Look for a `library` directory containing a hundred of `.dcm` and "
 "`.lib` files. Try in `C:\\Program Files (x86)\\KiCad\\share\\` (Windows) and "
 "`/usr/share/kicad/library/` (Linux). When you have found the directory, "
 "choose and add the 'microchip_pic12mcu' library and close the window."
-msgstr "È necessario trovare dove sono installate le librerie ufficiali di KiCad nel proprio computer. Cercare una cartella `library` contenente un centinaio di file `.dcm` e `.lib`. Provare in `C:\\Program Files (x86)\\KiCad\\share\\` (Windows) e `/usr/share/kicad/library/` (Linux). Una volta trovata la cartella, scegliere e aggiungere la libreria 'microchip_pic12mcu' e chiudere la finestra."
+msgstr ""
+"È necessario trovare dove sono installate le librerie ufficiali di KiCad nel "
+"proprio computer. Cercare una cartella `library` contenente un centinaio di "
+"file `.dcm` e `.lib`. Provare in `C:\\Program Files (x86)\\KiCad\\share\\` "
+"(Windows) e `/usr/share/kicad/library/` (Linux). Una volta trovata la "
+"cartella, scegliere e aggiungere la libreria 'microchip_pic12mcu' e chiudere "
+"la finestra."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:372
+#: getting_started_in_kicad.adoc:384
 msgid ""
 "Repeat the add-component steps, however this time select the "
 "'microchip_pic12mcu' library instead of the 'device' library and pick the "
 "'PIC12C508A-I/SN' component."
-msgstr "Ripetere i passi di aggiunta di componenti, questa volta scegliendo la libreria 'microchip_pic12mcu' invece della 'device' e prelevare il componente 'PIC12C508A-I/SN' da essa."
+msgstr ""
+"Ripetere i passi di aggiunta di componenti, questa volta scegliendo la "
+"libreria 'microchip_pic12mcu' invece della 'device' e prelevare il "
+"componente 'PIC12C508A-I/SN' da essa."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:377
+#: getting_started_in_kicad.adoc:389
 msgid ""
 "Hover the mouse over the microcontroller component. Press the y key or the x "
 "key on the keyboard. Notice how the component is flipped over its x axis or "
@@ -947,7 +968,7 @@ msgstr ""
 "originale."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:380
+#: getting_started_in_kicad.adoc:392
 msgid ""
 "Repeat the add-component steps, this time choosing the 'device' library and "
 "picking the 'LED' component from it."
@@ -956,18 +977,18 @@ msgstr ""
 "libreria 'device' e prelevando il componente 'LED' da essa."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:382
+#: getting_started_in_kicad.adoc:394
 msgid "Organise all components on your schematic sheet as shown below."
 msgstr "Ordinare tutti componenti sullo schema come mostrato in basso."
 
 # TOTR
 #. type: Plain text
-#: getting_started_in_kicad.adoc:384
+#: getting_started_in_kicad.adoc:396
 msgid "image:images/gsik_tutorial1_010.png[gsik_tutorial1_010_png]"
 msgstr "image:images/gsik_tutorial1_010.png[gsik_tutorial1_010_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:390
+#: getting_started_in_kicad.adoc:402
 msgid ""
 "We now need to create the schematic component 'MYCONN3' for our 3-pin "
 "connector. You can jump to the section titled <<make-schematic-components-in-"
@@ -982,7 +1003,7 @@ msgstr ""
 "sezione per continuare con la scheda."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:393
+#: getting_started_in_kicad.adoc:405
 msgid ""
 "You can now place the freshly made component. Press the 'a' key and pick the "
 "'MYCONN3' component in the 'myLib' library."
@@ -991,7 +1012,7 @@ msgstr ""
 "``a'' e prelevare il componente 'MYCONN3' nella libreria 'mylib'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:399
+#: getting_started_in_kicad.adoc:411
 msgid ""
 "The component identifier 'J?' will appear under the 'MYCONN3' label.  If you "
 "want to change its position, right click on 'J?' and click on 'Move "
@@ -1008,12 +1029,12 @@ msgstr ""
 
 # TOTR
 #. type: Plain text
-#: getting_started_in_kicad.adoc:401
+#: getting_started_in_kicad.adoc:413
 msgid "image:images/gsik_myconn3_s.png[gsik_myconn3_s_png]"
 msgstr "image:images/gsik_myconn3_s.png[gsik_myconn3_s_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:407
+#: getting_started_in_kicad.adoc:419
 msgid ""
 "It is time to place the power and ground symbols. Click on the 'Place a "
 "power port' button image:images/icons/add_power.png[add_power_png] on the "
@@ -1028,7 +1049,7 @@ msgstr ""
 "Fare clic su OK."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:413
+#: getting_started_in_kicad.adoc:425
 msgid ""
 "Click above the pin of the 1k resistor to place the VCC part. Click on the "
 "area above the microcontroller 'VDD'. In the 'Component Selection history' "
@@ -1042,7 +1063,7 @@ msgstr ""
 "pin VCC di 'MYCONN3'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:418
+#: getting_started_in_kicad.adoc:430
 msgid ""
 "Repeat the add-pin steps but this time select the GND part. Place a GND part "
 "under the GND pin of 'MYCONN3'. Place another GND symbol on the right of the "
@@ -1056,12 +1077,12 @@ msgstr ""
 
 # TOTR
 #. type: Plain text
-#: getting_started_in_kicad.adoc:420
+#: getting_started_in_kicad.adoc:432
 msgid "image:images/gsik_tutorial1_020.png[gsik_tutorial1_020_png]"
 msgstr "image:images/gsik_tutorial1_020.png[gsik_tutorial1_020_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:424
+#: getting_started_in_kicad.adoc:436
 msgid ""
 "Next, we will wire all our components. Click on the 'Place wire' icon image:"
 "images/icons/add_line.png[Place wire] on the right toolbar."
@@ -1071,7 +1092,7 @@ msgstr ""
 "filo] sulla barra strumenti a destra."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:429
+#: getting_started_in_kicad.adoc:441
 msgid ""
 "Be careful not to pick 'Place a bus', which appears directly beneath this "
 "button but has thicker lines. The section <<bus-connections-in-kicad,Bus "
@@ -1082,7 +1103,7 @@ msgstr ""
 "connessioni bus in KiCad>> descrive come usare la selezione bus."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:433
+#: getting_started_in_kicad.adoc:445
 msgid ""
 "Click on the little circle at the end of pin 7 of the microcontroller and "
 "then click on the little circle on pin 2 of the LED.  You can zoom in while "
@@ -1093,7 +1114,7 @@ msgstr ""
 "si instaurano le connessioni."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:438
+#: getting_started_in_kicad.adoc:450
 msgid ""
 "If you want to reposition wired components, it is important to use the g key "
 "(grab) option and not the m key (move) option. Using the grab option will "
@@ -1107,12 +1128,12 @@ msgstr ""
 
 # TOTR
 #. type: Plain text
-#: getting_started_in_kicad.adoc:440
+#: getting_started_in_kicad.adoc:452
 msgid "image:images/gsik_tutorial1_030.png[gsik_tutorial1_030_png]"
 msgstr "image:images/gsik_tutorial1_030.png[gsik_tutorial1_030_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:446
+#: getting_started_in_kicad.adoc:458
 msgid ""
 "Repeat this process and wire up all the other components as shown below. To "
 "terminate a wire just double-click. When wiring up the VCC and GND symbols, "
@@ -1127,12 +1148,12 @@ msgstr ""
 
 # TOTR
 #. type: Plain text
-#: getting_started_in_kicad.adoc:448
+#: getting_started_in_kicad.adoc:460
 msgid "image:images/gsik_tutorial1_040.png[gsik_tutorial1_040_png]"
 msgstr "image:images/gsik_tutorial1_040.png[gsik_tutorial1_040_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:453
+#: getting_started_in_kicad.adoc:465
 msgid ""
 "We will now consider an alternative way of making a connection using labels. "
 "Pick a net labelling tool by clicking on the 'Place net name' icon image:"
@@ -1146,7 +1167,7 @@ msgstr ""
 "tasto 'l'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:456
+#: getting_started_in_kicad.adoc:468
 msgid ""
 "Click in the middle of the wire connected to pin 6 of the microcontroller. "
 "Name this label 'INPUT'."
@@ -1155,7 +1176,7 @@ msgstr ""
 "Chiamare questa etichetta 'INPUT'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:465
+#: getting_started_in_kicad.adoc:477
 msgid ""
 "Follow the same procedure and place another label on line on the right of "
 "the 100 ohm resistor. Also name it 'INPUT'. The two labels, having the same "
@@ -1174,7 +1195,7 @@ msgstr ""
 "filo, si può anche collegare direttamente ad un pin."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:471
+#: getting_started_in_kicad.adoc:483
 msgid ""
 "Labels can also be used to simply label wires for informative purposes. "
 "Place a label on pin 7 of the PIC. Enter the name 'uCtoLED'.  Name the wire "
@@ -1188,7 +1209,7 @@ msgstr ""
 "'INPUTtoR'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:474
+#: getting_started_in_kicad.adoc:486
 msgid ""
 "You do not have to label the VCC and GND lines because the labels are "
 "implied from the power objects they are connected to."
@@ -1197,18 +1218,18 @@ msgstr ""
 "implicitamente dall'oggetto alimentazione a cui sono connesse."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:476
+#: getting_started_in_kicad.adoc:488
 msgid "Below you can see what the final result should look like."
 msgstr "Sotto si può osservare come dovrebbe apparire il risultato finale."
 
 # TOTR
 #. type: Plain text
-#: getting_started_in_kicad.adoc:478
+#: getting_started_in_kicad.adoc:490
 msgid "image:images/gsik_tutorial1_050.png[gsik_tutorial1_050_png]"
 msgstr "image:images/gsik_tutorial1_050.png[gsik_tutorial1_050_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:484
+#: getting_started_in_kicad.adoc:496
 msgid ""
 "Let's now deal with unconnected wires. Any pin or wire that is not connected "
 "will generate a warning when checked by KiCad. To avoid these warnings you "
@@ -1222,7 +1243,7 @@ msgstr ""
 "o pin come non connessi."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:489
+#: getting_started_in_kicad.adoc:501
 msgid ""
 "Click on the 'Place no connect flag' icon image:images/icons/noconn."
 "png[noconn_png] on the right toolbar. Click on pins 2, 3, 4 and 5. An X will "
@@ -1235,12 +1256,12 @@ msgstr ""
 
 # TOTR
 #. type: Plain text
-#: getting_started_in_kicad.adoc:491
+#: getting_started_in_kicad.adoc:503
 msgid "image:images/gsik_tutorial1_060.png[gsik_tutorial1_060_png]"
 msgstr "image:images/gsik_tutorial1_060.png[gsik_tutorial1_060_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:498
+#: getting_started_in_kicad.adoc:510
 msgid ""
 "Some components have power pins that are invisible. You can make them "
 "visible by clicking on the 'Show hidden pins' icon image:images/icons/"
@@ -1256,7 +1277,7 @@ msgstr ""
 "invisibili i pin di alimentazione."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:504
+#: getting_started_in_kicad.adoc:516
 msgid ""
 "It is now necessary to add a 'Power Flag' to indicate to KiCad that power "
 "comes in from somewhere. Press the a key, select 'List All', double click on "
@@ -1271,12 +1292,12 @@ msgstr ""
 
 # TOTR
 #. type: Plain text
-#: getting_started_in_kicad.adoc:506
+#: getting_started_in_kicad.adoc:518
 msgid "image:images/gsik_tutorial1_070.png[gsik_tutorial1_070_png]"
 msgstr "image:images/gsik_tutorial1_070.png[gsik_tutorial1_070_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:509
+#: getting_started_in_kicad.adoc:521
 msgid ""
 "This will avoid the classic schematic checking warning: Warning Pin power_in "
 "not driven (Net xx)"
@@ -1285,7 +1306,7 @@ msgstr ""
 "il pin power_in non è pilotato (Net xx)"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:513
+#: getting_started_in_kicad.adoc:525
 msgid ""
 "Sometimes it is good to write comments here and there. To add comments on "
 "the schematic use the 'Place graphic text (comment)' icon image:images/icons/"
@@ -1296,16 +1317,21 @@ msgstr ""
 "icons/add_text.png[add_text_png] sulla barra strumenti di destra."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:518
+#: getting_started_in_kicad.adoc:531
 msgid ""
 "All components now need to have unique identifiers. In fact, many of our "
 "components are still named 'R?' or 'J?'. Identifier assignation can be done "
 "automatically by clicking on the 'Annotate schematic' icon image:images/"
 "icons/annotate.png[annotate_png] on the top toolbar."
-msgstr "Tutti i componenti ora necessitano di avere degli identificatori univoci. In effetti, molti componenti del nostro esempio si chiamano ancora 'R?' o 'J?'. L'assegnazione degli identificatori può essere effettuata automaticamente facendo clic sull'icona del pulsante 'Annota schema' image:images/icons/annotate.png[annotate_png] sulla barra in cima."
+msgstr ""
+"Tutti i componenti ora necessitano di avere degli identificatori univoci. In "
+"effetti, molti componenti del nostro esempio si chiamano ancora 'R?' o 'J?'. "
+"L'assegnazione degli identificatori può essere effettuata automaticamente "
+"facendo clic sull'icona del pulsante 'Annota schema' image:images/icons/"
+"annotate.png[annotate_png] sulla barra in cima."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:525
+#: getting_started_in_kicad.adoc:538
 msgid ""
 "In the Annotate Schematic window, select 'Use the entire schematic' and "
 "click on the 'Annotation' button. Click OK in the confirmation message and "
@@ -1320,7 +1346,7 @@ msgstr ""
 "'R1', 'R2', 'U1' e 'J1'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:535
+#: getting_started_in_kicad.adoc:547
 msgid ""
 "We will now check our schematic for errors. Click on the 'Perform electrical "
 "rules check' icon image:images/icons/erc.png[erc_png] on the top toolbar. "
@@ -1330,27 +1356,44 @@ msgid ""
 "the schematic in the position where the error or the warning is located. "
 "Check 'Create ERC file report' and press the 'Run' button again to receive "
 "more information about the errors."
-msgstr "Ora controlleremo in nostro schema in cerca di errori. Fare clic sull'icona 'Esegui controllo regole elettriche' image:images/icons/erc.png[erc_png] sulla barra strumenti in cima. Fare clic sul pulsante 'Esegui'. Verrà generato un rapporto di informazione su errori o avvisi come per esempio per fili sconnessi. Dovremmo ottenere 0 errori e 0 avvisi. In caso di errori o avvisi, apparirà sullo schema una piccola freccia verde nella posizione dove è stato rilevato l'errore o l'avviso. Spuntare 'Crea file di rapporto ERC' e premere nuovamente il pulsante 'Esegui' per ricevere ulteriori informazioni sui problemi rilevati."
+msgstr ""
+"Ora controlleremo in nostro schema in cerca di errori. Fare clic sull'icona "
+"'Esegui controllo regole elettriche' image:images/icons/erc.png[erc_png] "
+"sulla barra strumenti in cima. Fare clic sul pulsante 'Esegui'. Verrà "
+"generato un rapporto di informazione su errori o avvisi come per esempio per "
+"fili sconnessi. Dovremmo ottenere 0 errori e 0 avvisi. In caso di errori o "
+"avvisi, apparirà sullo schema una piccola freccia verde nella posizione dove "
+"è stato rilevato l'errore o l'avviso. Spuntare 'Crea file di rapporto ERC' e "
+"premere nuovamente il pulsante 'Esegui' per ricevere ulteriori informazioni "
+"sui problemi rilevati."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:537
+#: getting_started_in_kicad.adoc:551
 msgid ""
 "If you have a warning with \"No default editor found you must choose it\", "
 "try setting the path to `c:\\windows\\notepad.exe` (windows) or `/usr/bin/"
 "gedit` (Linux)."
-msgstr "Se compare avvertimento che riporta \"Nessun editor predefinito trovato, sceglierne uno\", provare a impostare il percorso a `c:\\windows\\notepad.exe` (windows) o `/usr/bin/gedit` (Linux)."
+msgstr ""
+"Se compare avvertimento che riporta \"Nessun editor predefinito trovato, "
+"sceglierne uno\", provare a impostare il percorso a `c:\\windows\\notepad."
+"exe` (windows) o `/usr/bin/gedit` (Linux)."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:542
+#: getting_started_in_kicad.adoc:556
 msgid ""
 "The schematic is now finished. We can now create a Netlist file to which we "
 "will add the footprint of each component. Click on the 'Generate netlist' "
 "icon image:images/icons/netlist.png[netlist_png] on the top toolbar. Click "
 "on the 'Generate' button and save under the default file name."
-msgstr "Lo schema ora è finito. Possiamo ora creare un file netlist al quale aggiungeremo un'impronta ad ogni componente. Fare clic sull'icona 'Generazione netlist' image:images/icons/netlist.png[netlist_png] sulla barra strumenti in alto. Fare clic su 'Genera' e poi salvare con il nome file predefinito."
+msgstr ""
+"Lo schema ora è finito. Possiamo ora creare un file netlist al quale "
+"aggiungeremo un'impronta ad ogni componente. Fare clic sull'icona "
+"'Generazione netlist' image:images/icons/netlist.png[netlist_png] sulla "
+"barra strumenti in alto. Fare clic su 'Genera' e poi salvare con il nome "
+"file predefinito."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:547
+#: getting_started_in_kicad.adoc:561
 msgid ""
 "After generating the Netlist file, click on the 'Run Cvpcb' icon image:"
 "images/icons/cvpcb.png[cvpcb_png] on the top toolbar. If a missing file "
@@ -1362,7 +1405,7 @@ msgstr ""
 "premere OK."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:553
+#: getting_started_in_kicad.adoc:567
 msgid ""
 "_Cvpcb_ allows you to link all the components in your schematic with "
 "footprints in the KiCad library. The pane on the center shows all the "
@@ -1377,12 +1420,12 @@ msgstr ""
 "LED-5MM' e fare doppio clic su di esso."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:555
+#: getting_started_in_kicad.adoc:569
 msgid "image:images/icons/cvpcb.png[cvpcb_png]"
 msgstr "image:images/icons/cvpcb.png[cvpcb_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:563
+#: getting_started_in_kicad.adoc:577
 msgid ""
 "It is possible that the pane on the right shows only a selected subgroup of "
 "available footprints. This is because KiCad is trying to suggest to you a "
@@ -1401,7 +1444,7 @@ msgstr ""
 "disabilitare questi filtri."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:567
+#: getting_started_in_kicad.adoc:581
 msgid ""
 "For 'IC1' select the 'Housings_DIP:DIP-8_W7.62mm' footprint.  For 'J1' "
 "select the 'Connect:Banana_Jack_3Pin' footprint.  For 'R1' and 'R2' select "
@@ -1412,7 +1455,7 @@ msgstr ""
 "selezionare l'impronta 'Discret:R1'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:578
+#: getting_started_in_kicad.adoc:592
 msgid ""
 "If you are interested in knowing what the footprint you are choosing looks "
 "like, you have two options. You can click on the 'View selected footprint' "
@@ -1433,7 +1476,7 @@ msgstr ""
 "dimensioni corrispondano."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:587
+#: getting_started_in_kicad.adoc:601
 msgid ""
 "You are done. You can now update your netlist file with all the associated "
 "footprints. Click on *File* -> **Save As**. The default name 'tutorial1.net' "
@@ -1452,7 +1495,7 @@ msgstr ""
 "Quest'operazione sarà spiegata in una sezione successiva di questo documento."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:591
+#: getting_started_in_kicad.adoc:605
 msgid ""
 "You can close _Cvpcb_ and go back to the _Eeschema_ schematic editor. Save "
 "the project by clicking on *File* -> **Save Whole Schematic Project**. Close "
@@ -1463,12 +1506,12 @@ msgstr ""
 "progetto**. Chiudere l'editor dello schema elettrico."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:593
+#: getting_started_in_kicad.adoc:607
 msgid "Switch to the KiCad project manager."
 msgstr "Passare al gestore del progetto KiCad."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:597
+#: getting_started_in_kicad.adoc:611
 msgid ""
 "The netlist file describes all components and their respective pin "
 "connections. The netlist file is actually a text file that you can easily "
@@ -1479,7 +1522,7 @@ msgstr ""
 "facilmente ispezionabile, modificabile anche con uno script."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:600
+#: getting_started_in_kicad.adoc:614
 msgid ""
 "Library files (__*.lib__) are text files too and they are also easily "
 "editable or scriptable."
@@ -1488,7 +1531,7 @@ msgstr ""
 "facilmente modificabili a mano o con script."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:607
+#: getting_started_in_kicad.adoc:621
 msgid ""
 "To create a Bill Of Materials (BOM), go to the _Eeschema_ schematic editor "
 "and click on the 'Bill of materials' icon image:images/icons/bom."
@@ -1504,7 +1547,7 @@ msgstr ""
 "file *.xsl che si vuole usare, in questo caso selezioneremo, __bom2csv.xsl__."
 
 #. type: delimited block =
-#: getting_started_in_kicad.adoc:612
+#: getting_started_in_kicad.adoc:626
 msgid ""
 "The *.xsl file is located in __plugins__ directory of the KiCad "
 "installation, which is located at: /usr/lib/kicad/plugins/."
@@ -1513,47 +1556,47 @@ msgstr ""
 "KiCad, è posizionata in: /usr/lib/kicad/plugins/."
 
 #. type: delimited block =
-#: getting_started_in_kicad.adoc:614
+#: getting_started_in_kicad.adoc:628
 msgid "Or get the file via:"
 msgstr "O ottenere il file attraverso:"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:616
+#: getting_started_in_kicad.adoc:630
 #, no-wrap
 msgid "wget https://raw.githubusercontent.com/KiCad/kicad-source-mirror/master/eeschema/plugins/bom2csv.xsl\n"
 msgstr "wget https://raw.githubusercontent.com/KiCad/kicad-source-mirror/master/eeschema/plugins/bom2csv.xsl\n"
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:619
+#: getting_started_in_kicad.adoc:633
 #, no-wrap
 msgid "KiCad automatically generates the command, for example:"
 msgstr "KiCad genera automaticamente il comando, per esempio:"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:622
+#: getting_started_in_kicad.adoc:636
 #, no-wrap
 msgid "xsltproc -o \"%O\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 msgstr "xsltproc -o \"%O\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:624
+#: getting_started_in_kicad.adoc:638
 #, no-wrap
 msgid "You may want to add the extension, so change this command line to:"
 msgstr "Si potrebbe voler aggiungere l'estensione, in modo da cambiare questa linea di comando in:"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:627
+#: getting_started_in_kicad.adoc:641
 #, no-wrap
 msgid "xsltproc -o \"%O.csv\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 msgstr "xsltproc -o \"%O.csv\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:630
+#: getting_started_in_kicad.adoc:644
 msgid "Press Help button for more info."
 msgstr "Premere il tasto di Aiuto per ulteriori informazioni."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:634
+#: getting_started_in_kicad.adoc:648
 msgid ""
 "Now press 'Generate'. The file (same name as your project) is located in "
 "your project folder.  Open the **.csv* file with LibreOffice Calc or Excel. "
@@ -1564,7 +1607,7 @@ msgstr ""
 "LibreOffice Calc o Excel. Apparirà una finestra di importazione, premere OK."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:638
+#: getting_started_in_kicad.adoc:652
 msgid ""
 "You are now ready to move to the PCB layout part, which is presented in the "
 "next section. However, before moving on let's take a quick look at how to "
@@ -1576,13 +1619,13 @@ msgstr ""
 "componenti usando le linee bus."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:640
+#: getting_started_in_kicad.adoc:654
 #, no-wrap
 msgid "Bus connections in KiCad"
 msgstr "Connessioni Bus in KiCad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:646
+#: getting_started_in_kicad.adoc:660
 msgid ""
 "Sometimes you might need to connect several sequential pins of component A "
 "with some other sequential pins of component B. In this case you have two "
@@ -1595,7 +1638,7 @@ msgstr ""
 "connessione bus. Vediamo come si fa."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:653
+#: getting_started_in_kicad.adoc:667
 msgid ""
 "Let us suppose that you have three 4-pin connectors that you want to connect "
 "together pin to pin. Use the label option (press the l key) to label pin 4 "
@@ -1610,7 +1653,7 @@ msgstr ""
 "(pin 3). Si noti come l'etichetta viene automaticamente rinominata 'a2'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:657
+#: getting_started_in_kicad.adoc:671
 msgid ""
 "Press the Ins Key two more times. The Ins key corresponds to the action "
 "'Repeat last item' and it is an infinitely useful command that can make your "
@@ -1621,7 +1664,7 @@ msgstr ""
 "poco la vita."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:668
+#: getting_started_in_kicad.adoc:682
 msgid ""
 "Repeat the same labelling action on the two other connectors CONN_2 and "
 "CONN_3 and you are done. If you proceed and make a PCB you will see that the "
@@ -1643,7 +1686,7 @@ msgstr ""
 "saranno effetti sul circuito stampato."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:672
+#: getting_started_in_kicad.adoc:686
 msgid ""
 "It should be pointed out that the short wire attached to the pins in Figure "
 "2 is not strictly necessary. In fact, the labels could have been applied "
@@ -1654,7 +1697,7 @@ msgstr ""
 "applicare direttamente ai pin."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:679
+#: getting_started_in_kicad.adoc:693
 msgid ""
 "Let's take it one step further and suppose that you have a fourth connector "
 "named CONN_4 and, for whatever reason, its labelling happens to be a little "
@@ -1671,7 +1714,7 @@ msgstr ""
 "con un'etichetta per bus."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:686
+#: getting_started_in_kicad.adoc:700
 msgid ""
 "Connect and label CONN_4 using the labelling method explained before. Name "
 "the pins b1, b2, b3 and b4. Connect the pin to a series of 'Wire to bus "
@@ -1686,7 +1729,7 @@ msgstr ""
 "image:images/icons/add_bus.png[aggiungi bus]. Vedere figura 4."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:689
+#: getting_started_in_kicad.adoc:703
 msgid ""
 "Put a label (press the l key option) on the bus of CONN_4 and name it "
 "'b[1..4]'."
@@ -1695,7 +1738,7 @@ msgstr ""
 "'b[1..4]'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:692
+#: getting_started_in_kicad.adoc:706
 msgid ""
 "Put a label (press the l key option) on the previous a bus and name it "
 "'a[1..4]'."
@@ -1704,7 +1747,7 @@ msgstr ""
 "'a[1..4]'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:695
+#: getting_started_in_kicad.adoc:709
 msgid ""
 "What we can now do is connect bus a[1..4] with bus b[1..4] using a bus line "
 "with the button image:images/icons/add_bus.png[add_bus_png]."
@@ -1714,7 +1757,7 @@ msgstr ""
 "png[aggiungi un bus]."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:699
+#: getting_started_in_kicad.adoc:713
 msgid ""
 "By connecting the two buses together, pin a1 will be automatically connected "
 "to pin b1, a2 will be connected to b2 and so on. Figure 4 shows what the "
@@ -1725,7 +1768,7 @@ msgstr ""
 "risultato finale."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:704
+#: getting_started_in_kicad.adoc:718
 msgid ""
 "The 'Repeat last item' option accessible via the Ins key can be successfully "
 "used to repeat period item insertions. For instance, the short wires "
@@ -1738,7 +1781,7 @@ msgstr ""
 "stati piazzati con questo comando."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:708
+#: getting_started_in_kicad.adoc:722
 msgid ""
 "The 'Repeat last item' option accessible via the Ins key has also been "
 "extensively used to place the many series of 'Wire to bus entry' using the "
@@ -1750,18 +1793,18 @@ msgstr ""
 
 # TOTR
 #. type: Plain text
-#: getting_started_in_kicad.adoc:710
+#: getting_started_in_kicad.adoc:724
 msgid "image:images/gsik_bus_connection.png[gsik_bus_connection_png]"
 msgstr "image:images/gsik_bus_connection.png[gsik_bus_connection_png]"
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:712
+#: getting_started_in_kicad.adoc:726
 #, no-wrap
 msgid "Layout printed circuit boards"
 msgstr "Progettazione circuiti stampati"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:716
+#: getting_started_in_kicad.adoc:730
 msgid ""
 "It is now time to use the netlist file you generated to lay out the PCB.  "
 "This is done with the _Pcbnew_ tool."
@@ -1771,13 +1814,13 @@ msgstr ""
 "strumento __Pcbnew__."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:718
+#: getting_started_in_kicad.adoc:732
 #, no-wrap
 msgid "Using Pcbnew"
 msgstr "Usare Pcbnew"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:724
+#: getting_started_in_kicad.adoc:738
 msgid ""
 "From the KiCad project manager, click on the 'Pcbnew' icon image:images/"
 "icons/pcbnew.png[pcbnew_png]. The 'Pcbnew' window will open. If you get an "
@@ -1790,7 +1833,7 @@ msgstr ""
 "chiede se lo si vuole creare, fare clic su 'Si'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:728
+#: getting_started_in_kicad.adoc:742
 msgid ""
 "Begin by entering some schematic information. Click on the 'Page settings' "
 "icon image:images/icons/sheetset.png[sheetset_png] on the top toolbar. Set "
@@ -1803,7 +1846,7 @@ msgstr ""
 
 # TO CHECK FOR ORIGINAL
 #. type: Plain text
-#: getting_started_in_kicad.adoc:737
+#: getting_started_in_kicad.adoc:751
 msgid ""
 "It is a good idea to start by setting the *clearance* and the *minimum track "
 "width* to those required by your PCB manufacturer. In general you can set "
@@ -1823,13 +1866,13 @@ msgstr ""
 "mostrato sotto. Le misure qua sono in mm."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:739
+#: getting_started_in_kicad.adoc:753
 msgid "image:images/design_rules.png[Design Rules Window]"
 msgstr ""
 "image:images/it/design_rules.png[Finestra delle regole di progettazione]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:743
+#: getting_started_in_kicad.adoc:757
 msgid ""
 "Click on the 'Global Design Rules' tab and set 'Min track width' to 0.25'. "
 "Click the OK button to commit your changes and close the Design Rules Editor "
@@ -1841,7 +1884,7 @@ msgstr ""
 "progettazione."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:749
+#: getting_started_in_kicad.adoc:763
 msgid ""
 "Now we will import the netlist file. Click on the 'Read Netlist' icon image:"
 "images/icons/netlist.png[netlist_png] on the top toolbar. Click on the "
@@ -1855,7 +1898,7 @@ msgstr ""
 "premere il tasto 'Chiudi'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:752
+#: getting_started_in_kicad.adoc:766
 msgid ""
 "All components should now be visible in the top left hand corner just above "
 "the page. Scroll up if you cannot see them."
@@ -1864,7 +1907,7 @@ msgstr ""
 "sinistra appena sopra la pagina. Scorrere se non si vedono."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:756
+#: getting_started_in_kicad.adoc:770
 msgid ""
 "Select all components with the mouse and move them to the middle of the "
 "board. If necessary you can zoom in and out while you move the components."
@@ -1874,7 +1917,7 @@ msgstr ""
 "si spostano i componenti."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:762
+#: getting_started_in_kicad.adoc:776
 msgid ""
 "All components are connected via a thin group of wires called __ratsnest__. "
 "Make sure that the 'Hide board ratsnest' button image:images/icons/"
@@ -1888,7 +1931,7 @@ msgstr ""
 "collegamenti tra tutti i componenti."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:765
+#: getting_started_in_kicad.adoc:779
 msgid ""
 "The tool-tip is backwards; pressing this button actually displays the "
 "ratsnest."
@@ -1897,7 +1940,7 @@ msgstr ""
 "premendo il pulsante."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:769
+#: getting_started_in_kicad.adoc:783
 msgid ""
 "You can move each component by hovering over it and pressing the g key. "
 "Click where you want to place them. Move all components around until you "
@@ -1909,7 +1952,7 @@ msgstr ""
 "fili."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:774
+#: getting_started_in_kicad.adoc:788
 msgid ""
 "If instead of grabbing the components (with the g key ) you move them around "
 "using the m key you will later note that you lose the track connection (the "
@@ -1923,12 +1966,12 @@ msgstr ""
 
 # TOTR
 #. type: Plain text
-#: getting_started_in_kicad.adoc:776
+#: getting_started_in_kicad.adoc:790
 msgid "image:images/gsik_tutorial1_080.png[gsik_tutorial1_080_png]"
 msgstr "image:images/gsik_tutorial1_080.png[gsik_tutorial1_080_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:783
+#: getting_started_in_kicad.adoc:797
 msgid ""
 "If the ratsnest disappears or the screen gets messy, right click and click "
 "'Redraw view'. Note how one pin of the 100 ohm resistor is connected to pin "
@@ -1943,7 +1986,7 @@ msgstr ""
 "ai fili perché rendono lo schema elettrico meno disordinato."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:791
+#: getting_started_in_kicad.adoc:805
 msgid ""
 "Now we will define the edge of the PCB. Select 'Edge.Cuts' from the drop "
 "down menu in the top toolbar. Click on the 'Add graphic line or polygon' "
@@ -1961,7 +2004,7 @@ msgstr ""
 "stampato."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:795
+#: getting_started_in_kicad.adoc:809
 msgid ""
 "Next, connect up all the wires except GND. In fact, we will connect all GND "
 "connections in one go using a ground plane placed on the bottom copper "
@@ -1972,7 +2015,7 @@ msgstr ""
 "piazzato sullo strato rame inferiore (chiamato __B.Cu__) sulla scheda."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:799
+#: getting_started_in_kicad.adoc:813
 msgid ""
 "Now we must choose which copper layer we want to work on. Select 'F.Cu "
 "(PgUp)' in the drag down menu on the top toolbar. This is the front top "
@@ -1984,13 +2027,13 @@ msgstr ""
 
 # TOTR
 #. type: Plain text
-#: getting_started_in_kicad.adoc:801
+#: getting_started_in_kicad.adoc:815
 msgid "image:images/select_top_copper.png[Select the Front top copper layer]"
 msgstr ""
 "image:images/select_top_copper.png[Selezione dello strato rame superiore]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:807
+#: getting_started_in_kicad.adoc:821
 msgid ""
 "If you decide, for instance, to do a 4 layer PCB instead, go to *Design "
 "Rules* -> *Layers Setup* and change 'Copper Layers' to 4. In the 'Layers' "
@@ -2006,7 +2049,7 @@ msgstr ""
 "menu 'Raggruppamento predefinito strati'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:815
+#: getting_started_in_kicad.adoc:829
 msgid ""
 "Click on the 'Add Tracks and vias' icon image:images/icons/add_tracks."
 "png[add_tracks_png] on the right toolbar. Click on pin 1 of 'J1' and run a "
@@ -2025,12 +2068,12 @@ msgstr ""
 
 # TOTR
 #. type: Plain text
-#: getting_started_in_kicad.adoc:817
+#: getting_started_in_kicad.adoc:831
 msgid "image:images/pcbnew_1.png[pcbnew_1_png]"
 msgstr "image:images/pcbnew_1.png[pcbnew_1_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:823
+#: getting_started_in_kicad.adoc:837
 msgid ""
 "If you would like to add more track widths go to: *Design Rules* -> *Design "
 "Rules* -> *Global Design Rules* tab and at the bottom right of this window "
@@ -2047,12 +2090,12 @@ msgstr ""
 
 # TOTR
 #. type: Plain text
-#: getting_started_in_kicad.adoc:825
+#: getting_started_in_kicad.adoc:839
 msgid "image:images/custom_tracks_width.png[custom_tracks_width_png]"
 msgstr "image:images/custom_tracks_width.png[custom_tracks_width_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:832
+#: getting_started_in_kicad.adoc:846
 msgid ""
 "Alternatively, you can add a Net Class in which you specify a set of "
 "options. Go to *Design Rules* -> *Design Rules* -> *Net Classes Editor* and "
@@ -2070,7 +2113,7 @@ msgstr ""
 "destra e usare le frecce)."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:836
+#: getting_started_in_kicad.adoc:850
 msgid ""
 "If you want to change the grid size, *Right click* -> **Grid Select**. Be "
 "sure to select the appropriate grid size before or after laying down the "
@@ -2082,7 +2125,7 @@ msgstr ""
 "piste."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:839
+#: getting_started_in_kicad.adoc:853
 msgid ""
 "Repeat this process until all wires, except pin 3 of J1, are connected. Your "
 "board should look like the example below."
@@ -2093,12 +2136,12 @@ msgstr ""
 
 # TOTR
 #. type: Plain text
-#: getting_started_in_kicad.adoc:841
+#: getting_started_in_kicad.adoc:855
 msgid "image:images/gsik_tutorial1_090.png[gsik_tutorial1_090_png]"
 msgstr "image:images/gsik_tutorial1_090.png[gsik_tutorial1_090_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:849
+#: getting_started_in_kicad.adoc:863
 msgid ""
 "Let's now run a track on the other copper side of the PCB. Select 'B.Cu' in "
 "the drag down menu on the top toolbar. Click on the 'Add tracks and vias' "
@@ -2115,7 +2158,7 @@ msgstr ""
 "come è cambiato il colore della pista."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:856
+#: getting_started_in_kicad.adoc:870
 #, no-wrap
 msgid ""
 "**Go from pin A to pin B by changing layer**. It is possible to\n"
@@ -2134,13 +2177,13 @@ msgstr ""
 
 # TOTR
 #. type: Plain text
-#: getting_started_in_kicad.adoc:858
+#: getting_started_in_kicad.adoc:872
 #, no-wrap
 msgid "image:images/place_a_via.png[place_a_via_png]\n"
 msgstr "image:images/place_a_via.png[place_a_via_png]\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:864
+#: getting_started_in_kicad.adoc:878
 msgid ""
 "When you want to inspect a particular connection you can click on the 'Net "
 "highlight' icon image:images/icons/net_highlight.png[net_highlight_png] on "
@@ -2153,7 +2196,7 @@ msgstr ""
 "pista e tutte le piazzole connesse dovrebbero evidenziarsi."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:872
+#: getting_started_in_kicad.adoc:886
 msgid ""
 "Now we will make a ground plane that will be connected to all GND pins. "
 "Click on the 'Add Zones' icon image:images/icons/add_zone.png[add_zone_png] "
@@ -2171,7 +2214,7 @@ msgstr ""
 "e fare clic su OK."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:877
+#: getting_started_in_kicad.adoc:891
 msgid ""
 "Trace around the outline of the board by clicking each corner in rotation. "
 "Double-click to finish your rectangle. Right click inside the area you have "
@@ -2185,12 +2228,12 @@ msgstr ""
 
 # TOTR
 #. type: Plain text
-#: getting_started_in_kicad.adoc:879
+#: getting_started_in_kicad.adoc:893
 msgid "image:images/gsik_tutorial1_100.png[gsik_tutorial1_100_png]"
 msgstr "image:images/gsik_tutorial1_100.png[gsik_tutorial1_100_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:885
+#: getting_started_in_kicad.adoc:899
 msgid ""
 "Run the design rules checker by clicking on the 'Perform Design Rules Check' "
 "icon image:images/icons/drc.png[drc_png] on the top toolbar.  Click on "
@@ -2205,7 +2248,7 @@ msgstr ""
 "la finestra di dialogo."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:888
+#: getting_started_in_kicad.adoc:902
 msgid ""
 "Save your file by clicking on *File* -> **Save**. To admire your board in "
 "3D, click on *View* -> **3D Viewer**."
@@ -2215,17 +2258,17 @@ msgstr ""
 
 # TOTR
 #. type: Plain text
-#: getting_started_in_kicad.adoc:890
+#: getting_started_in_kicad.adoc:904
 msgid "image:images/pcbnew_3d_viewer.png[pcbnew_3d_viewer_png]"
 msgstr "image:images/pcbnew_3d_viewer.png[pcbnew_3d_viewer_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:892
+#: getting_started_in_kicad.adoc:906
 msgid "You can drag your mouse around to rotate the PCB."
 msgstr "Trascinare il puntatore del mouse per ruotare il circuito stampato."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:895
+#: getting_started_in_kicad.adoc:909
 msgid ""
 "Your board is complete. To send it off to a manufacturer you will need to "
 "generate all Gerber files."
@@ -2234,13 +2277,13 @@ msgstr ""
 "stampatiTo sarà necessario generare una serie di file Gerber."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:897
+#: getting_started_in_kicad.adoc:911
 #, no-wrap
 msgid "Generate Gerber files"
 msgstr "Generare file Gerber"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:902
+#: getting_started_in_kicad.adoc:916
 msgid ""
 "Once your PCB is complete, you can generate Gerber files for each layer and "
 "send them to your favourite PCB manufacturer, who will make the board for "
@@ -2251,7 +2294,7 @@ msgstr ""
 "stampati di fiducia, con i quali questo creerà lo stampato."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:906
+#: getting_started_in_kicad.adoc:920
 msgid ""
 "From KiCad, open the _Pcbnew_ software tool and load your board file by "
 "clicking on the icon image:images/icons/open_document.png[open_document_png]."
@@ -2260,7 +2303,7 @@ msgstr ""
 "facendo clic sull'icona image:images/icons/open_document.png[apri documento]."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:910
+#: getting_started_in_kicad.adoc:924
 msgid ""
 "Click on *File* -> **Plot**. Select 'Gerber' as the 'Plot Format' and select "
 "the folder in which to put all Gerber files.  Proceed by clicking on the "
@@ -2271,7 +2314,7 @@ msgstr ""
 "Gerber. Procedere facendo clic sul pulsante 'Traccia'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:913
+#: getting_started_in_kicad.adoc:927
 msgid ""
 "These are the layers you need to select for making a typical 2-layer PCB:"
 msgstr ""
@@ -2279,7 +2322,7 @@ msgstr ""
 "circuito stampato a 2 facce:"
 
 #. type: delimited block |
-#: getting_started_in_kicad.adoc:924
+#: getting_started_in_kicad.adoc:938
 #, no-wrap
 msgid ""
 "|Layer |KiCad Layer Name |Old KiCad Layer Name |Default Gerber Extension\n"
@@ -2301,13 +2344,13 @@ msgstr ""
 "|Bordi |Edge.Cuts |Edges_Pcb |.GBR |.GM1\n"
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:927
+#: getting_started_in_kicad.adoc:941
 #, no-wrap
 msgid "Using GerbView"
 msgstr "Usare GerbView"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:936
+#: getting_started_in_kicad.adoc:950
 msgid ""
 "To view all your Gerber files go to the KiCad project manager and click on "
 "the 'GerbView' icon.  On the drag down menu select 'Layer 1'. Click on "
@@ -2322,7 +2365,7 @@ msgstr ""
 "generati uno alla volta. Si noti come vengono visualizzati uno sopra l'altro."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:939
+#: getting_started_in_kicad.adoc:953
 msgid ""
 "Use the menu on the right to select/deselect which layer to show.  Carefully "
 "inspect each layer before sending them for production."
@@ -2332,7 +2375,7 @@ msgstr ""
 "produzione."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:942
+#: getting_started_in_kicad.adoc:956
 msgid ""
 "To generate the drill file, from _Pcbnew_ go again for the *File* -> *Plot* "
 "option. Default settings should be fine."
@@ -2342,13 +2385,13 @@ msgstr ""
 "bene."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:944
+#: getting_started_in_kicad.adoc:958
 #, no-wrap
 msgid "Automatically route with FreeRouter"
 msgstr "Sbroglio automatico con FreeRouter"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:952
+#: getting_started_in_kicad.adoc:966
 msgid ""
 "Routing a board by hand is quick and fun, however, for a board with lots of "
 "components you might want to use an autorouter. Remember that you should "
@@ -2364,7 +2407,7 @@ msgstr ""
 "net__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:957
+#: getting_started_in_kicad.adoc:971
 msgid ""
 "Freerouter is a open source java application, and it is needed to build by "
 "yourself to use with KiCad.  Source code of Freerouter can be found on this "
@@ -2375,7 +2418,7 @@ msgstr ""
 "su questo sito: https://github.com/nikropht/FreeRouting"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:963
+#: getting_started_in_kicad.adoc:977
 msgid ""
 "From _Pcbnew_ click on *File* -> *Export* -> *Specctra DSN* or click on "
 "*Tools* -> *FreeRoute* -> **Export a Specctra Design (*.dsn) file** and save "
@@ -2389,7 +2432,7 @@ msgstr ""
 "caricarlo."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:968
+#: getting_started_in_kicad.adoc:982
 msgid ""
 "The *Tools* -> *FreeRoute* dialog has a nice help button that opens a file "
 "viewer with a little document inside named **Freerouter Guidelines**. Please "
@@ -2401,7 +2444,7 @@ msgstr ""
 "guida per usare FreeRoute con efficacia."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:974
+#: getting_started_in_kicad.adoc:988
 msgid ""
 "FreeRouter has some features that KiCad does not currently have, both for "
 "manual routing and for automatic routing. FreeRouter operates in two main "
@@ -2415,7 +2458,7 @@ msgstr ""
 "in ogni istante."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:982
+#: getting_started_in_kicad.adoc:996
 msgid ""
 "You can start the automatic routing by clicking on the 'Autorouter' button "
 "on the top bar. The bottom bar gives you information about the on-going "
@@ -2433,7 +2476,7 @@ msgstr ""
 "dei componenti è di minimizzare il numero di incroci nella ratsnest."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:987
+#: getting_started_in_kicad.adoc:1001
 msgid ""
 "Making a left-click on the mouse can stop the automatic routing and "
 "automatically start the optimisation process. Another left-click will stop "
@@ -2447,7 +2490,7 @@ msgstr ""
 "suo lavoro."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:991
+#: getting_started_in_kicad.adoc:1005
 msgid ""
 "Click on the *File* -> *Export Specctra Session File* menu and save the "
 "board file with the _.ses_ extension. You do not really need to save the "
@@ -2458,7 +2501,7 @@ msgstr ""
 "il file delle regole di FreeRouter."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:996
+#: getting_started_in_kicad.adoc:1010
 msgid ""
 "Back to __Pcbnew__. You can import your freshly routed board by clicking on "
 "the link *Tools* -> *FreeRoute* and then on the icon 'Back Import the "
@@ -2469,7 +2512,7 @@ msgstr ""
 "file Spectra Session (.ses)' e selezionando il nostro file __.ses__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1001
+#: getting_started_in_kicad.adoc:1015
 msgid ""
 "If there is any routed trace that you do not like, you can delete it and re-"
 "route it again, using the del key and the routing tool, which is the 'Add "
@@ -2482,13 +2525,13 @@ msgstr ""
 "Track icon] sulla barra comandi di destra."
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1003
+#: getting_started_in_kicad.adoc:1017
 #, no-wrap
 msgid "Forward annotation in KiCad"
 msgstr "Forward annotation in KiCad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1009
+#: getting_started_in_kicad.adoc:1023
 msgid ""
 "Once you have completed your electronic schematic, the footprint assignment, "
 "the board layout and generated the Gerber files, you are ready to send "
@@ -2500,7 +2543,7 @@ msgstr ""
 "la nostra scheda possa diventare realtà."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1017
+#: getting_started_in_kicad.adoc:1031
 msgid ""
 "Often, this linear work-flow turns out to be not so uni-directional. For "
 "instance, when you have to modify/extend a board for which you or others "
@@ -2518,7 +2561,7 @@ msgstr ""
 "la scheda. Ecco invece come si può procedere:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1020
+#: getting_started_in_kicad.adoc:1034
 msgid ""
 "Let's suppose that you want to replace a hypothetical connector CON1 with "
 "CON2."
@@ -2526,14 +2569,14 @@ msgstr ""
 "Supponiamo che si voglia rimpiazzare un ipotetico connettore CON1 con CON2."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1022
+#: getting_started_in_kicad.adoc:1036
 msgid "You already have a completed schematic and a fully routed PCB."
 msgstr ""
 "Si è già completato lo schema elettrico e sbrogliato tutto il circuito "
 "stampato."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1028
+#: getting_started_in_kicad.adoc:1042
 msgid ""
 "From KiCad, start __Eeschema__, make your modifications by deleting CON1 and "
 "adding CON2. Save your schematic project with the icon image:images/icons/"
@@ -2546,7 +2589,7 @@ msgstr ""
 "images/icons/netlist.png[netlist_png] sulla barra degli strumenti in cima."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1031
+#: getting_started_in_kicad.adoc:1045
 msgid ""
 "Click on 'Netlist' then on 'save'. Save to the default file name.  You have "
 "to rewrite the old one."
@@ -2555,7 +2598,7 @@ msgstr ""
 "predefinito dato che bisogna riscrivere il vecchio."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1037
+#: getting_started_in_kicad.adoc:1051
 msgid ""
 "Now assign a footprint to CON2. Click on the 'Run Cvpcb' icon image:images/"
 "icons/cvpcb.png[cvpcb] on the top toolbar. Assign the footprint to the new "
@@ -2568,7 +2611,7 @@ msgstr ""
 "ancora le impronte precedenti assegnate. Chiudere __Cvpcb__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1040
+#: getting_started_in_kicad.adoc:1054
 msgid ""
 "Back in the schematic editor, save the project by clicking on 'File' -> "
 "'Save Whole Schematic Project'. Close the schematic editor."
@@ -2577,7 +2620,7 @@ msgstr ""
 "clic su 'File' -> 'Salva progetto schema'. Chiudere l'editor."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1043
+#: getting_started_in_kicad.adoc:1057
 msgid ""
 "From the KiCad project manager, click on the 'Pcbnew' icon. The 'Pcbnew' "
 "window will open."
@@ -2586,7 +2629,7 @@ msgstr ""
 "finestra di 'Pcbnew'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1047
+#: getting_started_in_kicad.adoc:1061
 msgid ""
 "The old, already routed, board should automatically open. Let's import the "
 "new netlist file. Click on the 'Read Netlist' icon image:images/icons/"
@@ -2597,7 +2640,7 @@ msgstr ""
 "images/icons/netlist.png[netlist_png] sulla barra strumenti in cima."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1051
+#: getting_started_in_kicad.adoc:1065
 msgid ""
 "Click on the 'Browse Netlist Files' button, select the netlist file in the "
 "file selection dialogue, and click on 'Read Current Netlist'.  Then click "
@@ -2608,7 +2651,7 @@ msgstr ""
 "corrente'. Poi fare clic sul pulsante 'Chiudi'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1056
+#: getting_started_in_kicad.adoc:1070
 msgid ""
 "At this point you should be able to see a layout with all previous "
 "components already routed. On the top left corner you should see all "
@@ -2622,7 +2665,7 @@ msgstr ""
 "della scheda."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1059
+#: getting_started_in_kicad.adoc:1073
 msgid ""
 "Place CON2 and route it. Once done, save and proceed with the Gerber file "
 "generation as usual."
@@ -2631,7 +2674,7 @@ msgstr ""
 "generazione dei file Gerber come di consueto."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1067
+#: getting_started_in_kicad.adoc:1081
 msgid ""
 "The process described here can easily be repeated as many times as you need. "
 "Beside the Forward Annotation method described above, there is another "
@@ -2649,13 +2692,13 @@ msgstr ""
 "considerato molto utile e perciò non lo si è descritto in questa sede."
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1069
+#: getting_started_in_kicad.adoc:1083
 #, no-wrap
 msgid "Make schematic components in KiCad"
 msgstr "Creare simboli elettrici in KiCad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1076
+#: getting_started_in_kicad.adoc:1090
 msgid ""
 "Sometimes a component that you want to place on your schematic is not in the "
 "KiCad libraries. This is quite normal and there is no reason to worry. In "
@@ -2671,12 +2714,12 @@ msgstr ""
 "qui:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1078
+#: getting_started_in_kicad.adoc:1092
 msgid "http://per.launay.free.fr/kicad/kicad_php/composant.php"
 msgstr "http://per.launay.free.fr/kicad/kicad_php/composant.php"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1083
+#: getting_started_in_kicad.adoc:1097
 msgid ""
 "In KiCad, a component is a piece of text that starts with a 'DEF' and ends "
 "with 'ENDDEF'. One or more components are normally placed in a library file "
@@ -2689,13 +2732,13 @@ msgstr ""
 "file libreria si può sempre usare i comandi di copia e incolla."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1085
+#: getting_started_in_kicad.adoc:1099
 #, no-wrap
 msgid "Using Component Library Editor"
 msgstr "Usare l'editor dei componenti di libreria"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1091
+#: getting_started_in_kicad.adoc:1105
 msgid ""
 "We can use the _Component Library Editor_ (part of __Eeschema__)  to make "
 "new components. In our project folder 'tutorial1' let's create a folder "
@@ -2708,7 +2751,7 @@ msgstr ""
 "file di libreria _myLib.lib_ appena avremo creato il nostro nuovo componente."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1106
+#: getting_started_in_kicad.adoc:1120
 msgid ""
 "Now we can start creating our new component. From KiCad, start __Eeschema__, "
 "click on the 'Library Editor' icon image:images/icons/libedit."
@@ -2735,7 +2778,7 @@ msgstr ""
 "appena sotto l'etichetta 'MYCONN3'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1110
+#: getting_started_in_kicad.adoc:1124
 msgid ""
 "In the Pin Properties window that appears, set the pin name to 'VCC', set "
 "the pin number to '1', and the 'Electrical type' to 'Passive' then click OK."
@@ -2746,12 +2789,12 @@ msgstr ""
 
 # TOTR
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1112
+#: getting_started_in_kicad.adoc:1126
 msgid "image:images/pin_properties.png[Pin Properties]"
 msgstr "image:images/pin_properties.png[Pin Properties]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1115
+#: getting_started_in_kicad.adoc:1129
 msgid ""
 "Place the pin by clicking on the location you would like it to go, right "
 "below the 'MYCONN3' label."
@@ -2760,7 +2803,7 @@ msgstr ""
 "appena sotto l'etichetta 'MYCONN3'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1119
+#: getting_started_in_kicad.adoc:1133
 msgid ""
 "Repeat the place-pin steps, this time 'Pin name' should be 'INPUT', 'Pin "
 "number' should be '2', and 'Electrical Type' should be 'Passive'."
@@ -2770,7 +2813,7 @@ msgstr ""
 "'Ingresso alimentazione'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1125
+#: getting_started_in_kicad.adoc:1139
 msgid ""
 "Repeat the place-pin steps, this time 'Pin name' should be 'GND', 'Pin "
 "number' should be '3', and 'Electrical Type' should be 'Passive'.  Arrange "
@@ -2784,7 +2827,7 @@ msgstr ""
 "incrociano)."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1133
+#: getting_started_in_kicad.adoc:1147
 msgid ""
 "Next, draw the contour of the component. Click on the 'Add rectangle' icon "
 "image:images/icons/add_rectangle.png[add_rectangle_png]. We want to draw a "
@@ -2792,16 +2835,22 @@ msgid ""
 "the top left corner of the rectangle to be (do not hold the mouse button "
 "down). Click again where you want the bottom right corner of the rectangle "
 "to be."
-msgstr "Poi, disegnare il contorno del componente. Clic sull'icona 'Aggiungi rettangolo' image:images/icons/add_rectangle.png[add_rectangle_png]. Vogliamo disegnare un rettangolo vicino ai pin, come mostrato sotto. Per far ciò, fare clic dove si desidera posizionare l'angolo alto a sinistra del rettangolo (non mantenere premuto il pulsante del mouse). Clic nuovamente dove si vuole posizionare l'angolo basso a destra del rettangolo."
+msgstr ""
+"Poi, disegnare il contorno del componente. Clic sull'icona 'Aggiungi "
+"rettangolo' image:images/icons/add_rectangle.png[add_rectangle_png]. "
+"Vogliamo disegnare un rettangolo vicino ai pin, come mostrato sotto. Per far "
+"ciò, fare clic dove si desidera posizionare l'angolo alto a sinistra del "
+"rettangolo (non mantenere premuto il pulsante del mouse). Clic nuovamente "
+"dove si vuole posizionare l'angolo basso a destra del rettangolo."
 
 # TOTR
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1135
+#: getting_started_in_kicad.adoc:1149
 msgid "image:images/gsik_myconn3_l.png[gsik_myconn3_l_png]"
 msgstr "image:images/gsik_myconn3_l.png[gsik_myconn3_l_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1140
+#: getting_started_in_kicad.adoc:1154
 msgid ""
 "Save the component in your library __myLib.lib__. Click on the 'New Library' "
 "icon image:images/icons/new_library.png[new_library_png], navigate into "
@@ -2814,7 +2863,7 @@ msgstr ""
 "__myLib.lib__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1143
+#: getting_started_in_kicad.adoc:1157
 msgid ""
 "Go to *Preferences* -> *Component Libraries* and add both _tutorial1/library/"
 "_ in 'User defined search path' and _myLib.lib in_ 'Component library files'."
@@ -2824,7 +2873,7 @@ msgstr ""
 "'File librerie componenti'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1149
+#: getting_started_in_kicad.adoc:1163
 msgid ""
 "Click on the 'Select working library' icon image:images/icons/library."
 "png[library_png]. In the Select Library window click on _myLib_ and click "
@@ -2837,7 +2886,7 @@ msgstr ""
 "libreria attualmente in uso, che ora dovrebbe essere __myLib__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1158
+#: getting_started_in_kicad.adoc:1172
 msgid ""
 "Click on the 'Update current component in current library' icon image:images/"
 "icons/save_part_in_mem.png[save_part_in_mem_png] in the top toolbar. Save "
@@ -2857,7 +2906,7 @@ msgstr ""
 "titolo della finestra."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1162
+#: getting_started_in_kicad.adoc:1176
 msgid ""
 "You can now close the Component library editor window. You will return to "
 "the schematic editor window. Your new component will now be available to you "
@@ -2868,7 +2917,7 @@ msgstr ""
 "componente ora sarà disponibile nella libreria __myLib__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1167
+#: getting_started_in_kicad.adoc:1181
 msgid ""
 "You can make any library _file.lib_ file available to you by adding it to "
 "the library path. From __Eeschema__, go to *Preferences* -> *Library* and "
@@ -2882,13 +2931,13 @@ msgstr ""
 "componenti'."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1169
+#: getting_started_in_kicad.adoc:1183
 #, no-wrap
 msgid "Export, import and modify library components"
 msgstr "Esportazione, importazione e modifica dei componenti di libreria"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1175
+#: getting_started_in_kicad.adoc:1189
 msgid ""
 "Instead of creating a library component from scratch it is sometimes easier "
 "to start from one already made and modify it. In this section we will see "
@@ -2901,7 +2950,7 @@ msgstr ""
 "nostra libreria _myOwnLib.lib_ e come modificarlo."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1183
+#: getting_started_in_kicad.adoc:1197
 msgid ""
 "From KiCad, start __Eeschema__, click on the 'Library Editor' icon image:"
 "images/icons/libedit.png[libedit_png], click on the 'Select working library' "
@@ -2918,7 +2967,7 @@ msgstr ""
 "png[import_cmp_from_lib_png] e importare 'RELAY_2RT'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1187
+#: getting_started_in_kicad.adoc:1201
 msgid ""
 "Click on the 'Export component' icon image:images/icons/export."
 "png[export_png], navigate into the _library/_ folder and save the new "
@@ -2929,7 +2978,7 @@ msgstr ""
 "di libreria con nome _myOwnLib.lib._"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1193
+#: getting_started_in_kicad.adoc:1207
 msgid ""
 "You can make this component and the whole library _myOwnLib.lib_ available "
 "to you by adding it to the library path. From __Eeschema__, go to "
@@ -2943,7 +2992,7 @@ msgstr ""
 "librerie componenti'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1199
+#: getting_started_in_kicad.adoc:1213
 msgid ""
 "Click on the 'Select working library' icon image:images/icons/library."
 "png[library_png]. In the Select Library window click on _myOwnLib_ and click "
@@ -2956,7 +3005,7 @@ msgstr ""
 "attualmente in uso, ora dovrebbe mostrare __myOwnLib__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1203
+#: getting_started_in_kicad.adoc:1217
 msgid ""
 "Click on the 'Load component to edit from the current lib' icon image:images/"
 "icons/import_cmp_from_lib.png[import_cmp_from_lib_png] and import the "
@@ -2967,7 +3016,7 @@ msgstr ""
 "importa 'RELAY_2RT'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1206
+#: getting_started_in_kicad.adoc:1220
 msgid ""
 "You can now modify the component as you like. Hover over the label "
 "'RELAY_2RT', press the e key and rename it 'MY_RELAY_2RT'."
@@ -2977,7 +3026,7 @@ msgstr ""
 "in 'MY_RELAY_2RT'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1213
+#: getting_started_in_kicad.adoc:1227
 msgid ""
 "Click on 'Update current component in current library' icon image:images/"
 "icons/save_part_in_mem.png[save_part_in_mem_png] in the top toolbar. Save "
@@ -2991,13 +3040,13 @@ msgstr ""
 "png[save_library_png] nella barra strumenti in alto."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1215
+#: getting_started_in_kicad.adoc:1229
 #, no-wrap
 msgid "Make schematic components with quicklib"
 msgstr "Creare componenti dello schema con quicklib"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1220
+#: getting_started_in_kicad.adoc:1234
 msgid ""
 "This section presents an alternative way of creating the schematic component "
 "for MYCONN3 (see <<myconn3,MYCONN3>> above) using the Internet tool "
@@ -3008,7 +3057,7 @@ msgstr ""
 "strumento Internet __quicklib__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1223
+#: getting_started_in_kicad.adoc:1237
 msgid ""
 "Head to the _quicklib_ web page: http://kicad.rohrbacher.net/quicklib.php"
 msgstr ""
@@ -3016,7 +3065,7 @@ msgstr ""
 "net/quicklib.php"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1226
+#: getting_started_in_kicad.adoc:1240
 msgid ""
 "Fill out the page with the following information: Component name: MYCONN3 "
 "Reference Prefix: J Pin Layout Style: SIL Pin Count, N: 3"
@@ -3025,7 +3074,7 @@ msgstr ""
 "Reference Prefix: J Pin Layout Style: SIL Pin Count, N: 3"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1230
+#: getting_started_in_kicad.adoc:1244
 msgid ""
 "Click on the 'Assign Pins' icon. Fill out the page with the following "
 "information: Pin 1: VCC Pin 2: input Pin 3: GND.  Type : Passive for all 3 "
@@ -3035,7 +3084,7 @@ msgstr ""
 "informazioni: Pin 1: VCC Pin 2: input Pin 3: GND"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1234
+#: getting_started_in_kicad.adoc:1248
 msgid ""
 "Click on the icon 'Preview it' and, if you are satisfied, click on the "
 "'Build Library Component'. Download the file and rename it __tutorial1/"
@@ -3047,7 +3096,7 @@ msgstr ""
 "Ecco fatto!"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1240
+#: getting_started_in_kicad.adoc:1254
 msgid ""
 "Have a look at it using KiCad. From the KiCad project manager, start "
 "__Eeschema__, click on the 'Library Editor' icon image:images/icons/libedit."
@@ -3062,12 +3111,12 @@ msgstr ""
 "selezionare _myQuickLib.lib._"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1242
+#: getting_started_in_kicad.adoc:1256
 msgid "image:images/gsik_myconn3_quicklib.png[gsik_myconn3_quicklib_png]"
 msgstr "image:images/gsik_myconn3_quicklib.png[gsik_myconn3_quicklib_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1248
+#: getting_started_in_kicad.adoc:1262
 msgid ""
 "You can make this component and the whole library _myQuickLib.lib_ available "
 "to you by adding it to the KiCad library path. From __Eeschema__, go to "
@@ -3081,7 +3130,7 @@ msgstr ""
 "librerie componenti'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1252
+#: getting_started_in_kicad.adoc:1266
 msgid ""
 "As you might guess, this method of creating library components can be quite "
 "effective when you want to create components with a large pin count."
@@ -3091,13 +3140,13 @@ msgstr ""
 "elevato numero di piedini."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1254
+#: getting_started_in_kicad.adoc:1268
 #, no-wrap
 msgid "Make a high pin count schematic component"
 msgstr "Fare un componente con un grande numero di pin"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1261
+#: getting_started_in_kicad.adoc:1275
 msgid ""
 "In the section titled _Make Schematic Components in quicklib_ we saw how to "
 "make a schematic component using the _quicklib_ web-based tool.  However, "
@@ -3112,7 +3161,7 @@ msgstr ""
 "(alcune centinaia). In KiCad per fortuna, ciò non è un grosso problema."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1267
+#: getting_started_in_kicad.adoc:1281
 msgid ""
 "Suppose that you want to create a schematic component for a device with 50 "
 "pins. It is common practise to draw it using multiple low pin-count "
@@ -3125,7 +3174,7 @@ msgstr ""
 "rappresentazione del componente semplifica la connessione ai piedini."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1272
+#: getting_started_in_kicad.adoc:1286
 msgid ""
 "The best way to create our component is to use _quicklib_ to generate two 25-"
 "pin components separately, re-number their pins using a Python script and "
@@ -3139,7 +3188,7 @@ msgstr ""
 "e un ENDDEF."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1278
+#: getting_started_in_kicad.adoc:1292
 msgid ""
 "You will find an example of a simple Python script below that can be used in "
 "conjunction with an _in.txt_ file and an _out.txt_ file to re-number the "
@@ -3152,13 +3201,13 @@ msgstr ""
 "viene effettuato per tutte le righe del file __in.txt__."
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:1279
+#: getting_started_in_kicad.adoc:1293
 #, no-wrap
 msgid "Simple script"
 msgstr "Semplice script"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1302
+#: getting_started_in_kicad.adoc:1316
 #, no-wrap
 msgid ""
 "#!/usr/bin/env python\n"
@@ -3204,7 +3253,7 @@ msgstr ""
 "# http://kicad.rohrbacher.net/quicklib.php\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1308
+#: getting_started_in_kicad.adoc:1322
 msgid ""
 "While merging the two components into one, it is necessary to use the "
 "Library Editor from Eeschema to move the first component so that the second "
@@ -3217,13 +3266,13 @@ msgstr ""
 "rappresentazione in __Eeschema__."
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:1309
+#: getting_started_in_kicad.adoc:1323
 #, no-wrap
 msgid "Contents of a *.lib file"
 msgstr "Contenuti di un file *.lib"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1321
+#: getting_started_in_kicad.adoc:1335
 #, no-wrap
 msgid ""
 "EESchema-LIBRARY Version 2.3\n"
@@ -3249,13 +3298,13 @@ msgstr ""
 "X PIN1 1 -2550 600 300 R 50 50 1 1 I\n"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1323
+#: getting_started_in_kicad.adoc:1337
 #, no-wrap
 msgid "...\n"
 msgstr "...\n"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1328
+#: getting_started_in_kicad.adoc:1342
 #, no-wrap
 msgid ""
 "X PIN49 49 750 -500 300 L 50 50 1 1 I\n"
@@ -3269,12 +3318,12 @@ msgstr ""
 "#End Library\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1331
+#: getting_started_in_kicad.adoc:1345
 msgid "image:images/gsik_high_number_pins.png[gsik_high_number_pins_png]"
 msgstr "image:images/gsik_high_number_pins.png[gsik_high_number_pins_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1336
+#: getting_started_in_kicad.adoc:1350
 msgid ""
 "The Python script presented here is a very powerful tool for manipulating "
 "both pin numbers and pin labels. Mind, however, that all its power comes for "
@@ -3288,13 +3337,13 @@ msgstr ""
 "RegExr/__."
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1338
+#: getting_started_in_kicad.adoc:1352
 #, no-wrap
 msgid "Make component footprints"
 msgstr "Creare impronte di componenti"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1344
+#: getting_started_in_kicad.adoc:1358
 msgid ""
 "Unlike other EDA software tools, which have one type of library that "
 "contains both the schematic symbol and the footprint variations, KiCad _."
@@ -3308,7 +3357,7 @@ msgstr ""
 "moduli. _Cvpcb_ serve quindi a mappare le impronte ai simboli."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1347
+#: getting_started_in_kicad.adoc:1361
 msgid ""
 "As for _.lib_ files, _.kicad_mod_ library files are text files that can "
 "contain anything from one to several parts."
@@ -3317,7 +3366,7 @@ msgstr ""
 "testo che possono contenere da una a qualsiasi numero di parti."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1351
+#: getting_started_in_kicad.adoc:1365
 msgid ""
 "There is an extensive footprint library with KiCad, however on occasion you "
 "might find that the footprint you need is not in the KiCad library.  Here "
@@ -3329,13 +3378,13 @@ msgstr ""
 "stampato KiCad: "
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1353
+#: getting_started_in_kicad.adoc:1367
 #, no-wrap
 msgid "Using Footprint Editor"
 msgstr "Usare l'editor delle impronte"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1359
+#: getting_started_in_kicad.adoc:1373
 msgid ""
 "From the KiCad project manager start the _Pcbnew_ tool. Click on the 'Open "
 "Footprint Editor' icon image:images/icons/edit_module.png[edit_module_png] "
@@ -3347,7 +3396,7 @@ msgstr ""
 "'L'editor delle impronte'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1371
+#: getting_started_in_kicad.adoc:1385
 msgid ""
 "We are going to save the new footprint 'MYCONN3' in the new footprint "
 "library 'myfootprint'.  Create a new folder _myfootprint.pretty_ in the "
@@ -3371,7 +3420,7 @@ msgstr ""
 "libreria 'myfootprint'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1380
+#: getting_started_in_kicad.adoc:1394
 msgid ""
 "Click on the 'New Footprint' icon image:images/icons/new_footprint."
 "png[new_footprint_png] on the top toolbar.  Type 'MYCONN3' as the 'footprint "
@@ -3390,7 +3439,7 @@ msgstr ""
 
 # Probabilmente Display andrebbe tradotto in questo caso in Aspetto
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1385
+#: getting_started_in_kicad.adoc:1399
 msgid ""
 "Select the 'Add Pads' icon image:images/icons/pad.png[pad_png] on the right "
 "toolbar. Click on the working sheet to place the pad. Right click on the new "
@@ -3403,12 +3452,12 @@ msgstr ""
 
 # TOTR
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1387
+#: getting_started_in_kicad.adoc:1401
 msgid "image:images/pad_properties.png[Pad Properties]"
 msgstr "image:images/pad_properties.png[Pad Properties]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1391
+#: getting_started_in_kicad.adoc:1405
 msgid ""
 "Set the 'Pad Num' to '1', 'Pad Shape' to 'Rect', 'Pad Type' to 'SMD', 'Shape "
 "Size X' to '0.4', and 'Shape Size Y' to '0.8'. Click OK.  Click on 'Add "
@@ -3420,7 +3469,7 @@ msgstr ""
 "ancora due piazzole."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1395
+#: getting_started_in_kicad.adoc:1409
 msgid ""
 "If you want to change the grid size, *Right click* -> **Grid Select**. Be "
 "sure to select the appropriate grid size before laying down the components."
@@ -3430,7 +3479,7 @@ msgstr ""
 "prima di aggiungere i componenti."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1398
+#: getting_started_in_kicad.adoc:1412
 msgid ""
 "Move the 'MYCONN3' label and the 'SMD' label out of the way so that it looks "
 "like the image shown above."
@@ -3439,7 +3488,7 @@ msgstr ""
 "risultato somigli all'immagine mostrata sopra."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1405
+#: getting_started_in_kicad.adoc:1419
 msgid ""
 "When placing pads it is often necessary to measure relative distances. Place "
 "the cursor where you want the relative coordinate point _(0,0)_ to be and "
@@ -3455,7 +3504,7 @@ msgstr ""
 "nuova origine per le coordinate."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1410
+#: getting_started_in_kicad.adoc:1424
 msgid ""
 "Now add a footprint contour. Click on the 'Add graphic line or polygon' "
 "button image:images/icons/add_polygon.png[add_polygon_png] in the right "
@@ -3468,7 +3517,7 @@ msgstr ""
 
 # Original string must be updated
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1414
+#: getting_started_in_kicad.adoc:1428
 msgid ""
 "Click on the 'Save Footprint in Active Library' icon image:images/icons/"
 "save_library.png[save_library_png] on the top toolbar, using the default "
@@ -3479,13 +3528,13 @@ msgstr ""
 "nome predefinito MYCONN3."
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1416
+#: getting_started_in_kicad.adoc:1430
 #, no-wrap
 msgid "Note about portability of KiCad project files"
 msgstr "Note sulla portabilità dei file di progetto di KiCad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1420
+#: getting_started_in_kicad.adoc:1434
 msgid ""
 "What files do you need to send to someone so that they can fully load and "
 "use your KiCad project?"
@@ -3495,7 +3544,7 @@ msgstr ""
 
 # Original string must be updated
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1427
+#: getting_started_in_kicad.adoc:1441
 msgid ""
 "When you have a KiCad project to share with somebody, it is important that "
 "the schematic file __.sch__, the board file __.kicad_pcb__, the project file "
@@ -3513,7 +3562,7 @@ msgstr ""
 
 # Original string must be updated
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1439
+#: getting_started_in_kicad.adoc:1453
 msgid ""
 "With KiCad schematics, people need the _.lib_ files that contain the "
 "symbols. Those library files need to be loaded in the _Eeschema_ "
@@ -3539,7 +3588,7 @@ msgstr ""
 "che tali impronte vengano mostrate in __Cvpcb__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1447
+#: getting_started_in_kicad.adoc:1461
 msgid ""
 "If someone sends you a _.kicad_pcb_ file with footprints you would like to "
 "use in another board, you can open the Footprint Editor, load a footprint "
@@ -3558,7 +3607,7 @@ msgstr ""
 "file _.kicad_mod_ con tutte le impronte della scheda."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1453
+#: getting_started_in_kicad.adoc:1467
 msgid ""
 "Bottom line, if the PCB is the only thing you want to distribute, then the "
 "board file _.kicad_pcb_ is enough. However, if you want to give people the "
@@ -3573,7 +3622,7 @@ msgstr ""
 "di creare un archivio zip e spedire la seguente cartella di progetto:"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1471
+#: getting_started_in_kicad.adoc:1485
 #, no-wrap
 msgid ""
 "tutorial1/\n"
@@ -3611,13 +3660,13 @@ msgstr ""
 "    \\-- ...\n"
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1474
+#: getting_started_in_kicad.adoc:1488
 #, no-wrap
 msgid "More about KiCad documentation"
 msgstr "Uno sguardo sulla documentazione di KiCad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1479
+#: getting_started_in_kicad.adoc:1493
 msgid ""
 "This has been a quick guide on most of the features in KiCad. For more "
 "detailed instructions consult the help files which you can access through "
@@ -3629,7 +3678,7 @@ msgstr ""
 "clic su *Aiuto* -> **Manuale**."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1482
+#: getting_started_in_kicad.adoc:1496
 msgid ""
 "KiCad comes with a pretty good set of multi-language manuals for all its "
 "four software components."
@@ -3638,13 +3687,13 @@ msgstr ""
 "sue componenti software."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1484
+#: getting_started_in_kicad.adoc:1498
 msgid "The English version of all KiCad manuals are distributed with KiCad."
 msgstr ""
 "La versione inglese di tutti i manuali di KiCad viene distribuita con KiCad."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1490
+#: getting_started_in_kicad.adoc:1504
 msgid ""
 "In addition to its manuals, KiCad is distributed with this tutorial, which "
 "has been translated into other languages. All the different versions of this "
@@ -3659,7 +3708,7 @@ msgstr ""
 "disponibile già pacchettizzata assieme a KiCad per la propria piattaforma."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1493
+#: getting_started_in_kicad.adoc:1507
 msgid ""
 "For example, on Linux the typical locations are in the following "
 "directories, depending on your exact distribution:"
@@ -3668,7 +3717,7 @@ msgstr ""
 "seconda della propria distribuzione:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1496
+#: getting_started_in_kicad.adoc:1510
 #, no-wrap
 msgid ""
 " /usr/share/doc/kicad/help/en/\n"
@@ -3678,40 +3727,40 @@ msgstr ""
 " /usr/local/share/doc/kicad/help/it\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1498
+#: getting_started_in_kicad.adoc:1512
 msgid "On Windows it is in:"
 msgstr "Su Windows è in:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1500
+#: getting_started_in_kicad.adoc:1514
 #, no-wrap
 msgid " <installation directory>/share/doc/kicad/help/en\n"
 msgstr " <directory di installazione>/share/doc/kicad/help/it\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1502
+#: getting_started_in_kicad.adoc:1516
 msgid "On OS X:"
 msgstr "Su OS X:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1504
+#: getting_started_in_kicad.adoc:1518
 #, no-wrap
 msgid " /Library/Application Support/kicad/help/en\n"
 msgstr " /Library/Application Support/kicad/help/it\n"
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1506
+#: getting_started_in_kicad.adoc:1520
 #, no-wrap
 msgid "KiCad documentation on the Web"
 msgstr "La documentazione di KiCad sul Web"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1509
+#: getting_started_in_kicad.adoc:1523
 msgid ""
 "Latest KiCad documentations are available in multiple languages on the Web."
 msgstr "L'ultima documentazione di KiCad è disponibile in più lingue sul Web."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1511
+#: getting_started_in_kicad.adoc:1525
 msgid "http://kicad-pcb.org/help/documentation/"
 msgstr "http://kicad-pcb.org/help/documentation/"

--- a/src/getting_started_in_kicad/po/ja.po
+++ b/src/getting_started_in_kicad/po/ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: KiCadことはじめ\n"
-"POT-Creation-Date: 2016-01-06 23:55+0100\n"
+"POT-Creation-Date: 2016-01-07 20:18+0100\n"
 "PO-Revision-Date: 2015-12-26 18:39+0100\n"
 "Last-Translator: kinichiro <kinichiro.inoguchi@gmail.com>\n"
 "Language-Team: kicad.jp <kicad@kicad.jp>\n"
@@ -713,7 +713,7 @@ msgstr ""
 "向にパンするにはマウスの（中央）ホイールを押します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:304
+#: getting_started_in_kicad.adoc:306
 #, fuzzy
 #| msgid ""
 #| "Hover the mouse over the component 'R' and press the r key. Notice how "
@@ -727,7 +727,7 @@ msgstr ""
 "ポーネントがどのように回転するか注目しましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:306
+#: getting_started_in_kicad.adoc:312
 msgid ""
 "If your mouse was also over the _Field Reference_ ('R') or the _Field Value_ "
 "('R?'), a menu will appear. You will see these 'Clarify Selection' menu "
@@ -737,7 +737,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:312
+#: getting_started_in_kicad.adoc:318
 msgid ""
 "Right click in the middle of the component and select *Edit Component* -> "
 "**Value**. You can achieve the same result by hovering over the component "
@@ -752,12 +752,12 @@ msgstr ""
 "の利用可能なショートカットキーを見せてくれることに注目しましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:314
+#: getting_started_in_kicad.adoc:320
 msgid "image:images/edit_component_dropdown.png[Edit component menu]"
 msgstr "image:images/ja/edit_component_dropdown.png[Edit component menu]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:317
+#: getting_started_in_kicad.adoc:323
 msgid ""
 "The Component value window will appear. Replace the current value 'R' with "
 "'1k'. Click OK."
@@ -766,7 +766,7 @@ msgstr ""
 "き換えます。OKをクリックします。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:320
+#: getting_started_in_kicad.adoc:326
 msgid ""
 "Do not change the Reference field (R?), this will be done automatically "
 "later on. The value inside the resistor should now be '1k'."
@@ -775,12 +775,12 @@ msgstr ""
 "れます。これで抵抗器の中の定数は '1k' となりました。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:322
+#: getting_started_in_kicad.adoc:328
 msgid "image:images/resistor_value.png[Resistor Value]"
 msgstr "image:images/resistor_value.png[Resistor Value]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:325
+#: getting_started_in_kicad.adoc:331
 msgid ""
 "To place another resistor, simply click where you want the resistor to "
 "appear. The Component Selection window will appear again."
@@ -789,7 +789,7 @@ msgstr ""
 "ネント選択のウィンドウが再び表示されます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:328
+#: getting_started_in_kicad.adoc:334
 msgid ""
 "The resistor you previously chose is now in your history list, appearing as "
 "'R'. Click OK and place the component."
@@ -798,12 +798,12 @@ msgstr ""
 "コンポーネントを配置します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:330
+#: getting_started_in_kicad.adoc:336
 msgid "image:images/component_history.png[Component history]"
 msgstr "image:images/ja/component_history.png[Component history]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:335
+#: getting_started_in_kicad.adoc:341
 msgid ""
 "In case you make a mistake and want to delete a component, right click on "
 "the component and click 'Delete Component'. This will remove the component "
@@ -816,7 +816,7 @@ msgstr ""
 "\"Delete\" キーを押すこともできます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:339
+#: getting_started_in_kicad.adoc:345
 msgid ""
 "You can edit any default shortcut key by going to *Preferences* -> *Hotkeys* "
 "-> **Edit hotkeys**. Any modification will be saved immediately."
@@ -825,7 +825,7 @@ msgstr ""
 "** で編集できます。変更は即座に保存されます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:343
+#: getting_started_in_kicad.adoc:349
 msgid ""
 "You can also duplicate a component already on your schematic sheet by "
 "hovering over it and pressing the c key. Click where you want to place the "
@@ -836,7 +836,7 @@ msgstr ""
 "い場所をクリックして下さい。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:349
+#: getting_started_in_kicad.adoc:355
 msgid ""
 "Right click on the second resistor. Select 'Drag Component'.  Reposition the "
 "component and left click to drop. The same functionality can be achieved by "
@@ -849,7 +849,7 @@ msgstr ""
 "\" キーを使います。\"x\" キーと \"y\" キーはコンポーネントを反転させます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:354
+#: getting_started_in_kicad.adoc:360
 #, no-wrap
 msgid ""
 "*Right-Click* -> *Move component* (equivalent to the m key\n"
@@ -863,7 +863,7 @@ msgstr ""
 "なぜそうなのかは後述します。\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:358
+#: getting_started_in_kicad.adoc:364
 msgid ""
 "Edit the second resistor by hovering over it and pressing the v key.  "
 "Replace 'R' with '100'. You can undo any of your editing actions with the "
@@ -874,7 +874,7 @@ msgstr ""
 "きます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:364
+#: getting_started_in_kicad.adoc:370
 msgid ""
 "Change the grid size. You have probably noticed that on the schematic sheet "
 "all components are snapped onto a large pitch grid. You can easily change "
@@ -887,7 +887,7 @@ msgstr ""
 "回路図シートでは50.0ミルのグリッドをお勧めします。__"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:366
+#: getting_started_in_kicad.adoc:374
 msgid ""
 "We are going to add a component from a library that isn't configured in the "
 "default project. In the menu, choose *Preferences* -> **Component "
@@ -895,7 +895,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:368
+#: getting_started_in_kicad.adoc:380
 msgid ""
 "You need to find where the official KiCad libraries are installed on your "
 "computer. Look for a `library` directory containing a hundred of `.dcm` and "
@@ -905,7 +905,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:372
+#: getting_started_in_kicad.adoc:384
 #, fuzzy
 #| msgid ""
 #| "Repeat the add-component steps, this time choosing the 'device' library "
@@ -919,7 +919,7 @@ msgstr ""
 "て 'LED' コンポーネントを選びましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:377
+#: getting_started_in_kicad.adoc:389
 msgid ""
 "Hover the mouse over the microcontroller component. Press the y key or the x "
 "key on the keyboard. Notice how the component is flipped over its x axis or "
@@ -930,7 +930,7 @@ msgstr ""
 "ます。キーをもう一度押すと元の方向に戻ります。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:380
+#: getting_started_in_kicad.adoc:392
 msgid ""
 "Repeat the add-component steps, this time choosing the 'device' library and "
 "picking the 'LED' component from it."
@@ -939,17 +939,17 @@ msgstr ""
 "て 'LED' コンポーネントを選びましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:382
+#: getting_started_in_kicad.adoc:394
 msgid "Organise all components on your schematic sheet as shown below."
 msgstr "回路図シート上の全てのコンポーネントを以下のように整理します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:384
+#: getting_started_in_kicad.adoc:396
 msgid "image:images/gsik_tutorial1_010.png[gsik_tutorial1_010_png]"
 msgstr "image:images/gsik_tutorial1_010.png[gsik_tutorial1_010_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:390
+#: getting_started_in_kicad.adoc:402
 msgid ""
 "We now need to create the schematic component 'MYCONN3' for our 3-pin "
 "connector. You can jump to the section titled <<make-schematic-components-in-"
@@ -963,7 +963,7 @@ msgstr ""
 "に戻ってきて下さい。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:393
+#: getting_started_in_kicad.adoc:405
 msgid ""
 "You can now place the freshly made component. Press the 'a' key and pick the "
 "'MYCONN3' component in the 'myLib' library."
@@ -973,7 +973,7 @@ msgstr ""
 "'MYCONN3' コンポーネントを選びます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:399
+#: getting_started_in_kicad.adoc:411
 msgid ""
 "The component identifier 'J?' will appear under the 'MYCONN3' label.  If you "
 "want to change its position, right click on 'J?' and click on 'Move "
@@ -988,12 +988,12 @@ msgstr ""
 "動かすことができます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:401
+#: getting_started_in_kicad.adoc:413
 msgid "image:images/gsik_myconn3_s.png[gsik_myconn3_s_png]"
 msgstr "image:images/gsik_myconn3_s.png[gsik_myconn3_s_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:407
+#: getting_started_in_kicad.adoc:419
 msgid ""
 "It is time to place the power and ground symbols. Click on the 'Place a "
 "power port' button image:images/icons/add_power.png[add_power_png] on the "
@@ -1006,7 +1006,7 @@ msgstr ""
 "し、 'power' ライブラリから 'VCC' 選択します。OKをクリックします。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:413
+#: getting_started_in_kicad.adoc:425
 msgid ""
 "Click above the pin of the 1k resistor to place the VCC part. Click on the "
 "area above the microcontroller 'VDD'. In the 'Component Selection history' "
@@ -1019,7 +1019,7 @@ msgstr ""
 "'MYCONN3' のVCCピンの上方に配置します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:418
+#: getting_started_in_kicad.adoc:430
 msgid ""
 "Repeat the add-pin steps but this time select the GND part. Place a GND part "
 "under the GND pin of 'MYCONN3'. Place another GND symbol on the right of the "
@@ -1031,12 +1031,12 @@ msgstr ""
 "のVSSピンの右に配置します。回路図はこのようになっているはずです。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:420
+#: getting_started_in_kicad.adoc:432
 msgid "image:images/gsik_tutorial1_020.png[gsik_tutorial1_020_png]"
 msgstr "image:images/gsik_tutorial1_020.png[gsik_tutorial1_020_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:424
+#: getting_started_in_kicad.adoc:436
 msgid ""
 "Next, we will wire all our components. Click on the 'Place wire' icon image:"
 "images/icons/add_line.png[Place wire] on the right toolbar."
@@ -1045,7 +1045,7 @@ msgstr ""
 "コン image:images/icons/add_line.png[Place wire] をクリックします。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:429
+#: getting_started_in_kicad.adoc:441
 msgid ""
 "Be careful not to pick 'Place a bus', which appears directly beneath this "
 "button but has thicker lines. The section <<bus-connections-in-kicad,Bus "
@@ -1056,7 +1056,7 @@ msgstr ""
 "ように使うか説明しています。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:433
+#: getting_started_in_kicad.adoc:445
 msgid ""
 "Click on the little circle at the end of pin 7 of the microcontroller and "
 "then click on the little circle on pin 2 of the LED.  You can zoom in while "
@@ -1066,7 +1066,7 @@ msgstr ""
 "クリックします。接続を配置する時にズームインすることができます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:438
+#: getting_started_in_kicad.adoc:450
 msgid ""
 "If you want to reposition wired components, it is important to use the g key "
 "(grab) option and not the m key (move) option. Using the grab option will "
@@ -1079,12 +1079,12 @@ msgstr ""
 "ましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:440
+#: getting_started_in_kicad.adoc:452
 msgid "image:images/gsik_tutorial1_030.png[gsik_tutorial1_030_png]"
 msgstr "image:images/gsik_tutorial1_030.png[gsik_tutorial1_030_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:446
+#: getting_started_in_kicad.adoc:458
 msgid ""
 "Repeat this process and wire up all the other components as shown below. To "
 "terminate a wire just double-click. When wiring up the VCC and GND symbols, "
@@ -1097,12 +1097,12 @@ msgstr ""
 "ください。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:448
+#: getting_started_in_kicad.adoc:460
 msgid "image:images/gsik_tutorial1_040.png[gsik_tutorial1_040_png]"
 msgstr "image:images/gsik_tutorial1_040.png[gsik_tutorial1_040_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:453
+#: getting_started_in_kicad.adoc:465
 msgid ""
 "We will now consider an alternative way of making a connection using labels. "
 "Pick a net labelling tool by clicking on the 'Place net name' icon image:"
@@ -1114,7 +1114,7 @@ msgstr ""
 "して ネット名の配置ツールを選びます。\"l\" キーを使うこともできます。 "
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:456
+#: getting_started_in_kicad.adoc:468
 msgid ""
 "Click in the middle of the wire connected to pin 6 of the microcontroller. "
 "Name this label 'INPUT'."
@@ -1123,7 +1123,7 @@ msgstr ""
 "ラベルに 'INPUT' と名前をつけます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:465
+#: getting_started_in_kicad.adoc:477
 msgid ""
 "Follow the same procedure and place another label on line on the right of "
 "the 100 ohm resistor. Also name it 'INPUT'. The two labels, having the same "
@@ -1140,7 +1140,7 @@ msgstr ""
 "ピンにラベルを付けることができます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:471
+#: getting_started_in_kicad.adoc:483
 msgid ""
 "Labels can also be used to simply label wires for informative purposes. "
 "Place a label on pin 7 of the PIC. Enter the name 'uCtoLED'.  Name the wire "
@@ -1153,7 +1153,7 @@ msgstr ""
 "り、です。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:474
+#: getting_started_in_kicad.adoc:486
 msgid ""
 "You do not have to label the VCC and GND lines because the labels are "
 "implied from the power objects they are connected to."
@@ -1162,17 +1162,17 @@ msgstr ""
 "源オブジェクトから暗黙的に定義されています。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:476
+#: getting_started_in_kicad.adoc:488
 msgid "Below you can see what the final result should look like."
 msgstr "下図に最終的な結果がどのように見えるかを示します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:478
+#: getting_started_in_kicad.adoc:490
 msgid "image:images/gsik_tutorial1_050.png[gsik_tutorial1_050_png]"
 msgstr "image:images/gsik_tutorial1_050.png[gsik_tutorial1_050_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:484
+#: getting_started_in_kicad.adoc:496
 msgid ""
 "Let's now deal with unconnected wires. Any pin or wire that is not connected "
 "will generate a warning when checked by KiCad. To avoid these warnings you "
@@ -1184,7 +1184,7 @@ msgstr ""
 "続されていないのが意図的であることをプログラムに指示することができます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:489
+#: getting_started_in_kicad.adoc:501
 msgid ""
 "Click on the 'Place no connect flag' icon image:images/icons/noconn."
 "png[noconn_png] on the right toolbar. Click on pins 2, 3, 4 and 5. An X will "
@@ -1195,12 +1195,12 @@ msgstr ""
 "でクリックします。 Xは未接続が意図的であることを示すために表示されます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:491
+#: getting_started_in_kicad.adoc:503
 msgid "image:images/gsik_tutorial1_060.png[gsik_tutorial1_060_png]"
 msgstr "image:images/gsik_tutorial1_060.png[gsik_tutorial1_060_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:498
+#: getting_started_in_kicad.adoc:510
 msgid ""
 "Some components have power pins that are invisible. You can make them "
 "visible by clicking on the 'Show hidden pins' icon image:images/icons/"
@@ -1215,7 +1215,7 @@ msgstr ""
 "うに努力すべきです。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:504
+#: getting_started_in_kicad.adoc:516
 msgid ""
 "It is now necessary to add a 'Power Flag' to indicate to KiCad that power "
 "comes in from somewhere. Press the a key, select 'List All', double click on "
@@ -1228,12 +1228,12 @@ msgstr ""
 "にGNDとVCCに接続しましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:506
+#: getting_started_in_kicad.adoc:518
 msgid "image:images/gsik_tutorial1_070.png[gsik_tutorial1_070_png]"
 msgstr "image:images/gsik_tutorial1_070.png[gsik_tutorial1_070_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:509
+#: getting_started_in_kicad.adoc:521
 msgid ""
 "This will avoid the classic schematic checking warning: Warning Pin power_in "
 "not driven (Net xx)"
@@ -1242,7 +1242,7 @@ msgstr ""
 "ピンは駆動されていません (Net xx)"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:513
+#: getting_started_in_kicad.adoc:525
 msgid ""
 "Sometimes it is good to write comments here and there. To add comments on "
 "the schematic use the 'Place graphic text (comment)' icon image:images/icons/"
@@ -1253,7 +1253,7 @@ msgstr ""
 "add_text.png[add_text_png] を使います。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:518
+#: getting_started_in_kicad.adoc:531
 #, fuzzy
 #| msgid ""
 #| "All components now need to have unique identifiers. In fact, many of our "
@@ -1272,7 +1272,7 @@ msgstr ""
 "png[annotate_png] をクリックすることで自動的に行われます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:525
+#: getting_started_in_kicad.adoc:538
 msgid ""
 "In the Annotate Schematic window, select 'Use the entire schematic' and "
 "click on the 'Annotation' button. Click OK in the confirmation message and "
@@ -1287,7 +1287,7 @@ msgstr ""
 "'U1' 、 'D1' そして 'J1' と名付けられました。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:535
+#: getting_started_in_kicad.adoc:547
 #, fuzzy
 #| msgid ""
 #| "We will now check our schematic for errors. Click on the 'Perform "
@@ -1316,7 +1316,7 @@ msgstr ""
 "イルの生成' をチェックし、'実行' ボタンを再度押します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:537
+#: getting_started_in_kicad.adoc:551
 msgid ""
 "If you have a warning with \"No default editor found you must choose it\", "
 "try setting the path to `c:\\windows\\notepad.exe` (windows) or `/usr/bin/"
@@ -1324,7 +1324,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:542
+#: getting_started_in_kicad.adoc:556
 #, fuzzy
 #| msgid ""
 #| "The schematic is now finished. We can now create a Netlist file to which "
@@ -1345,7 +1345,7 @@ msgstr ""
 "名で '保存' をクリックします。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:547
+#: getting_started_in_kicad.adoc:561
 msgid ""
 "After generating the Netlist file, click on the 'Run Cvpcb' icon image:"
 "images/icons/cvpcb.png[cvpcb_png] on the top toolbar. If a missing file "
@@ -1357,7 +1357,7 @@ msgstr ""
 "表示されたらOKをクリックします。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:553
+#: getting_started_in_kicad.adoc:567
 msgid ""
 "_Cvpcb_ allows you to link all the components in your schematic with "
 "footprints in the KiCad library. The pane on the center shows all the "
@@ -1372,12 +1372,12 @@ msgstr ""
 "ダウンして、それをダブルクリックします。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:555
+#: getting_started_in_kicad.adoc:569
 msgid "image:images/icons/cvpcb.png[cvpcb_png]"
 msgstr "image:images/icons/cvpcb.png[cvpcb_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:563
+#: getting_started_in_kicad.adoc:577
 msgid ""
 "It is possible that the pane on the right shows only a selected subgroup of "
 "available footprints. This is because KiCad is trying to suggest to you a "
@@ -1396,7 +1396,7 @@ msgstr ""
 "す。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:567
+#: getting_started_in_kicad.adoc:581
 msgid ""
 "For 'IC1' select the 'Housings_DIP:DIP-8_W7.62mm' footprint.  For 'J1' "
 "select the 'Connect:Banana_Jack_3Pin' footprint.  For 'R1' and 'R2' select "
@@ -1407,7 +1407,7 @@ msgstr ""
 "フットプリント 'Discret:R1' footprint を選択します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:578
+#: getting_started_in_kicad.adoc:592
 msgid ""
 "If you are interested in knowing what the footprint you are choosing looks "
 "like, you have two options. You can click on the 'View selected footprint' "
@@ -1426,7 +1426,7 @@ msgstr ""
 "リントのPDF文書が得られます。印刷して部品の寸法が適合することを確認できます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:587
+#: getting_started_in_kicad.adoc:601
 msgid ""
 "You are done. You can now update your netlist file with all the associated "
 "footprints. Click on *File* -> **Save As**. The default name 'tutorial1.net' "
@@ -1445,7 +1445,7 @@ msgstr ""
 "についてはこの文書の後の章で説明されます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:591
+#: getting_started_in_kicad.adoc:605
 msgid ""
 "You can close _Cvpcb_ and go back to the _Eeschema_ schematic editor. Save "
 "the project by clicking on *File* -> **Save Whole Schematic Project**. Close "
@@ -1456,12 +1456,12 @@ msgstr ""
 "ます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:593
+#: getting_started_in_kicad.adoc:607
 msgid "Switch to the KiCad project manager."
 msgstr "KiCadプロジェクト・マネージャに切り替えます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:597
+#: getting_started_in_kicad.adoc:611
 msgid ""
 "The netlist file describes all components and their respective pin "
 "connections. The netlist file is actually a text file that you can easily "
@@ -1472,7 +1472,7 @@ msgstr ""
 "りすることができます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:600
+#: getting_started_in_kicad.adoc:614
 msgid ""
 "Library files (__*.lib__) are text files too and they are also easily "
 "editable or scriptable."
@@ -1481,7 +1481,7 @@ msgstr ""
 "り記述することができます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:607
+#: getting_started_in_kicad.adoc:621
 msgid ""
 "To create a Bill Of Materials (BOM), go to the _Eeschema_ schematic editor "
 "and click on the 'Bill of materials' icon image:images/icons/bom."
@@ -1496,7 +1496,7 @@ msgstr ""
 "イルを選択します。この場合は __bom2csv.xsl__ を選択します。"
 
 #. type: delimited block =
-#: getting_started_in_kicad.adoc:612
+#: getting_started_in_kicad.adoc:626
 msgid ""
 "The *.xsl file is located in __plugins__ directory of the KiCad "
 "installation, which is located at: /usr/lib/kicad/plugins/."
@@ -1505,47 +1505,47 @@ msgstr ""
 "それは次の場所に位置します: /usr/lib/kicad/plugins/"
 
 #. type: delimited block =
-#: getting_started_in_kicad.adoc:614
+#: getting_started_in_kicad.adoc:628
 msgid "Or get the file via:"
 msgstr "または次のようにしてファイルを入手します:"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:616
+#: getting_started_in_kicad.adoc:630
 #, no-wrap
 msgid "wget https://raw.githubusercontent.com/KiCad/kicad-source-mirror/master/eeschema/plugins/bom2csv.xsl\n"
 msgstr "wget https://raw.githubusercontent.com/KiCad/kicad-source-mirror/master/eeschema/plugins/bom2csv.xsl\n"
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:619
+#: getting_started_in_kicad.adoc:633
 #, no-wrap
 msgid "KiCad automatically generates the command, for example:"
 msgstr "KiCadは自動的にコマンドを生成します、例えばこのように:"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:622
+#: getting_started_in_kicad.adoc:636
 #, no-wrap
 msgid "xsltproc -o \"%O\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 msgstr "xsltproc -o \"%O\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:624
+#: getting_started_in_kicad.adoc:638
 #, no-wrap
 msgid "You may want to add the extension, so change this command line to:"
 msgstr "拡張子を与えたい場合、このコマンドラインを変更します:"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:627
+#: getting_started_in_kicad.adoc:641
 #, no-wrap
 msgid "xsltproc -o \"%O.csv\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 msgstr "xsltproc -o \"%O.csv\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:630
+#: getting_started_in_kicad.adoc:644
 msgid "Press Help button for more info."
 msgstr "ヘルプボタンを押すことで更に情報が得られます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:634
+#: getting_started_in_kicad.adoc:648
 msgid ""
 "Now press 'Generate'. The file (same name as your project) is located in "
 "your project folder.  Open the **.csv* file with LibreOffice Calc or Excel. "
@@ -1556,7 +1556,7 @@ msgstr ""
 "で開いてみましょう。インポートのウィンドウが表示されたらOKを押します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:638
+#: getting_started_in_kicad.adoc:652
 msgid ""
 "You are now ready to move to the PCB layout part, which is presented in the "
 "next section. However, before moving on let's take a quick look at how to "
@@ -1566,13 +1566,13 @@ msgstr ""
 "進む前に、コンポーネントのピンをバスで接続する方法をさっと見ておきましょう。"
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:640
+#: getting_started_in_kicad.adoc:654
 #, no-wrap
 msgid "Bus connections in KiCad"
 msgstr "KiCadでのバス接続"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:646
+#: getting_started_in_kicad.adoc:660
 msgid ""
 "Sometimes you might need to connect several sequential pins of component A "
 "with some other sequential pins of component B. In this case you have two "
@@ -1584,7 +1584,7 @@ msgstr ""
 "たラベルによる方法とバス接続です。どうするのか見てみましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:653
+#: getting_started_in_kicad.adoc:667
 msgid ""
 "Let us suppose that you have three 4-pin connectors that you want to connect "
 "together pin to pin. Use the label option (press the l key) to label pin 4 "
@@ -1598,7 +1598,7 @@ msgstr ""
 "は自動的に 'a2' とリネームされます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:657
+#: getting_started_in_kicad.adoc:671
 msgid ""
 "Press the Ins Key two more times. The Ins key corresponds to the action "
 "'Repeat last item' and it is an infinitely useful command that can make your "
@@ -1608,7 +1608,7 @@ msgstr ""
 "機能に対応しており、あなたの仕事を楽にしてくれるとても便利なコマンドです。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:668
+#: getting_started_in_kicad.adoc:682
 msgid ""
 "Repeat the same labelling action on the two other connectors CONN_2 and "
 "CONN_3 and you are done. If you proceed and make a PCB you will see that the "
@@ -1628,7 +1628,7 @@ msgstr ""
 "可能です。PCBにはなんの影響もありませんが。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:672
+#: getting_started_in_kicad.adoc:686
 msgid ""
 "It should be pointed out that the short wire attached to the pins in Figure "
 "2 is not strictly necessary. In fact, the labels could have been applied "
@@ -1638,7 +1638,7 @@ msgstr ""
 "す。実際、ラベルはピンに直接付けることができるのでした。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:679
+#: getting_started_in_kicad.adoc:693
 msgid ""
 "Let's take it one step further and suppose that you have a fourth connector "
 "named CONN_4 and, for whatever reason, its labelling happens to be a little "
@@ -1654,7 +1654,7 @@ msgstr ""
 "たいわけです。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:686
+#: getting_started_in_kicad.adoc:700
 msgid ""
 "Connect and label CONN_4 using the labelling method explained before. Name "
 "the pins b1, b2, b3 and b4. Connect the pin to a series of 'Wire to bus "
@@ -1669,7 +1669,7 @@ msgstr ""
 "ンに、ピンを接続します。図4を見て下さい。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:689
+#: getting_started_in_kicad.adoc:703
 msgid ""
 "Put a label (press the l key option) on the bus of CONN_4 and name it "
 "'b[1..4]'."
@@ -1677,7 +1677,7 @@ msgstr ""
 "CONN_4のバスにラベルを付けて(\"l\" キーを押して) 'b[1..4]' と名付けます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:692
+#: getting_started_in_kicad.adoc:706
 msgid ""
 "Put a label (press the l key option) on the previous a bus and name it "
 "'a[1..4]'."
@@ -1685,7 +1685,7 @@ msgstr ""
 "以前のバスにラベルを付けて(\"l\" キーを押して) 'a[1..4]' と名付けます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:695
+#: getting_started_in_kicad.adoc:709
 msgid ""
 "What we can now do is connect bus a[1..4] with bus b[1..4] using a bus line "
 "with the button image:images/icons/add_bus.png[add_bus_png]."
@@ -1694,7 +1694,7 @@ msgstr ""
 "a[1..4]とバスb[1..4]を接続することでできるようになりました。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:699
+#: getting_started_in_kicad.adoc:713
 msgid ""
 "By connecting the two buses together, pin a1 will be automatically connected "
 "to pin b1, a2 will be connected to b2 and so on. Figure 4 shows what the "
@@ -1704,7 +1704,7 @@ msgstr ""
 "れ、以下同様となります。図4は最終結果がどのように見えるか示しています。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:704
+#: getting_started_in_kicad.adoc:718
 msgid ""
 "The 'Repeat last item' option accessible via the Ins key can be successfully "
 "used to repeat period item insertions. For instance, the short wires "
@@ -1716,7 +1716,7 @@ msgstr ""
 "4 での作業はこの機能でできました。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:708
+#: getting_started_in_kicad.adoc:722
 msgid ""
 "The 'Repeat last item' option accessible via the Ins key has also been "
 "extensively used to place the many series of 'Wire to bus entry' using the "
@@ -1727,18 +1727,18 @@ msgstr ""
 "スエントリを配置' にも適用できます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:710
+#: getting_started_in_kicad.adoc:724
 msgid "image:images/gsik_bus_connection.png[gsik_bus_connection_png]"
 msgstr "image:images/gsik_bus_connection.png[gsik_bus_connection_png]"
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:712
+#: getting_started_in_kicad.adoc:726
 #, no-wrap
 msgid "Layout printed circuit boards"
 msgstr "プリント基板のレイアウト"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:716
+#: getting_started_in_kicad.adoc:730
 msgid ""
 "It is now time to use the netlist file you generated to lay out the PCB.  "
 "This is done with the _Pcbnew_ tool."
@@ -1747,13 +1747,13 @@ msgstr ""
 "は _Pcbnew_ ツールで行います。"
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:718
+#: getting_started_in_kicad.adoc:732
 #, no-wrap
 msgid "Using Pcbnew"
 msgstr "Pcbnew の使用"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:724
+#: getting_started_in_kicad.adoc:738
 msgid ""
 "From the KiCad project manager, click on the 'Pcbnew' icon image:images/"
 "icons/pcbnew.png[pcbnew_png]. The 'Pcbnew' window will open. If you get an "
@@ -1766,7 +1766,7 @@ msgstr ""
 "セージが出たら 'はい' をクリックします。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:728
+#: getting_started_in_kicad.adoc:742
 msgid ""
 "Begin by entering some schematic information. Click on the 'Page settings' "
 "icon image:images/icons/sheetset.png[sheetset_png] on the top toolbar. Set "
@@ -1778,7 +1778,7 @@ msgstr ""
 "す。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:737
+#: getting_started_in_kicad.adoc:751
 msgid ""
 "It is a good idea to start by setting the *clearance* and the *minimum track "
 "width* to those required by your PCB manufacturer. In general you can set "
@@ -1797,12 +1797,12 @@ msgstr ""
 "す。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:739
+#: getting_started_in_kicad.adoc:753
 msgid "image:images/design_rules.png[Design Rules Window]"
 msgstr "image:images/ja/design_rules.png[Design Rules Window]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:743
+#: getting_started_in_kicad.adoc:757
 msgid ""
 "Click on the 'Global Design Rules' tab and set 'Min track width' to 0.25'. "
 "Click the OK button to commit your changes and close the Design Rules Editor "
@@ -1813,7 +1813,7 @@ msgstr ""
 "ウィンドウを閉じます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:749
+#: getting_started_in_kicad.adoc:763
 msgid ""
 "Now we will import the netlist file. Click on the 'Read Netlist' icon image:"
 "images/icons/netlist.png[netlist_png] on the top toolbar. Click on the "
@@ -1827,7 +1827,7 @@ msgstr ""
 "リックします。その後、'閉じる' ボタンをクリックします。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:752
+#: getting_started_in_kicad.adoc:766
 msgid ""
 "All components should now be visible in the top left hand corner just above "
 "the page. Scroll up if you cannot see them."
@@ -1836,7 +1836,7 @@ msgstr ""
 "スクロールアップしましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:756
+#: getting_started_in_kicad.adoc:770
 msgid ""
 "Select all components with the mouse and move them to the middle of the "
 "board. If necessary you can zoom in and out while you move the components."
@@ -1845,7 +1845,7 @@ msgstr ""
 "コンポーネントの移動中にズームインやズームアウトすることができます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:762
+#: getting_started_in_kicad.adoc:776
 msgid ""
 "All components are connected via a thin group of wires called __ratsnest__. "
 "Make sure that the 'Hide board ratsnest' button image:images/icons/"
@@ -1858,7 +1858,7 @@ msgstr ""
 "これでラッツネストが全てのコンポーネントをつないでいるのが見えます。 "
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:765
+#: getting_started_in_kicad.adoc:779
 msgid ""
 "The tool-tip is backwards; pressing this button actually displays the "
 "ratsnest."
@@ -1866,7 +1866,7 @@ msgstr ""
 "ツールチップは逆を示します; このボタンを押すことでラッツネストを表示します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:769
+#: getting_started_in_kicad.adoc:783
 msgid ""
 "You can move each component by hovering over it and pressing the g key. "
 "Click where you want to place them. Move all components around until you "
@@ -1877,7 +1877,7 @@ msgstr ""
 "ポーネントを移動します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:774
+#: getting_started_in_kicad.adoc:788
 msgid ""
 "If instead of grabbing the components (with the g key ) you move them around "
 "using the m key you will later note that you lose the track connection (the "
@@ -1889,12 +1889,12 @@ msgstr ""
 "つでも \"g\" キーを使いましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:776
+#: getting_started_in_kicad.adoc:790
 msgid "image:images/gsik_tutorial1_080.png[gsik_tutorial1_080_png]"
 msgstr "image:images/gsik_tutorial1_080.png[gsik_tutorial1_080_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:783
+#: getting_started_in_kicad.adoc:797
 msgid ""
 "If the ratsnest disappears or the screen gets messy, right click and click "
 "'Redraw view'. Note how one pin of the 100 ohm resistor is connected to pin "
@@ -1909,7 +1909,7 @@ msgstr ""
 "するからです。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:791
+#: getting_started_in_kicad.adoc:805
 msgid ""
 "Now we will define the edge of the PCB. Select 'Edge.Cuts' from the drop "
 "down menu in the top toolbar. Click on the 'Add graphic line or polygon' "
@@ -1925,7 +1925,7 @@ msgstr ""
 "色端部とPCBの端部の間には小さな隙間を残すことを覚えておきましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:795
+#: getting_started_in_kicad.adoc:809
 msgid ""
 "Next, connect up all the wires except GND. In fact, we will connect all GND "
 "connections in one go using a ground plane placed on the bottom copper "
@@ -1936,7 +1936,7 @@ msgstr ""
 "使って一気に行います。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:799
+#: getting_started_in_kicad.adoc:813
 msgid ""
 "Now we must choose which copper layer we want to work on. Select 'F.Cu "
 "(PgUp)' in the drag down menu on the top toolbar. This is the front top "
@@ -1946,13 +1946,13 @@ msgstr ""
 "ドロップダウンメニューの 'F.Cu (\"PgUp\" キー)' を選択します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:801
+#: getting_started_in_kicad.adoc:815
 msgid "image:images/select_top_copper.png[Select the Front top copper layer]"
 msgstr ""
 "image:images/ja/select_top_copper.png[Select the Front top copper layer]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:807
+#: getting_started_in_kicad.adoc:821
 msgid ""
 "If you decide, for instance, to do a 4 layer PCB instead, go to *Design "
 "Rules* -> *Layers Setup* and change 'Copper Layers' to 4. In the 'Layers' "
@@ -1966,7 +1966,7 @@ msgstr ""
 "グループ' メニューで、便利なプリセットが選択できることを覚えておきましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:815
+#: getting_started_in_kicad.adoc:829
 msgid ""
 "Click on the 'Add Tracks and vias' icon image:images/icons/add_tracks."
 "png[add_tracks_png] on the right toolbar. Click on pin 1 of 'J1' and run a "
@@ -1983,12 +1983,12 @@ msgstr ""
 "とに気付いてください。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:817
+#: getting_started_in_kicad.adoc:831
 msgid "image:images/pcbnew_1.png[pcbnew_1_png]"
 msgstr "image:images/ja/pcbnew_1.png[pcbnew_1_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:823
+#: getting_started_in_kicad.adoc:837
 msgid ""
 "If you would like to add more track widths go to: *Design Rules* -> *Design "
 "Rules* -> *Global Design Rules* tab and at the bottom right of this window "
@@ -2002,12 +2002,12 @@ msgstr ""
 "ことができるようになります。以下の例(インチ単位)をご覧下さい。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:825
+#: getting_started_in_kicad.adoc:839
 msgid "image:images/custom_tracks_width.png[custom_tracks_width_png]"
 msgstr "image:images/ja/custom_tracks_width.png[custom_tracks_width_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:832
+#: getting_started_in_kicad.adoc:846
 msgid ""
 "Alternatively, you can add a Net Class in which you specify a set of "
 "options. Go to *Design Rules* -> *Design Rules* -> *Net Classes Editor* and "
@@ -2023,7 +2023,7 @@ msgstr ""
 "す(左で 'default' を選び、右で 'power' を選び、矢印を使います)。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:836
+#: getting_started_in_kicad.adoc:850
 msgid ""
 "If you want to change the grid size, *Right click* -> **Grid Select**. Be "
 "sure to select the appropriate grid size before or after laying down the "
@@ -2034,7 +2034,7 @@ msgstr ""
 "下さい。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:839
+#: getting_started_in_kicad.adoc:853
 msgid ""
 "Repeat this process until all wires, except pin 3 of J1, are connected. Your "
 "board should look like the example below."
@@ -2043,12 +2043,12 @@ msgstr ""
 "板は以下の例のようになるでしょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:841
+#: getting_started_in_kicad.adoc:855
 msgid "image:images/gsik_tutorial1_090.png[gsik_tutorial1_090_png]"
 msgstr "image:images/gsik_tutorial1_090.png[gsik_tutorial1_090_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:849
+#: getting_started_in_kicad.adoc:863
 msgid ""
 "Let's now run a track on the other copper side of the PCB. Select 'B.Cu' in "
 "the drag down menu on the top toolbar. Click on the 'Add tracks and vias' "
@@ -2064,7 +2064,7 @@ msgstr ""
 "でこの配線は必要ではありません。配線の色が変わっていることに注意しましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:856
+#: getting_started_in_kicad.adoc:870
 #, no-wrap
 msgid ""
 "**Go from pin A to pin B by changing layer**. It is possible to\n"
@@ -2082,13 +2082,13 @@ msgstr ""
 "これにより配線を終えた所で底面のレイヤに行くことができます。\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:858
+#: getting_started_in_kicad.adoc:872
 #, no-wrap
 msgid "image:images/place_a_via.png[place_a_via_png]\n"
 msgstr "image:images/ja/place_a_via.png[place_a_via_png]\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:864
+#: getting_started_in_kicad.adoc:878
 msgid ""
 "When you want to inspect a particular connection you can click on the 'Net "
 "highlight' icon image:images/icons/net_highlight.png[net_highlight_png] on "
@@ -2101,7 +2101,7 @@ msgstr ""
 "がハイライトされるでしょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:872
+#: getting_started_in_kicad.adoc:886
 msgid ""
 "Now we will make a ground plane that will be connected to all GND pins. "
 "Click on the 'Add Zones' icon image:images/icons/add_zone.png[add_zone_png] "
@@ -2118,7 +2118,7 @@ msgstr ""
 "ます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:877
+#: getting_started_in_kicad.adoc:891
 msgid ""
 "Trace around the outline of the board by clicking each corner in rotation. "
 "Double-click to finish your rectangle. Right click inside the area you have "
@@ -2131,12 +2131,12 @@ msgstr ""
 "う。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:879
+#: getting_started_in_kicad.adoc:893
 msgid "image:images/gsik_tutorial1_100.png[gsik_tutorial1_100_png]"
 msgstr "image:images/gsik_tutorial1_100.png[gsik_tutorial1_100_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:885
+#: getting_started_in_kicad.adoc:899
 msgid ""
 "Run the design rules checker by clicking on the 'Perform Design Rules Check' "
 "icon image:images/icons/drc.png[drc_png] on the top toolbar.  Click on "
@@ -2150,7 +2150,7 @@ msgstr ""
 "閉じます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:888
+#: getting_started_in_kicad.adoc:902
 msgid ""
 "Save your file by clicking on *File* -> **Save**. To admire your board in "
 "3D, click on *View* -> **3D Viewer**."
@@ -2159,17 +2159,17 @@ msgstr ""
 "ためには *表示* -> **3D ビューア** をクリックします。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:890
+#: getting_started_in_kicad.adoc:904
 msgid "image:images/pcbnew_3d_viewer.png[pcbnew_3d_viewer_png]"
 msgstr "image:images/pcbnew_3d_viewer.png[pcbnew_3d_viewer_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:892
+#: getting_started_in_kicad.adoc:906
 msgid "You can drag your mouse around to rotate the PCB."
 msgstr "PCBの周囲でマウスをドラッグしてPCBを回転させることができます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:895
+#: getting_started_in_kicad.adoc:909
 msgid ""
 "Your board is complete. To send it off to a manufacturer you will need to "
 "generate all Gerber files."
@@ -2178,13 +2178,13 @@ msgstr ""
 "あります。"
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:897
+#: getting_started_in_kicad.adoc:911
 #, no-wrap
 msgid "Generate Gerber files"
 msgstr "ガーバーファイルの生成"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:902
+#: getting_started_in_kicad.adoc:916
 msgid ""
 "Once your PCB is complete, you can generate Gerber files for each layer and "
 "send them to your favourite PCB manufacturer, who will make the board for "
@@ -2194,7 +2194,7 @@ msgstr ""
 "るあなたのお好みのPCBメーカーに送ることができます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:906
+#: getting_started_in_kicad.adoc:920
 msgid ""
 "From KiCad, open the _Pcbnew_ software tool and load your board file by "
 "clicking on the icon image:images/icons/open_document.png[open_document_png]."
@@ -2203,7 +2203,7 @@ msgstr ""
 "png[open_document_png] をクリックして基板のファイルを読み込みます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:910
+#: getting_started_in_kicad.adoc:924
 msgid ""
 "Click on *File* -> **Plot**. Select 'Gerber' as the 'Plot Format' and select "
 "the folder in which to put all Gerber files.  Proceed by clicking on the "
@@ -2214,13 +2214,13 @@ msgstr ""
 "ル出力' ボタンを押して出力します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:913
+#: getting_started_in_kicad.adoc:927
 msgid ""
 "These are the layers you need to select for making a typical 2-layer PCB:"
 msgstr "これらは典型的な2層PCBを製造するために選択する必要があるレイヤです:"
 
 #. type: delimited block |
-#: getting_started_in_kicad.adoc:924
+#: getting_started_in_kicad.adoc:938
 #, no-wrap
 msgid ""
 "|Layer |KiCad Layer Name |Old KiCad Layer Name |Default Gerber Extension\n"
@@ -2242,13 +2242,13 @@ msgstr ""
 "|基板外形 |Edge.Cuts |Edges_Pcb |.GBR |.GM1\n"
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:927
+#: getting_started_in_kicad.adoc:941
 #, no-wrap
 msgid "Using GerbView"
 msgstr "GerbView の使用"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:936
+#: getting_started_in_kicad.adoc:950
 msgid ""
 "To view all your Gerber files go to the KiCad project manager and click on "
 "the 'GerbView' icon.  On the drag down menu select 'Layer 1'. Click on "
@@ -2264,7 +2264,7 @@ msgstr ""
 "て表示されることに注意しましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:939
+#: getting_started_in_kicad.adoc:953
 msgid ""
 "Use the menu on the right to select/deselect which layer to show.  Carefully "
 "inspect each layer before sending them for production."
@@ -2273,7 +2273,7 @@ msgstr ""
 "前に注意深く全てのレイヤを検査しましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:942
+#: getting_started_in_kicad.adoc:956
 msgid ""
 "To generate the drill file, from _Pcbnew_ go again for the *File* -> *Plot* "
 "option. Default settings should be fine."
@@ -2282,13 +2282,13 @@ msgstr ""
 "行います。デフォルトの設定でよいでしょう。"
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:944
+#: getting_started_in_kicad.adoc:958
 #, no-wrap
 msgid "Automatically route with FreeRouter"
 msgstr "Freerouterによる自動配線"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:952
+#: getting_started_in_kicad.adoc:966
 msgid ""
 "Routing a board by hand is quick and fun, however, for a board with lots of "
 "components you might want to use an autorouter. Remember that you should "
@@ -2303,7 +2303,7 @@ msgstr ""
 "__freerouting.net__ のFreerouterです。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:957
+#: getting_started_in_kicad.adoc:971
 msgid ""
 "Freerouter is a open source java application, and it is needed to build by "
 "yourself to use with KiCad.  Source code of Freerouter can be found on this "
@@ -2314,7 +2314,7 @@ msgstr ""
 "す: https://github.com/nikropht/FreeRouting"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:963
+#: getting_started_in_kicad.adoc:977
 msgid ""
 "From _Pcbnew_ click on *File* -> *Export* -> *Specctra DSN* or click on "
 "*Tools* -> *FreeRoute* -> **Export a Specctra Design (*.dsn) file** and save "
@@ -2328,7 +2328,7 @@ msgstr ""
 "イルを選んで読み込ませます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:968
+#: getting_started_in_kicad.adoc:982
 msgid ""
 "The *Tools* -> *FreeRoute* dialog has a nice help button that opens a file "
 "viewer with a little document inside named **Freerouter Guidelines**. Please "
@@ -2339,7 +2339,7 @@ msgstr ""
 "す。 Freerouter を効果的に使うためにこのガイドラインに従いましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:974
+#: getting_started_in_kicad.adoc:988
 msgid ""
 "FreeRouter has some features that KiCad does not currently have, both for "
 "manual routing and for automatic routing. FreeRouter operates in two main "
@@ -2352,7 +2352,7 @@ msgstr ""
 "でも必要なら停止することができます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:982
+#: getting_started_in_kicad.adoc:996
 msgid ""
 "You can start the automatic routing by clicking on the 'Autorouter' button "
 "on the top bar. The bottom bar gives you information about the on-going "
@@ -2369,7 +2369,7 @@ msgstr ""
 "くすることです。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:987
+#: getting_started_in_kicad.adoc:1001
 msgid ""
 "Making a left-click on the mouse can stop the automatic routing and "
 "automatically start the optimisation process. Another left-click will stop "
@@ -2382,7 +2382,7 @@ msgstr ""
 "う。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:991
+#: getting_started_in_kicad.adoc:1005
 msgid ""
 "Click on the *File* -> *Export Specctra Session File* menu and save the "
 "board file with the _.ses_ extension. You do not really need to save the "
@@ -2393,7 +2393,7 @@ msgstr ""
 "せん。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:996
+#: getting_started_in_kicad.adoc:1010
 msgid ""
 "Back to __Pcbnew__. You can import your freshly routed board by clicking on "
 "the link *Tools* -> *FreeRoute* and then on the icon 'Back Import the "
@@ -2404,7 +2404,7 @@ msgstr ""
 "ses_ ファイルを選択し、新たに配線された基板をインポートします。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1001
+#: getting_started_in_kicad.adoc:1015
 msgid ""
 "If there is any routed trace that you do not like, you can delete it and re-"
 "route it again, using the del key and the routing tool, which is the 'Add "
@@ -2416,13 +2416,13 @@ msgstr ""
 "add_tracks.png[Add Track icon] の配線ツールを使いましょう。"
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1003
+#: getting_started_in_kicad.adoc:1017
 #, no-wrap
 msgid "Forward annotation in KiCad"
 msgstr "KiCadの前方向アノテーション"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1009
+#: getting_started_in_kicad.adoc:1023
 msgid ""
 "Once you have completed your electronic schematic, the footprint assignment, "
 "the board layout and generated the Gerber files, you are ready to send "
@@ -2433,7 +2433,7 @@ msgstr ""
 "ました。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1017
+#: getting_started_in_kicad.adoc:1031
 msgid ""
 "Often, this linear work-flow turns out to be not so uni-directional. For "
 "instance, when you have to modify/extend a board for which you or others "
@@ -2449,19 +2449,19 @@ msgstr ""
 "から配線し直すことでしょう。代わりにこのようにすべきです:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1020
+#: getting_started_in_kicad.adoc:1034
 msgid ""
 "Let's suppose that you want to replace a hypothetical connector CON1 with "
 "CON2."
 msgstr "仮想的なコネクタのCON1をCON2と入れ替えたいと想定しましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1022
+#: getting_started_in_kicad.adoc:1036
 msgid "You already have a completed schematic and a fully routed PCB."
 msgstr "あなたは既に完成した回路図と配線を終えたPCBを持っています。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1028
+#: getting_started_in_kicad.adoc:1042
 msgid ""
 "From KiCad, start __Eeschema__, make your modifications by deleting CON1 and "
 "adding CON2. Save your schematic project with the icon image:images/icons/"
@@ -2474,7 +2474,7 @@ msgstr ""
 "icons/netlist.png[netlist_png] をクリックします。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1031
+#: getting_started_in_kicad.adoc:1045
 msgid ""
 "Click on 'Netlist' then on 'save'. Save to the default file name.  You have "
 "to rewrite the old one."
@@ -2483,7 +2483,7 @@ msgstr ""
 "しょう。古いファイルを上書きします。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1037
+#: getting_started_in_kicad.adoc:1051
 msgid ""
 "Now assign a footprint to CON2. Click on the 'Run Cvpcb' icon image:images/"
 "icons/cvpcb.png[cvpcb] on the top toolbar. Assign the footprint to the new "
@@ -2497,7 +2497,7 @@ msgstr ""
 "__CvPcb__ を閉じます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1040
+#: getting_started_in_kicad.adoc:1054
 msgid ""
 "Back in the schematic editor, save the project by clicking on 'File' -> "
 "'Save Whole Schematic Project'. Close the schematic editor."
@@ -2506,7 +2506,7 @@ msgstr ""
 "ジェクトを保存します。 Eeschema を閉じます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1043
+#: getting_started_in_kicad.adoc:1057
 msgid ""
 "From the KiCad project manager, click on the 'Pcbnew' icon. The 'Pcbnew' "
 "window will open."
@@ -2515,7 +2515,7 @@ msgstr ""
 "'Pcbnew' のウィンドウが開きます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1047
+#: getting_started_in_kicad.adoc:1061
 msgid ""
 "The old, already routed, board should automatically open. Let's import the "
 "new netlist file. Click on the 'Read Netlist' icon image:images/icons/"
@@ -2526,7 +2526,7 @@ msgstr ""
 "images/icons/netlist.png[netlist_png] をクリックします。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1051
+#: getting_started_in_kicad.adoc:1065
 msgid ""
 "Click on the 'Browse Netlist Files' button, select the netlist file in the "
 "file selection dialogue, and click on 'Read Current Netlist'.  Then click "
@@ -2537,7 +2537,7 @@ msgstr ""
 "タンをクリックします。 "
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1056
+#: getting_started_in_kicad.adoc:1070
 msgid ""
 "At this point you should be able to see a layout with all previous "
 "components already routed. On the top left corner you should see all "
@@ -2549,7 +2549,7 @@ msgstr ""
 "す。基板の中央まで移動しましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1059
+#: getting_started_in_kicad.adoc:1073
 msgid ""
 "Place CON2 and route it. Once done, save and proceed with the Gerber file "
 "generation as usual."
@@ -2558,7 +2558,7 @@ msgstr ""
 "生成をしましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1067
+#: getting_started_in_kicad.adoc:1081
 msgid ""
 "The process described here can easily be repeated as many times as you need. "
 "Beside the Forward Annotation method described above, there is another "
@@ -2574,13 +2574,13 @@ msgstr ""
 "でここでは書きません。"
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1069
+#: getting_started_in_kicad.adoc:1083
 #, no-wrap
 msgid "Make schematic components in KiCad"
 msgstr "KiCad回路図コンポーネントの作成"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1076
+#: getting_started_in_kicad.adoc:1090
 msgid ""
 "Sometimes a component that you want to place on your schematic is not in the "
 "KiCad libraries. This is quite normal and there is no reason to worry. In "
@@ -2595,12 +2595,12 @@ msgstr ""
 "しょう。例えば、ここからです:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1078
+#: getting_started_in_kicad.adoc:1092
 msgid "http://per.launay.free.fr/kicad/kicad_php/composant.php"
 msgstr "http://per.launay.free.fr/kicad/kicad_php/composant.php"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1083
+#: getting_started_in_kicad.adoc:1097
 msgid ""
 "In KiCad, a component is a piece of text that starts with a 'DEF' and ends "
 "with 'ENDDEF'. One or more components are normally placed in a library file "
@@ -2613,13 +2613,13 @@ msgstr ""
 "だカット＆ペーストを使えばよいのです。"
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1085
+#: getting_started_in_kicad.adoc:1099
 #, no-wrap
 msgid "Using Component Library Editor"
 msgstr "コンポーネント・ライブラリ・エディタの使用"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1091
+#: getting_started_in_kicad.adoc:1105
 msgid ""
 "We can use the _Component Library Editor_ (part of __Eeschema__)  to make "
 "new components. In our project folder 'tutorial1' let's create a folder "
@@ -2632,7 +2632,7 @@ msgstr ""
 "しいライブラリファイル _myLib.lib_ を置きます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1106
+#: getting_started_in_kicad.adoc:1120
 msgid ""
 "Now we can start creating our new component. From KiCad, start __Eeschema__, "
 "click on the 'Library Editor' icon image:images/icons/libedit."
@@ -2658,7 +2658,7 @@ msgstr ""
 "るには、シートの 'MYCONN3' ラベルの下あたりを左クリックします。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1110
+#: getting_started_in_kicad.adoc:1124
 msgid ""
 "In the Pin Properties window that appears, set the pin name to 'VCC', set "
 "the pin number to '1', and the 'Electrical type' to 'Passive' then click OK."
@@ -2667,12 +2667,12 @@ msgstr ""
 "レクトリックタイプ' を 'パッシブ' と設定してOKをクリックします。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1112
+#: getting_started_in_kicad.adoc:1126
 msgid "image:images/pin_properties.png[Pin Properties]"
 msgstr "image:images/ja/pin_properties.png[Pin Properties]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1115
+#: getting_started_in_kicad.adoc:1129
 msgid ""
 "Place the pin by clicking on the location you would like it to go, right "
 "below the 'MYCONN3' label."
@@ -2680,7 +2680,7 @@ msgstr ""
 "適当な場所、 'MYCONN3' ラベルの右下あたり、をクリックしてピンを配置します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1119
+#: getting_started_in_kicad.adoc:1133
 msgid ""
 "Repeat the place-pin steps, this time 'Pin name' should be 'INPUT', 'Pin "
 "number' should be '2', and 'Electrical Type' should be 'Passive'."
@@ -2689,7 +2689,7 @@ msgstr ""
 "は '2' で、 'エレクトリックタイプ' は 'パッシブ' とします。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1125
+#: getting_started_in_kicad.adoc:1139
 msgid ""
 "Repeat the place-pin steps, this time 'Pin name' should be 'GND', 'Pin "
 "number' should be '3', and 'Electrical Type' should be 'Passive'.  Arrange "
@@ -2702,7 +2702,7 @@ msgstr ""
 "する所)にします。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1133
+#: getting_started_in_kicad.adoc:1147
 #, fuzzy
 #| msgid ""
 #| "Next, draw the contour of the component. Click on the 'Add rectangle' "
@@ -2725,12 +2725,12 @@ msgstr ""
 "リックします。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1135
+#: getting_started_in_kicad.adoc:1149
 msgid "image:images/gsik_myconn3_l.png[gsik_myconn3_l_png]"
 msgstr "image:images/gsik_myconn3_l.png[gsik_myconn3_l_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1140
+#: getting_started_in_kicad.adoc:1154
 msgid ""
 "Save the component in your library __myLib.lib__. Click on the 'New Library' "
 "icon image:images/icons/new_library.png[new_library_png], navigate into "
@@ -2743,7 +2743,7 @@ msgstr ""
 "_ を選び、新しいライブラリファイルを __myLib.lib__ という名前で保存します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1143
+#: getting_started_in_kicad.adoc:1157
 msgid ""
 "Go to *Preferences* -> *Component Libraries* and add both _tutorial1/library/"
 "_ in 'User defined search path' and _myLib.lib in_ 'Component library files'."
@@ -2753,7 +2753,7 @@ msgstr ""
 "加します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1149
+#: getting_started_in_kicad.adoc:1163
 msgid ""
 "Click on the 'Select working library' icon image:images/icons/library."
 "png[library_png]. In the Select Library window click on _myLib_ and click "
@@ -2766,7 +2766,7 @@ msgstr ""
 "おり、それが __myLib__ であることに注意しましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1158
+#: getting_started_in_kicad.adoc:1172
 msgid ""
 "Click on the 'Update current component in current library' icon image:images/"
 "icons/save_part_in_mem.png[save_part_in_mem_png] in the top toolbar. Save "
@@ -2785,7 +2785,7 @@ msgstr ""
 "リから使えます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1162
+#: getting_started_in_kicad.adoc:1176
 msgid ""
 "You can now close the Component library editor window. You will return to "
 "the schematic editor window. Your new component will now be available to you "
@@ -2796,7 +2796,7 @@ msgstr ""
 "できます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1167
+#: getting_started_in_kicad.adoc:1181
 msgid ""
 "You can make any library _file.lib_ file available to you by adding it to "
 "the library path. From __Eeschema__, go to *Preferences* -> *Library* and "
@@ -2809,13 +2809,13 @@ msgstr ""
 "ンポーネントライブラリファイル' に追加します。"
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1169
+#: getting_started_in_kicad.adoc:1183
 #, no-wrap
 msgid "Export, import and modify library components"
 msgstr "コンポーネントのエクスポート、インポート、変更"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1175
+#: getting_started_in_kicad.adoc:1189
 msgid ""
 "Instead of creating a library component from scratch it is sometimes easier "
 "to start from one already made and modify it. In this section we will see "
@@ -2828,7 +2828,7 @@ msgstr ""
 "変更する方法を見ていきましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1183
+#: getting_started_in_kicad.adoc:1197
 msgid ""
 "From KiCad, start __Eeschema__, click on the 'Library Editor' icon image:"
 "images/icons/libedit.png[libedit_png], click on the 'Select working library' "
@@ -2845,7 +2845,7 @@ msgstr ""
 "png[import_cmp_from_lib_png] をクリックして 'RELAY_2RT' をインポートします。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1187
+#: getting_started_in_kicad.adoc:1201
 msgid ""
 "Click on the 'Export component' icon image:images/icons/export."
 "png[export_png], navigate into the _library/_ folder and save the new "
@@ -2856,7 +2856,7 @@ msgstr ""
 "ファイルを _myOwnLib.lib_ という名前で保存します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1193
+#: getting_started_in_kicad.adoc:1207
 msgid ""
 "You can make this component and the whole library _myOwnLib.lib_ available "
 "to you by adding it to the library path. From __Eeschema__, go to "
@@ -2869,7 +2869,7 @@ msgstr ""
 "_myOwnLib.lib_ を 'コンポーネントライブラリファイル' に追加します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1199
+#: getting_started_in_kicad.adoc:1213
 msgid ""
 "Click on the 'Select working library' icon image:images/icons/library."
 "png[library_png]. In the Select Library window click on _myOwnLib_ and click "
@@ -2882,7 +2882,7 @@ msgstr ""
 "ラリを示しており、それが __myOwnLib__ であることに注意しましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1203
+#: getting_started_in_kicad.adoc:1217
 msgid ""
 "Click on the 'Load component to edit from the current lib' icon image:images/"
 "icons/import_cmp_from_lib.png[import_cmp_from_lib_png] and import the "
@@ -2893,7 +2893,7 @@ msgstr ""
 "'RELAY_2RT' をインポートします。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1206
+#: getting_started_in_kicad.adoc:1220
 msgid ""
 "You can now modify the component as you like. Hover over the label "
 "'RELAY_2RT', press the e key and rename it 'MY_RELAY_2RT'."
@@ -2902,7 +2902,7 @@ msgstr ""
 "'RELAY_2RT' に重ねて \"e\" キーを押して 'MY_RELAY_2RT' にリネームします。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1213
+#: getting_started_in_kicad.adoc:1227
 msgid ""
 "Click on 'Update current component in current library' icon image:images/"
 "icons/save_part_in_mem.png[save_part_in_mem_png] in the top toolbar. Save "
@@ -2916,13 +2916,13 @@ msgstr ""
 "全て保存します。"
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1215
+#: getting_started_in_kicad.adoc:1229
 #, no-wrap
 msgid "Make schematic components with quicklib"
 msgstr "quicklibによる回路図コンポーネントの作成"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1220
+#: getting_started_in_kicad.adoc:1234
 msgid ""
 "This section presents an alternative way of creating the schematic component "
 "for MYCONN3 (see <<myconn3,MYCONN3>> above) using the Internet tool "
@@ -2932,7 +2932,7 @@ msgstr ""
 "ト MYCONN3 (前の <<myconn3, 「MYCONN3」>> 参照) の別の作成方法を紹介します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1223
+#: getting_started_in_kicad.adoc:1237
 msgid ""
 "Head to the _quicklib_ web page: http://kicad.rohrbacher.net/quicklib.php"
 msgstr ""
@@ -2940,7 +2940,7 @@ msgstr ""
 "quicklib.php"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1226
+#: getting_started_in_kicad.adoc:1240
 msgid ""
 "Fill out the page with the following information: Component name: MYCONN3 "
 "Reference Prefix: J Pin Layout Style: SIL Pin Count, N: 3"
@@ -2949,7 +2949,7 @@ msgstr ""
 "Prefix: J、 Pin Layout Style: SIL、 Pin Count, N: 3"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1230
+#: getting_started_in_kicad.adoc:1244
 msgid ""
 "Click on the 'Assign Pins' icon. Fill out the page with the following "
 "information: Pin 1: VCC Pin 2: input Pin 3: GND.  Type : Passive for all 3 "
@@ -2959,7 +2959,7 @@ msgstr ""
 "VCC、 Pin 2: input、 Pin 3: GND 。Type は3つのピンとも Passive を選択します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1234
+#: getting_started_in_kicad.adoc:1248
 msgid ""
 "Click on the icon 'Preview it' and, if you are satisfied, click on the "
 "'Build Library Component'. Download the file and rename it __tutorial1/"
@@ -2970,7 +2970,7 @@ msgstr ""
 "ます。できました！"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1240
+#: getting_started_in_kicad.adoc:1254
 msgid ""
 "Have a look at it using KiCad. From the KiCad project manager, start "
 "__Eeschema__, click on the 'Library Editor' icon image:images/icons/libedit."
@@ -2985,12 +2985,12 @@ msgstr ""
 "し、 _tutorial1/library/_ へ行き _myQuickLib.lib_ を選択します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1242
+#: getting_started_in_kicad.adoc:1256
 msgid "image:images/gsik_myconn3_quicklib.png[gsik_myconn3_quicklib_png]"
 msgstr "image:images/gsik_myconn3_quicklib.png[gsik_myconn3_quicklib_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1248
+#: getting_started_in_kicad.adoc:1262
 msgid ""
 "You can make this component and the whole library _myQuickLib.lib_ available "
 "to you by adding it to the KiCad library path. From __Eeschema__, go to "
@@ -3003,7 +3003,7 @@ msgstr ""
 "し、 _myQuickLib.lib_ を 'コンポーネントライブラリファイル' に追加します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1252
+#: getting_started_in_kicad.adoc:1266
 msgid ""
 "As you might guess, this method of creating library components can be quite "
 "effective when you want to create components with a large pin count."
@@ -3012,13 +3012,13 @@ msgstr ""
 "に非常に効果的であると想像できるでしょう。"
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1254
+#: getting_started_in_kicad.adoc:1268
 #, no-wrap
 msgid "Make a high pin count schematic component"
 msgstr "大量ピンの回路図コンポーネントの作成"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1261
+#: getting_started_in_kicad.adoc:1275
 msgid ""
 "In the section titled _Make Schematic Components in quicklib_ we saw how to "
 "make a schematic component using the _quicklib_ web-based tool.  However, "
@@ -3032,7 +3032,7 @@ msgstr ""
 "しょう。KiCadでは、これはそんなにややこしい仕事ではありません。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1267
+#: getting_started_in_kicad.adoc:1281
 msgid ""
 "Suppose that you want to create a schematic component for a device with 50 "
 "pins. It is common practise to draw it using multiple low pin-count "
@@ -3044,7 +3044,7 @@ msgstr ""
 "このコンポーネント表現はピン接続が容易でしょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1272
+#: getting_started_in_kicad.adoc:1286
 msgid ""
 "The best way to create our component is to use _quicklib_ to generate two 25-"
 "pin components separately, re-number their pins using a Python script and "
@@ -3056,7 +3056,7 @@ msgstr ""
 "に2つを統合して一組のDEFとENDDEFの中にコピー＆ペーストすることです。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1278
+#: getting_started_in_kicad.adoc:1292
 msgid ""
 "You will find an example of a simple Python script below that can be used in "
 "conjunction with an _in.txt_ file and an _out.txt_ file to re-number the "
@@ -3069,13 +3069,13 @@ msgstr ""
 "1 I+ のように数字の振り替えをします。"
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:1279
+#: getting_started_in_kicad.adoc:1293
 #, no-wrap
 msgid "Simple script"
 msgstr "シンプルなスクリプト"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1302
+#: getting_started_in_kicad.adoc:1316
 #, no-wrap
 msgid ""
 "#!/usr/bin/env python\n"
@@ -3121,7 +3121,7 @@ msgstr ""
 "# http://kicad.rohrbacher.net/quicklib.php\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1308
+#: getting_started_in_kicad.adoc:1322
 msgid ""
 "While merging the two components into one, it is necessary to use the "
 "Library Editor from Eeschema to move the first component so that the second "
@@ -3134,13 +3134,13 @@ msgstr ""
 "__Eeschema__ での表現を示します。"
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:1309
+#: getting_started_in_kicad.adoc:1323
 #, no-wrap
 msgid "Contents of a *.lib file"
 msgstr "*.lib ファイルの内容"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1321
+#: getting_started_in_kicad.adoc:1335
 #, no-wrap
 msgid ""
 "EESchema-LIBRARY Version 2.3\n"
@@ -3166,13 +3166,13 @@ msgstr ""
 "X PIN1 1 -2550 600 300 R 50 50 1 1 I\n"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1323
+#: getting_started_in_kicad.adoc:1337
 #, no-wrap
 msgid "...\n"
 msgstr "...\n"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1328
+#: getting_started_in_kicad.adoc:1342
 #, no-wrap
 msgid ""
 "X PIN49 49 750 -500 300 L 50 50 1 1 I\n"
@@ -3186,12 +3186,12 @@ msgstr ""
 "#End Library\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1331
+#: getting_started_in_kicad.adoc:1345
 msgid "image:images/gsik_high_number_pins.png[gsik_high_number_pins_png]"
 msgstr "image:images/gsik_high_number_pins.png[gsik_high_number_pins_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1336
+#: getting_started_in_kicad.adoc:1350
 msgid ""
 "The Python script presented here is a very powerful tool for manipulating "
 "both pin numbers and pin labels. Mind, however, that all its power comes for "
@@ -3203,13 +3203,13 @@ msgstr ""
 "よる、ということを覚えておいて下さい: http://gskinner.com/RegExr/"
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1338
+#: getting_started_in_kicad.adoc:1352
 #, no-wrap
 msgid "Make component footprints"
 msgstr "フットプリントの作成"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1344
+#: getting_started_in_kicad.adoc:1358
 msgid ""
 "Unlike other EDA software tools, which have one type of library that "
 "contains both the schematic symbol and the footprint variations, KiCad _."
@@ -3222,7 +3222,7 @@ msgstr ""
 "ントを割り当てるのに使われます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1347
+#: getting_started_in_kicad.adoc:1361
 msgid ""
 "As for _.lib_ files, _.kicad_mod_ library files are text files that can "
 "contain anything from one to several parts."
@@ -3231,7 +3231,7 @@ msgstr ""
 "ントを含むことができます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1351
+#: getting_started_in_kicad.adoc:1365
 msgid ""
 "There is an extensive footprint library with KiCad, however on occasion you "
 "might find that the footprint you need is not in the KiCad library.  Here "
@@ -3242,13 +3242,13 @@ msgstr ""
 "いPCBフットプリントを作成する手順を示します:"
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1353
+#: getting_started_in_kicad.adoc:1367
 #, no-wrap
 msgid "Using Footprint Editor"
 msgstr "フットプリント・エディタの使用"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1359
+#: getting_started_in_kicad.adoc:1373
 msgid ""
 "From the KiCad project manager start the _Pcbnew_ tool. Click on the 'Open "
 "Footprint Editor' icon image:images/icons/edit_module.png[edit_module_png] "
@@ -3260,7 +3260,7 @@ msgstr ""
 "タ' が開きます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1371
+#: getting_started_in_kicad.adoc:1385
 msgid ""
 "We are going to save the new footprint 'MYCONN3' in the new footprint "
 "library 'myfootprint'.  Create a new folder _myfootprint.pretty_ in the "
@@ -3284,7 +3284,7 @@ msgstr ""
 "ライブラリを選択しましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1380
+#: getting_started_in_kicad.adoc:1394
 msgid ""
 "Click on the 'New Footprint' icon image:images/icons/new_footprint."
 "png[new_footprint_png] on the top toolbar.  Type 'MYCONN3' as the 'footprint "
@@ -3302,7 +3302,7 @@ msgstr ""
 "す。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1385
+#: getting_started_in_kicad.adoc:1399
 msgid ""
 "Select the 'Add Pads' icon image:images/icons/pad.png[pad_png] on the right "
 "toolbar. Click on the working sheet to place the pad. Right click on the new "
@@ -3314,12 +3314,12 @@ msgstr ""
 "ショートカットも使えます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1387
+#: getting_started_in_kicad.adoc:1401
 msgid "image:images/pad_properties.png[Pad Properties]"
 msgstr "image:images/ja/pad_properties.png[Pad Properties]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1391
+#: getting_started_in_kicad.adoc:1405
 msgid ""
 "Set the 'Pad Num' to '1', 'Pad Shape' to 'Rect', 'Pad Type' to 'SMD', 'Shape "
 "Size X' to '0.4', and 'Shape Size Y' to '0.8'. Click OK.  Click on 'Add "
@@ -3330,7 +3330,7 @@ msgstr ""
 "'パッド入力' をクリックし、 もう2つパッドを配置します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1395
+#: getting_started_in_kicad.adoc:1409
 msgid ""
 "If you want to change the grid size, *Right click* -> **Grid Select**. Be "
 "sure to select the appropriate grid size before laying down the components."
@@ -3339,14 +3339,14 @@ msgstr ""
 "配置する前に適切なグリッドサイズを選択しましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1398
+#: getting_started_in_kicad.adoc:1412
 msgid ""
 "Move the 'MYCONN3' label and the 'SMD' label out of the way so that it looks "
 "like the image shown above."
 msgstr "上の図のように 'MYCONN3' と 'SMD' のラベルを外側に移動します。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1405
+#: getting_started_in_kicad.adoc:1419
 msgid ""
 "When placing pads it is often necessary to measure relative distances. Place "
 "the cursor where you want the relative coordinate point _(0,0)_ to be and "
@@ -3360,7 +3360,7 @@ msgstr ""
 "を設定するにはスペースキーを押しましょう。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1410
+#: getting_started_in_kicad.adoc:1424
 msgid ""
 "Now add a footprint contour. Click on the 'Add graphic line or polygon' "
 "button image:images/icons/add_polygon.png[add_polygon_png] in the right "
@@ -3371,7 +3371,7 @@ msgstr ""
 "をクリックします。パーツの周囲にコネクタの外形を描きます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1414
+#: getting_started_in_kicad.adoc:1428
 msgid ""
 "Click on the 'Save Footprint in Active Library' icon image:images/icons/"
 "save_library.png[save_library_png] on the top toolbar, using the default "
@@ -3382,13 +3382,13 @@ msgstr ""
 "フォルト名のMYCONN3で保存します。"
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1416
+#: getting_started_in_kicad.adoc:1430
 #, no-wrap
 msgid "Note about portability of KiCad project files"
 msgstr "KiCadプロジェクトファイルの可搬性について"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1420
+#: getting_started_in_kicad.adoc:1434
 msgid ""
 "What files do you need to send to someone so that they can fully load and "
 "use your KiCad project?"
@@ -3397,7 +3397,7 @@ msgstr ""
 "ルを送る必要があるでしょうか？"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1427
+#: getting_started_in_kicad.adoc:1441
 msgid ""
 "When you have a KiCad project to share with somebody, it is important that "
 "the schematic file __.sch__, the board file __.kicad_pcb__, the project file "
@@ -3413,7 +3413,7 @@ msgstr ""
 "由に回路図と基板を変更することができます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1439
+#: getting_started_in_kicad.adoc:1453
 msgid ""
 "With KiCad schematics, people need the _.lib_ files that contain the "
 "symbols. Those library files need to be loaded in the _Eeschema_ "
@@ -3437,7 +3437,7 @@ msgstr ""
 "_Pcbnew_ の設定で _.kicad_mod_ ファイルが読み込まれていることが必要です。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1447
+#: getting_started_in_kicad.adoc:1461
 msgid ""
 "If someone sends you a _.kicad_pcb_ file with footprints you would like to "
 "use in another board, you can open the Footprint Editor, load a footprint "
@@ -3456,7 +3456,7 @@ msgstr ""
 "てのフットプリントの _.kicad_mod_ ファイルが生成されます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1453
+#: getting_started_in_kicad.adoc:1467
 msgid ""
 "Bottom line, if the PCB is the only thing you want to distribute, then the "
 "board file _.kicad_pcb_ is enough. However, if you want to give people the "
@@ -3470,7 +3470,7 @@ msgstr ""
 "します。"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1471
+#: getting_started_in_kicad.adoc:1485
 #, no-wrap
 msgid ""
 "tutorial1/\n"
@@ -3508,13 +3508,13 @@ msgstr ""
 "    \\-- ...\n"
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1474
+#: getting_started_in_kicad.adoc:1488
 #, no-wrap
 msgid "More about KiCad documentation"
 msgstr "KiCadドキュメントの詳細"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1479
+#: getting_started_in_kicad.adoc:1493
 msgid ""
 "This has been a quick guide on most of the features in KiCad. For more "
 "detailed instructions consult the help files which you can access through "
@@ -3525,7 +3525,7 @@ msgstr ""
 "プ* -> *マニュアル* をクリックです。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1482
+#: getting_started_in_kicad.adoc:1496
 msgid ""
 "KiCad comes with a pretty good set of multi-language manuals for all its "
 "four software components."
@@ -3534,12 +3534,12 @@ msgstr ""
 "ニュアルが付いてきます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1484
+#: getting_started_in_kicad.adoc:1498
 msgid "The English version of all KiCad manuals are distributed with KiCad."
 msgstr "全KiCadマニュアルの英語版はKiCadと一緒に配布されます。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1490
+#: getting_started_in_kicad.adoc:1504
 msgid ""
 "In addition to its manuals, KiCad is distributed with this tutorial, which "
 "has been translated into other languages. All the different versions of this "
@@ -3552,7 +3552,7 @@ msgstr ""
 "チュートリアルとマニュアルはご利用のKiCadと共にパッケージされています。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1493
+#: getting_started_in_kicad.adoc:1507
 msgid ""
 "For example, on Linux the typical locations are in the following "
 "directories, depending on your exact distribution:"
@@ -3561,7 +3561,7 @@ msgstr ""
 "でしょう:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1496
+#: getting_started_in_kicad.adoc:1510
 #, no-wrap
 msgid ""
 " /usr/share/doc/kicad/help/en/\n"
@@ -3571,42 +3571,42 @@ msgstr ""
 " /usr/local/share/doc/kicad/help/en\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1498
+#: getting_started_in_kicad.adoc:1512
 msgid "On Windows it is in:"
 msgstr "Windows の場合:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1500
+#: getting_started_in_kicad.adoc:1514
 #, no-wrap
 msgid " <installation directory>/share/doc/kicad/help/en\n"
 msgstr " <installation directory>/share/doc/kicad/help/en\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1502
+#: getting_started_in_kicad.adoc:1516
 msgid "On OS X:"
 msgstr "OS X の場合:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1504
+#: getting_started_in_kicad.adoc:1518
 #, no-wrap
 msgid " /Library/Application Support/kicad/help/en\n"
 msgstr " /Library/Application Support/kicad/help/en\n"
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1506
+#: getting_started_in_kicad.adoc:1520
 #, no-wrap
 msgid "KiCad documentation on the Web"
 msgstr "Web上のKiCadドキュメント"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1509
+#: getting_started_in_kicad.adoc:1523
 msgid ""
 "Latest KiCad documentations are available in multiple languages on the Web."
 msgstr ""
 "最新のKiCadのドキュメンテーションは、複数の言語に翻訳されてWeb上にあります。"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1511
+#: getting_started_in_kicad.adoc:1525
 msgid "http://kicad-pcb.org/help/documentation/"
 msgstr "http://kicad-pcb.org/help/documentation/"
 

--- a/src/getting_started_in_kicad/po/nl.po
+++ b/src/getting_started_in_kicad/po/nl.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.1\n"
-"POT-Creation-Date: 2016-01-06 23:55+0100\n"
+"POT-Creation-Date: 2016-01-07 20:18+0100\n"
 "PO-Revision-Date: 2015-09-12 23:38+0200\n"
 "Last-Translator: Marco Ciampa <ciampix@libero.it>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -574,7 +574,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:304
+#: getting_started_in_kicad.adoc:306
 msgid ""
 "Try to hover the mouse over the component 'R' and press the r key. The "
 "component should rotate. You do not need to actually click on the component "
@@ -582,7 +582,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:306
+#: getting_started_in_kicad.adoc:312
 msgid ""
 "If your mouse was also over the _Field Reference_ ('R') or the _Field Value_ "
 "('R?'), a menu will appear. You will see these 'Clarify Selection' menu "
@@ -592,7 +592,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:312
+#: getting_started_in_kicad.adoc:318
 msgid ""
 "Right click in the middle of the component and select *Edit Component* -> "
 "**Value**. You can achieve the same result by hovering over the component "
@@ -602,50 +602,50 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:314
+#: getting_started_in_kicad.adoc:320
 msgid "image:images/edit_component_dropdown.png[Edit component menu]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:317
+#: getting_started_in_kicad.adoc:323
 msgid ""
 "The Component value window will appear. Replace the current value 'R' with "
 "'1k'. Click OK."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:320
+#: getting_started_in_kicad.adoc:326
 msgid ""
 "Do not change the Reference field (R?), this will be done automatically "
 "later on. The value inside the resistor should now be '1k'."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:322
+#: getting_started_in_kicad.adoc:328
 msgid "image:images/resistor_value.png[Resistor Value]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:325
+#: getting_started_in_kicad.adoc:331
 msgid ""
 "To place another resistor, simply click where you want the resistor to "
 "appear. The Component Selection window will appear again."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:328
+#: getting_started_in_kicad.adoc:334
 msgid ""
 "The resistor you previously chose is now in your history list, appearing as "
 "'R'. Click OK and place the component."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:330
+#: getting_started_in_kicad.adoc:336
 msgid "image:images/component_history.png[Component history]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:335
+#: getting_started_in_kicad.adoc:341
 msgid ""
 "In case you make a mistake and want to delete a component, right click on "
 "the component and click 'Delete Component'. This will remove the component "
@@ -654,14 +654,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:339
+#: getting_started_in_kicad.adoc:345
 msgid ""
 "You can edit any default shortcut key by going to *Preferences* -> *Hotkeys* "
 "-> **Edit hotkeys**. Any modification will be saved immediately."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:343
+#: getting_started_in_kicad.adoc:349
 msgid ""
 "You can also duplicate a component already on your schematic sheet by "
 "hovering over it and pressing the c key. Click where you want to place the "
@@ -669,7 +669,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:349
+#: getting_started_in_kicad.adoc:355
 msgid ""
 "Right click on the second resistor. Select 'Drag Component'.  Reposition the "
 "component and left click to drop. The same functionality can be achieved by "
@@ -678,7 +678,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:354
+#: getting_started_in_kicad.adoc:360
 #, no-wrap
 msgid ""
 "*Right-Click* -> *Move component* (equivalent to the m key\n"
@@ -688,7 +688,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:358
+#: getting_started_in_kicad.adoc:364
 msgid ""
 "Edit the second resistor by hovering over it and pressing the v key.  "
 "Replace 'R' with '100'. You can undo any of your editing actions with the "
@@ -696,7 +696,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:364
+#: getting_started_in_kicad.adoc:370
 msgid ""
 "Change the grid size. You have probably noticed that on the schematic sheet "
 "all components are snapped onto a large pitch grid. You can easily change "
@@ -705,7 +705,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:366
+#: getting_started_in_kicad.adoc:374
 msgid ""
 "We are going to add a component from a library that isn't configured in the "
 "default project. In the menu, choose *Preferences* -> **Component "
@@ -713,7 +713,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:368
+#: getting_started_in_kicad.adoc:380
 msgid ""
 "You need to find where the official KiCad libraries are installed on your "
 "computer. Look for a `library` directory containing a hundred of `.dcm` and "
@@ -723,7 +723,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:372
+#: getting_started_in_kicad.adoc:384
 msgid ""
 "Repeat the add-component steps, however this time select the "
 "'microchip_pic12mcu' library instead of the 'device' library and pick the "
@@ -731,7 +731,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:377
+#: getting_started_in_kicad.adoc:389
 msgid ""
 "Hover the mouse over the microcontroller component. Press the y key or the x "
 "key on the keyboard. Notice how the component is flipped over its x axis or "
@@ -739,24 +739,24 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:380
+#: getting_started_in_kicad.adoc:392
 msgid ""
 "Repeat the add-component steps, this time choosing the 'device' library and "
 "picking the 'LED' component from it."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:382
+#: getting_started_in_kicad.adoc:394
 msgid "Organise all components on your schematic sheet as shown below."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:384
+#: getting_started_in_kicad.adoc:396
 msgid "image:images/gsik_tutorial1_010.png[gsik_tutorial1_010_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:390
+#: getting_started_in_kicad.adoc:402
 msgid ""
 "We now need to create the schematic component 'MYCONN3' for our 3-pin "
 "connector. You can jump to the section titled <<make-schematic-components-in-"
@@ -766,14 +766,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:393
+#: getting_started_in_kicad.adoc:405
 msgid ""
 "You can now place the freshly made component. Press the 'a' key and pick the "
 "'MYCONN3' component in the 'myLib' library."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:399
+#: getting_started_in_kicad.adoc:411
 msgid ""
 "The component identifier 'J?' will appear under the 'MYCONN3' label.  If you "
 "want to change its position, right click on 'J?' and click on 'Move "
@@ -783,12 +783,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:401
+#: getting_started_in_kicad.adoc:413
 msgid "image:images/gsik_myconn3_s.png[gsik_myconn3_s_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:407
+#: getting_started_in_kicad.adoc:419
 msgid ""
 "It is time to place the power and ground symbols. Click on the 'Place a "
 "power port' button image:images/icons/add_power.png[add_power_png] on the "
@@ -797,7 +797,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:413
+#: getting_started_in_kicad.adoc:425
 msgid ""
 "Click above the pin of the 1k resistor to place the VCC part. Click on the "
 "area above the microcontroller 'VDD'. In the 'Component Selection history' "
@@ -806,7 +806,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:418
+#: getting_started_in_kicad.adoc:430
 msgid ""
 "Repeat the add-pin steps but this time select the GND part. Place a GND part "
 "under the GND pin of 'MYCONN3'. Place another GND symbol on the right of the "
@@ -815,19 +815,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:420
+#: getting_started_in_kicad.adoc:432
 msgid "image:images/gsik_tutorial1_020.png[gsik_tutorial1_020_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:424
+#: getting_started_in_kicad.adoc:436
 msgid ""
 "Next, we will wire all our components. Click on the 'Place wire' icon image:"
 "images/icons/add_line.png[Place wire] on the right toolbar."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:429
+#: getting_started_in_kicad.adoc:441
 msgid ""
 "Be careful not to pick 'Place a bus', which appears directly beneath this "
 "button but has thicker lines. The section <<bus-connections-in-kicad,Bus "
@@ -835,7 +835,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:433
+#: getting_started_in_kicad.adoc:445
 msgid ""
 "Click on the little circle at the end of pin 7 of the microcontroller and "
 "then click on the little circle on pin 2 of the LED.  You can zoom in while "
@@ -843,7 +843,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:438
+#: getting_started_in_kicad.adoc:450
 msgid ""
 "If you want to reposition wired components, it is important to use the g key "
 "(grab) option and not the m key (move) option. Using the grab option will "
@@ -852,12 +852,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:440
+#: getting_started_in_kicad.adoc:452
 msgid "image:images/gsik_tutorial1_030.png[gsik_tutorial1_030_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:446
+#: getting_started_in_kicad.adoc:458
 msgid ""
 "Repeat this process and wire up all the other components as shown below. To "
 "terminate a wire just double-click. When wiring up the VCC and GND symbols, "
@@ -866,12 +866,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:448
+#: getting_started_in_kicad.adoc:460
 msgid "image:images/gsik_tutorial1_040.png[gsik_tutorial1_040_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:453
+#: getting_started_in_kicad.adoc:465
 msgid ""
 "We will now consider an alternative way of making a connection using labels. "
 "Pick a net labelling tool by clicking on the 'Place net name' icon image:"
@@ -880,14 +880,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:456
+#: getting_started_in_kicad.adoc:468
 msgid ""
 "Click in the middle of the wire connected to pin 6 of the microcontroller. "
 "Name this label 'INPUT'."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:465
+#: getting_started_in_kicad.adoc:477
 msgid ""
 "Follow the same procedure and place another label on line on the right of "
 "the 100 ohm resistor. Also name it 'INPUT'. The two labels, having the same "
@@ -899,7 +899,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:471
+#: getting_started_in_kicad.adoc:483
 msgid ""
 "Labels can also be used to simply label wires for informative purposes. "
 "Place a label on pin 7 of the PIC. Enter the name 'uCtoLED'.  Name the wire "
@@ -908,24 +908,24 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:474
+#: getting_started_in_kicad.adoc:486
 msgid ""
 "You do not have to label the VCC and GND lines because the labels are "
 "implied from the power objects they are connected to."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:476
+#: getting_started_in_kicad.adoc:488
 msgid "Below you can see what the final result should look like."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:478
+#: getting_started_in_kicad.adoc:490
 msgid "image:images/gsik_tutorial1_050.png[gsik_tutorial1_050_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:484
+#: getting_started_in_kicad.adoc:496
 msgid ""
 "Let's now deal with unconnected wires. Any pin or wire that is not connected "
 "will generate a warning when checked by KiCad. To avoid these warnings you "
@@ -934,7 +934,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:489
+#: getting_started_in_kicad.adoc:501
 msgid ""
 "Click on the 'Place no connect flag' icon image:images/icons/noconn."
 "png[noconn_png] on the right toolbar. Click on pins 2, 3, 4 and 5. An X will "
@@ -942,12 +942,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:491
+#: getting_started_in_kicad.adoc:503
 msgid "image:images/gsik_tutorial1_060.png[gsik_tutorial1_060_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:498
+#: getting_started_in_kicad.adoc:510
 msgid ""
 "Some components have power pins that are invisible. You can make them "
 "visible by clicking on the 'Show hidden pins' icon image:images/icons/"
@@ -957,7 +957,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:504
+#: getting_started_in_kicad.adoc:516
 msgid ""
 "It is now necessary to add a 'Power Flag' to indicate to KiCad that power "
 "comes in from somewhere. Press the a key, select 'List All', double click on "
@@ -966,19 +966,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:506
+#: getting_started_in_kicad.adoc:518
 msgid "image:images/gsik_tutorial1_070.png[gsik_tutorial1_070_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:509
+#: getting_started_in_kicad.adoc:521
 msgid ""
 "This will avoid the classic schematic checking warning: Warning Pin power_in "
 "not driven (Net xx)"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:513
+#: getting_started_in_kicad.adoc:525
 msgid ""
 "Sometimes it is good to write comments here and there. To add comments on "
 "the schematic use the 'Place graphic text (comment)' icon image:images/icons/"
@@ -986,7 +986,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:518
+#: getting_started_in_kicad.adoc:531
 msgid ""
 "All components now need to have unique identifiers. In fact, many of our "
 "components are still named 'R?' or 'J?'. Identifier assignation can be done "
@@ -995,7 +995,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:525
+#: getting_started_in_kicad.adoc:538
 msgid ""
 "In the Annotate Schematic window, select 'Use the entire schematic' and "
 "click on the 'Annotation' button. Click OK in the confirmation message and "
@@ -1005,7 +1005,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:535
+#: getting_started_in_kicad.adoc:547
 msgid ""
 "We will now check our schematic for errors. Click on the 'Perform electrical "
 "rules check' icon image:images/icons/erc.png[erc_png] on the top toolbar. "
@@ -1018,7 +1018,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:537
+#: getting_started_in_kicad.adoc:551
 msgid ""
 "If you have a warning with \"No default editor found you must choose it\", "
 "try setting the path to `c:\\windows\\notepad.exe` (windows) or `/usr/bin/"
@@ -1026,7 +1026,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:542
+#: getting_started_in_kicad.adoc:556
 msgid ""
 "The schematic is now finished. We can now create a Netlist file to which we "
 "will add the footprint of each component. Click on the 'Generate netlist' "
@@ -1035,7 +1035,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:547
+#: getting_started_in_kicad.adoc:561
 msgid ""
 "After generating the Netlist file, click on the 'Run Cvpcb' icon image:"
 "images/icons/cvpcb.png[cvpcb_png] on the top toolbar. If a missing file "
@@ -1043,7 +1043,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:553
+#: getting_started_in_kicad.adoc:567
 msgid ""
 "_Cvpcb_ allows you to link all the components in your schematic with "
 "footprints in the KiCad library. The pane on the center shows all the "
@@ -1053,12 +1053,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:555
+#: getting_started_in_kicad.adoc:569
 msgid "image:images/icons/cvpcb.png[cvpcb_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:563
+#: getting_started_in_kicad.adoc:577
 msgid ""
 "It is possible that the pane on the right shows only a selected subgroup of "
 "available footprints. This is because KiCad is trying to suggest to you a "
@@ -1070,7 +1070,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:567
+#: getting_started_in_kicad.adoc:581
 msgid ""
 "For 'IC1' select the 'Housings_DIP:DIP-8_W7.62mm' footprint.  For 'J1' "
 "select the 'Connect:Banana_Jack_3Pin' footprint.  For 'R1' and 'R2' select "
@@ -1078,7 +1078,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:578
+#: getting_started_in_kicad.adoc:592
 msgid ""
 "If you are interested in knowing what the footprint you are choosing looks "
 "like, you have two options. You can click on the 'View selected footprint' "
@@ -1091,7 +1091,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:587
+#: getting_started_in_kicad.adoc:601
 msgid ""
 "You are done. You can now update your netlist file with all the associated "
 "footprints. Click on *File* -> **Save As**. The default name 'tutorial1.net' "
@@ -1103,7 +1103,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:591
+#: getting_started_in_kicad.adoc:605
 msgid ""
 "You can close _Cvpcb_ and go back to the _Eeschema_ schematic editor. Save "
 "the project by clicking on *File* -> **Save Whole Schematic Project**. Close "
@@ -1111,12 +1111,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:593
+#: getting_started_in_kicad.adoc:607
 msgid "Switch to the KiCad project manager."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:597
+#: getting_started_in_kicad.adoc:611
 msgid ""
 "The netlist file describes all components and their respective pin "
 "connections. The netlist file is actually a text file that you can easily "
@@ -1124,14 +1124,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:600
+#: getting_started_in_kicad.adoc:614
 msgid ""
 "Library files (__*.lib__) are text files too and they are also easily "
 "editable or scriptable."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:607
+#: getting_started_in_kicad.adoc:621
 msgid ""
 "To create a Bill Of Materials (BOM), go to the _Eeschema_ schematic editor "
 "and click on the 'Bill of materials' icon image:images/icons/bom."
@@ -1141,54 +1141,54 @@ msgid ""
 msgstr ""
 
 #. type: delimited block =
-#: getting_started_in_kicad.adoc:612
+#: getting_started_in_kicad.adoc:626
 msgid ""
 "The *.xsl file is located in __plugins__ directory of the KiCad "
 "installation, which is located at: /usr/lib/kicad/plugins/."
 msgstr ""
 
 #. type: delimited block =
-#: getting_started_in_kicad.adoc:614
+#: getting_started_in_kicad.adoc:628
 msgid "Or get the file via:"
 msgstr ""
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:616
+#: getting_started_in_kicad.adoc:630
 #, no-wrap
 msgid "wget https://raw.githubusercontent.com/KiCad/kicad-source-mirror/master/eeschema/plugins/bom2csv.xsl\n"
 msgstr ""
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:619
+#: getting_started_in_kicad.adoc:633
 #, no-wrap
 msgid "KiCad automatically generates the command, for example:"
 msgstr ""
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:622
+#: getting_started_in_kicad.adoc:636
 #, no-wrap
 msgid "xsltproc -o \"%O\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 msgstr ""
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:624
+#: getting_started_in_kicad.adoc:638
 #, no-wrap
 msgid "You may want to add the extension, so change this command line to:"
 msgstr ""
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:627
+#: getting_started_in_kicad.adoc:641
 #, no-wrap
 msgid "xsltproc -o \"%O.csv\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:630
+#: getting_started_in_kicad.adoc:644
 msgid "Press Help button for more info."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:634
+#: getting_started_in_kicad.adoc:648
 msgid ""
 "Now press 'Generate'. The file (same name as your project) is located in "
 "your project folder.  Open the **.csv* file with LibreOffice Calc or Excel. "
@@ -1196,7 +1196,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:638
+#: getting_started_in_kicad.adoc:652
 msgid ""
 "You are now ready to move to the PCB layout part, which is presented in the "
 "next section. However, before moving on let's take a quick look at how to "
@@ -1204,13 +1204,13 @@ msgid ""
 msgstr ""
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:640
+#: getting_started_in_kicad.adoc:654
 #, no-wrap
 msgid "Bus connections in KiCad"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:646
+#: getting_started_in_kicad.adoc:660
 msgid ""
 "Sometimes you might need to connect several sequential pins of component A "
 "with some other sequential pins of component B. In this case you have two "
@@ -1219,7 +1219,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:653
+#: getting_started_in_kicad.adoc:667
 msgid ""
 "Let us suppose that you have three 4-pin connectors that you want to connect "
 "together pin to pin. Use the label option (press the l key) to label pin 4 "
@@ -1229,7 +1229,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:657
+#: getting_started_in_kicad.adoc:671
 msgid ""
 "Press the Ins Key two more times. The Ins key corresponds to the action "
 "'Repeat last item' and it is an infinitely useful command that can make your "
@@ -1237,7 +1237,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:668
+#: getting_started_in_kicad.adoc:682
 msgid ""
 "Repeat the same labelling action on the two other connectors CONN_2 and "
 "CONN_3 and you are done. If you proceed and make a PCB you will see that the "
@@ -1250,7 +1250,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:672
+#: getting_started_in_kicad.adoc:686
 msgid ""
 "It should be pointed out that the short wire attached to the pins in Figure "
 "2 is not strictly necessary. In fact, the labels could have been applied "
@@ -1258,7 +1258,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:679
+#: getting_started_in_kicad.adoc:693
 msgid ""
 "Let's take it one step further and suppose that you have a fourth connector "
 "named CONN_4 and, for whatever reason, its labelling happens to be a little "
@@ -1269,7 +1269,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:686
+#: getting_started_in_kicad.adoc:700
 msgid ""
 "Connect and label CONN_4 using the labelling method explained before. Name "
 "the pins b1, b2, b3 and b4. Connect the pin to a series of 'Wire to bus "
@@ -1279,28 +1279,28 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:689
+#: getting_started_in_kicad.adoc:703
 msgid ""
 "Put a label (press the l key option) on the bus of CONN_4 and name it "
 "'b[1..4]'."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:692
+#: getting_started_in_kicad.adoc:706
 msgid ""
 "Put a label (press the l key option) on the previous a bus and name it "
 "'a[1..4]'."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:695
+#: getting_started_in_kicad.adoc:709
 msgid ""
 "What we can now do is connect bus a[1..4] with bus b[1..4] using a bus line "
 "with the button image:images/icons/add_bus.png[add_bus_png]."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:699
+#: getting_started_in_kicad.adoc:713
 msgid ""
 "By connecting the two buses together, pin a1 will be automatically connected "
 "to pin b1, a2 will be connected to b2 and so on. Figure 4 shows what the "
@@ -1308,7 +1308,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:704
+#: getting_started_in_kicad.adoc:718
 msgid ""
 "The 'Repeat last item' option accessible via the Ins key can be successfully "
 "used to repeat period item insertions. For instance, the short wires "
@@ -1317,7 +1317,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:708
+#: getting_started_in_kicad.adoc:722
 msgid ""
 "The 'Repeat last item' option accessible via the Ins key has also been "
 "extensively used to place the many series of 'Wire to bus entry' using the "
@@ -1325,31 +1325,31 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:710
+#: getting_started_in_kicad.adoc:724
 msgid "image:images/gsik_bus_connection.png[gsik_bus_connection_png]"
 msgstr ""
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:712
+#: getting_started_in_kicad.adoc:726
 #, no-wrap
 msgid "Layout printed circuit boards"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:716
+#: getting_started_in_kicad.adoc:730
 msgid ""
 "It is now time to use the netlist file you generated to lay out the PCB.  "
 "This is done with the _Pcbnew_ tool."
 msgstr ""
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:718
+#: getting_started_in_kicad.adoc:732
 #, no-wrap
 msgid "Using Pcbnew"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:724
+#: getting_started_in_kicad.adoc:738
 msgid ""
 "From the KiCad project manager, click on the 'Pcbnew' icon image:images/"
 "icons/pcbnew.png[pcbnew_png]. The 'Pcbnew' window will open. If you get an "
@@ -1358,7 +1358,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:728
+#: getting_started_in_kicad.adoc:742
 msgid ""
 "Begin by entering some schematic information. Click on the 'Page settings' "
 "icon image:images/icons/sheetset.png[sheetset_png] on the top toolbar. Set "
@@ -1366,7 +1366,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:737
+#: getting_started_in_kicad.adoc:751
 msgid ""
 "It is a good idea to start by setting the *clearance* and the *minimum track "
 "width* to those required by your PCB manufacturer. In general you can set "
@@ -1378,12 +1378,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:739
+#: getting_started_in_kicad.adoc:753
 msgid "image:images/design_rules.png[Design Rules Window]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:743
+#: getting_started_in_kicad.adoc:757
 msgid ""
 "Click on the 'Global Design Rules' tab and set 'Min track width' to 0.25'. "
 "Click the OK button to commit your changes and close the Design Rules Editor "
@@ -1391,7 +1391,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:749
+#: getting_started_in_kicad.adoc:763
 msgid ""
 "Now we will import the netlist file. Click on the 'Read Netlist' icon image:"
 "images/icons/netlist.png[netlist_png] on the top toolbar. Click on the "
@@ -1400,21 +1400,21 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:752
+#: getting_started_in_kicad.adoc:766
 msgid ""
 "All components should now be visible in the top left hand corner just above "
 "the page. Scroll up if you cannot see them."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:756
+#: getting_started_in_kicad.adoc:770
 msgid ""
 "Select all components with the mouse and move them to the middle of the "
 "board. If necessary you can zoom in and out while you move the components."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:762
+#: getting_started_in_kicad.adoc:776
 msgid ""
 "All components are connected via a thin group of wires called __ratsnest__. "
 "Make sure that the 'Hide board ratsnest' button image:images/icons/"
@@ -1423,14 +1423,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:765
+#: getting_started_in_kicad.adoc:779
 msgid ""
 "The tool-tip is backwards; pressing this button actually displays the "
 "ratsnest."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:769
+#: getting_started_in_kicad.adoc:783
 msgid ""
 "You can move each component by hovering over it and pressing the g key. "
 "Click where you want to place them. Move all components around until you "
@@ -1438,7 +1438,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:774
+#: getting_started_in_kicad.adoc:788
 msgid ""
 "If instead of grabbing the components (with the g key ) you move them around "
 "using the m key you will later note that you lose the track connection (the "
@@ -1447,12 +1447,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:776
+#: getting_started_in_kicad.adoc:790
 msgid "image:images/gsik_tutorial1_080.png[gsik_tutorial1_080_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:783
+#: getting_started_in_kicad.adoc:797
 msgid ""
 "If the ratsnest disappears or the screen gets messy, right click and click "
 "'Redraw view'. Note how one pin of the 100 ohm resistor is connected to pin "
@@ -1462,7 +1462,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:791
+#: getting_started_in_kicad.adoc:805
 msgid ""
 "Now we will define the edge of the PCB. Select 'Edge.Cuts' from the drop "
 "down menu in the top toolbar. Click on the 'Add graphic line or polygon' "
@@ -1473,7 +1473,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:795
+#: getting_started_in_kicad.adoc:809
 msgid ""
 "Next, connect up all the wires except GND. In fact, we will connect all GND "
 "connections in one go using a ground plane placed on the bottom copper "
@@ -1481,7 +1481,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:799
+#: getting_started_in_kicad.adoc:813
 msgid ""
 "Now we must choose which copper layer we want to work on. Select 'F.Cu "
 "(PgUp)' in the drag down menu on the top toolbar. This is the front top "
@@ -1489,12 +1489,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:801
+#: getting_started_in_kicad.adoc:815
 msgid "image:images/select_top_copper.png[Select the Front top copper layer]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:807
+#: getting_started_in_kicad.adoc:821
 msgid ""
 "If you decide, for instance, to do a 4 layer PCB instead, go to *Design "
 "Rules* -> *Layers Setup* and change 'Copper Layers' to 4. In the 'Layers' "
@@ -1504,7 +1504,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:815
+#: getting_started_in_kicad.adoc:829
 msgid ""
 "Click on the 'Add Tracks and vias' icon image:images/icons/add_tracks."
 "png[add_tracks_png] on the right toolbar. Click on pin 1 of 'J1' and run a "
@@ -1515,12 +1515,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:817
+#: getting_started_in_kicad.adoc:831
 msgid "image:images/pcbnew_1.png[pcbnew_1_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:823
+#: getting_started_in_kicad.adoc:837
 msgid ""
 "If you would like to add more track widths go to: *Design Rules* -> *Design "
 "Rules* -> *Global Design Rules* tab and at the bottom right of this window "
@@ -1530,12 +1530,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:825
+#: getting_started_in_kicad.adoc:839
 msgid "image:images/custom_tracks_width.png[custom_tracks_width_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:832
+#: getting_started_in_kicad.adoc:846
 msgid ""
 "Alternatively, you can add a Net Class in which you specify a set of "
 "options. Go to *Design Rules* -> *Design Rules* -> *Net Classes Editor* and "
@@ -1546,7 +1546,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:836
+#: getting_started_in_kicad.adoc:850
 msgid ""
 "If you want to change the grid size, *Right click* -> **Grid Select**. Be "
 "sure to select the appropriate grid size before or after laying down the "
@@ -1554,19 +1554,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:839
+#: getting_started_in_kicad.adoc:853
 msgid ""
 "Repeat this process until all wires, except pin 3 of J1, are connected. Your "
 "board should look like the example below."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:841
+#: getting_started_in_kicad.adoc:855
 msgid "image:images/gsik_tutorial1_090.png[gsik_tutorial1_090_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:849
+#: getting_started_in_kicad.adoc:863
 msgid ""
 "Let's now run a track on the other copper side of the PCB. Select 'B.Cu' in "
 "the drag down menu on the top toolbar. Click on the 'Add tracks and vias' "
@@ -1577,7 +1577,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:856
+#: getting_started_in_kicad.adoc:870
 #, no-wrap
 msgid ""
 "**Go from pin A to pin B by changing layer**. It is possible to\n"
@@ -1589,13 +1589,13 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:858
+#: getting_started_in_kicad.adoc:872
 #, no-wrap
 msgid "image:images/place_a_via.png[place_a_via_png]\n"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:864
+#: getting_started_in_kicad.adoc:878
 msgid ""
 "When you want to inspect a particular connection you can click on the 'Net "
 "highlight' icon image:images/icons/net_highlight.png[net_highlight_png] on "
@@ -1604,7 +1604,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:872
+#: getting_started_in_kicad.adoc:886
 msgid ""
 "Now we will make a ground plane that will be connected to all GND pins. "
 "Click on the 'Add Zones' icon image:images/icons/add_zone.png[add_zone_png] "
@@ -1615,7 +1615,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:877
+#: getting_started_in_kicad.adoc:891
 msgid ""
 "Trace around the outline of the board by clicking each corner in rotation. "
 "Double-click to finish your rectangle. Right click inside the area you have "
@@ -1624,12 +1624,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:879
+#: getting_started_in_kicad.adoc:893
 msgid "image:images/gsik_tutorial1_100.png[gsik_tutorial1_100_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:885
+#: getting_started_in_kicad.adoc:899
 msgid ""
 "Run the design rules checker by clicking on the 'Perform Design Rules Check' "
 "icon image:images/icons/drc.png[drc_png] on the top toolbar.  Click on "
@@ -1638,37 +1638,37 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:888
+#: getting_started_in_kicad.adoc:902
 msgid ""
 "Save your file by clicking on *File* -> **Save**. To admire your board in "
 "3D, click on *View* -> **3D Viewer**."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:890
+#: getting_started_in_kicad.adoc:904
 msgid "image:images/pcbnew_3d_viewer.png[pcbnew_3d_viewer_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:892
+#: getting_started_in_kicad.adoc:906
 msgid "You can drag your mouse around to rotate the PCB."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:895
+#: getting_started_in_kicad.adoc:909
 msgid ""
 "Your board is complete. To send it off to a manufacturer you will need to "
 "generate all Gerber files."
 msgstr ""
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:897
+#: getting_started_in_kicad.adoc:911
 #, no-wrap
 msgid "Generate Gerber files"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:902
+#: getting_started_in_kicad.adoc:916
 msgid ""
 "Once your PCB is complete, you can generate Gerber files for each layer and "
 "send them to your favourite PCB manufacturer, who will make the board for "
@@ -1676,14 +1676,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:906
+#: getting_started_in_kicad.adoc:920
 msgid ""
 "From KiCad, open the _Pcbnew_ software tool and load your board file by "
 "clicking on the icon image:images/icons/open_document.png[open_document_png]."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:910
+#: getting_started_in_kicad.adoc:924
 msgid ""
 "Click on *File* -> **Plot**. Select 'Gerber' as the 'Plot Format' and select "
 "the folder in which to put all Gerber files.  Proceed by clicking on the "
@@ -1691,13 +1691,13 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:913
+#: getting_started_in_kicad.adoc:927
 msgid ""
 "These are the layers you need to select for making a typical 2-layer PCB:"
 msgstr ""
 
 #. type: delimited block |
-#: getting_started_in_kicad.adoc:924
+#: getting_started_in_kicad.adoc:938
 #, no-wrap
 msgid ""
 "|Layer |KiCad Layer Name |Old KiCad Layer Name |Default Gerber Extension\n"
@@ -1711,13 +1711,13 @@ msgid ""
 msgstr ""
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:927
+#: getting_started_in_kicad.adoc:941
 #, no-wrap
 msgid "Using GerbView"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:936
+#: getting_started_in_kicad.adoc:950
 msgid ""
 "To view all your Gerber files go to the KiCad project manager and click on "
 "the 'GerbView' icon.  On the drag down menu select 'Layer 1'. Click on "
@@ -1727,27 +1727,27 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:939
+#: getting_started_in_kicad.adoc:953
 msgid ""
 "Use the menu on the right to select/deselect which layer to show.  Carefully "
 "inspect each layer before sending them for production."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:942
+#: getting_started_in_kicad.adoc:956
 msgid ""
 "To generate the drill file, from _Pcbnew_ go again for the *File* -> *Plot* "
 "option. Default settings should be fine."
 msgstr ""
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:944
+#: getting_started_in_kicad.adoc:958
 #, no-wrap
 msgid "Automatically route with FreeRouter"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:952
+#: getting_started_in_kicad.adoc:966
 msgid ""
 "Routing a board by hand is quick and fun, however, for a board with lots of "
 "components you might want to use an autorouter. Remember that you should "
@@ -1757,7 +1757,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:957
+#: getting_started_in_kicad.adoc:971
 msgid ""
 "Freerouter is a open source java application, and it is needed to build by "
 "yourself to use with KiCad.  Source code of Freerouter can be found on this "
@@ -1765,7 +1765,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:963
+#: getting_started_in_kicad.adoc:977
 msgid ""
 "From _Pcbnew_ click on *File* -> *Export* -> *Specctra DSN* or click on "
 "*Tools* -> *FreeRoute* -> **Export a Specctra Design (*.dsn) file** and save "
@@ -1774,7 +1774,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:968
+#: getting_started_in_kicad.adoc:982
 msgid ""
 "The *Tools* -> *FreeRoute* dialog has a nice help button that opens a file "
 "viewer with a little document inside named **Freerouter Guidelines**. Please "
@@ -1782,7 +1782,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:974
+#: getting_started_in_kicad.adoc:988
 msgid ""
 "FreeRouter has some features that KiCad does not currently have, both for "
 "manual routing and for automatic routing. FreeRouter operates in two main "
@@ -1791,7 +1791,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:982
+#: getting_started_in_kicad.adoc:996
 msgid ""
 "You can start the automatic routing by clicking on the 'Autorouter' button "
 "on the top bar. The bottom bar gives you information about the on-going "
@@ -1802,7 +1802,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:987
+#: getting_started_in_kicad.adoc:1001
 msgid ""
 "Making a left-click on the mouse can stop the automatic routing and "
 "automatically start the optimisation process. Another left-click will stop "
@@ -1811,7 +1811,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:991
+#: getting_started_in_kicad.adoc:1005
 msgid ""
 "Click on the *File* -> *Export Specctra Session File* menu and save the "
 "board file with the _.ses_ extension. You do not really need to save the "
@@ -1819,7 +1819,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:996
+#: getting_started_in_kicad.adoc:1010
 msgid ""
 "Back to __Pcbnew__. You can import your freshly routed board by clicking on "
 "the link *Tools* -> *FreeRoute* and then on the icon 'Back Import the "
@@ -1827,7 +1827,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1001
+#: getting_started_in_kicad.adoc:1015
 msgid ""
 "If there is any routed trace that you do not like, you can delete it and re-"
 "route it again, using the del key and the routing tool, which is the 'Add "
@@ -1836,13 +1836,13 @@ msgid ""
 msgstr ""
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1003
+#: getting_started_in_kicad.adoc:1017
 #, no-wrap
 msgid "Forward annotation in KiCad"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1009
+#: getting_started_in_kicad.adoc:1023
 msgid ""
 "Once you have completed your electronic schematic, the footprint assignment, "
 "the board layout and generated the Gerber files, you are ready to send "
@@ -1850,7 +1850,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1017
+#: getting_started_in_kicad.adoc:1031
 msgid ""
 "Often, this linear work-flow turns out to be not so uni-directional. For "
 "instance, when you have to modify/extend a board for which you or others "
@@ -1861,19 +1861,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1020
+#: getting_started_in_kicad.adoc:1034
 msgid ""
 "Let's suppose that you want to replace a hypothetical connector CON1 with "
 "CON2."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1022
+#: getting_started_in_kicad.adoc:1036
 msgid "You already have a completed schematic and a fully routed PCB."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1028
+#: getting_started_in_kicad.adoc:1042
 msgid ""
 "From KiCad, start __Eeschema__, make your modifications by deleting CON1 and "
 "adding CON2. Save your schematic project with the icon image:images/icons/"
@@ -1882,14 +1882,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1031
+#: getting_started_in_kicad.adoc:1045
 msgid ""
 "Click on 'Netlist' then on 'save'. Save to the default file name.  You have "
 "to rewrite the old one."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1037
+#: getting_started_in_kicad.adoc:1051
 msgid ""
 "Now assign a footprint to CON2. Click on the 'Run Cvpcb' icon image:images/"
 "icons/cvpcb.png[cvpcb] on the top toolbar. Assign the footprint to the new "
@@ -1898,21 +1898,21 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1040
+#: getting_started_in_kicad.adoc:1054
 msgid ""
 "Back in the schematic editor, save the project by clicking on 'File' -> "
 "'Save Whole Schematic Project'. Close the schematic editor."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1043
+#: getting_started_in_kicad.adoc:1057
 msgid ""
 "From the KiCad project manager, click on the 'Pcbnew' icon. The 'Pcbnew' "
 "window will open."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1047
+#: getting_started_in_kicad.adoc:1061
 msgid ""
 "The old, already routed, board should automatically open. Let's import the "
 "new netlist file. Click on the 'Read Netlist' icon image:images/icons/"
@@ -1920,7 +1920,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1051
+#: getting_started_in_kicad.adoc:1065
 msgid ""
 "Click on the 'Browse Netlist Files' button, select the netlist file in the "
 "file selection dialogue, and click on 'Read Current Netlist'.  Then click "
@@ -1928,7 +1928,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1056
+#: getting_started_in_kicad.adoc:1070
 msgid ""
 "At this point you should be able to see a layout with all previous "
 "components already routed. On the top left corner you should see all "
@@ -1937,14 +1937,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1059
+#: getting_started_in_kicad.adoc:1073
 msgid ""
 "Place CON2 and route it. Once done, save and proceed with the Gerber file "
 "generation as usual."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1067
+#: getting_started_in_kicad.adoc:1081
 msgid ""
 "The process described here can easily be repeated as many times as you need. "
 "Beside the Forward Annotation method described above, there is another "
@@ -1955,13 +1955,13 @@ msgid ""
 msgstr ""
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1069
+#: getting_started_in_kicad.adoc:1083
 #, no-wrap
 msgid "Make schematic components in KiCad"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1076
+#: getting_started_in_kicad.adoc:1090
 msgid ""
 "Sometimes a component that you want to place on your schematic is not in the "
 "KiCad libraries. This is quite normal and there is no reason to worry. In "
@@ -1971,12 +1971,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1078
+#: getting_started_in_kicad.adoc:1092
 msgid "http://per.launay.free.fr/kicad/kicad_php/composant.php"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1083
+#: getting_started_in_kicad.adoc:1097
 msgid ""
 "In KiCad, a component is a piece of text that starts with a 'DEF' and ends "
 "with 'ENDDEF'. One or more components are normally placed in a library file "
@@ -1985,13 +1985,13 @@ msgid ""
 msgstr ""
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1085
+#: getting_started_in_kicad.adoc:1099
 #, no-wrap
 msgid "Using Component Library Editor"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1091
+#: getting_started_in_kicad.adoc:1105
 msgid ""
 "We can use the _Component Library Editor_ (part of __Eeschema__)  to make "
 "new components. In our project folder 'tutorial1' let's create a folder "
@@ -2000,7 +2000,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1106
+#: getting_started_in_kicad.adoc:1120
 msgid ""
 "Now we can start creating our new component. From KiCad, start __Eeschema__, "
 "click on the 'Library Editor' icon image:images/icons/libedit."
@@ -2015,33 +2015,33 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1110
+#: getting_started_in_kicad.adoc:1124
 msgid ""
 "In the Pin Properties window that appears, set the pin name to 'VCC', set "
 "the pin number to '1', and the 'Electrical type' to 'Passive' then click OK."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1112
+#: getting_started_in_kicad.adoc:1126
 msgid "image:images/pin_properties.png[Pin Properties]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1115
+#: getting_started_in_kicad.adoc:1129
 msgid ""
 "Place the pin by clicking on the location you would like it to go, right "
 "below the 'MYCONN3' label."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1119
+#: getting_started_in_kicad.adoc:1133
 msgid ""
 "Repeat the place-pin steps, this time 'Pin name' should be 'INPUT', 'Pin "
 "number' should be '2', and 'Electrical Type' should be 'Passive'."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1125
+#: getting_started_in_kicad.adoc:1139
 msgid ""
 "Repeat the place-pin steps, this time 'Pin name' should be 'GND', 'Pin "
 "number' should be '3', and 'Electrical Type' should be 'Passive'.  Arrange "
@@ -2050,7 +2050,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1133
+#: getting_started_in_kicad.adoc:1147
 msgid ""
 "Next, draw the contour of the component. Click on the 'Add rectangle' icon "
 "image:images/icons/add_rectangle.png[add_rectangle_png]. We want to draw a "
@@ -2061,12 +2061,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1135
+#: getting_started_in_kicad.adoc:1149
 msgid "image:images/gsik_myconn3_l.png[gsik_myconn3_l_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1140
+#: getting_started_in_kicad.adoc:1154
 msgid ""
 "Save the component in your library __myLib.lib__. Click on the 'New Library' "
 "icon image:images/icons/new_library.png[new_library_png], navigate into "
@@ -2075,14 +2075,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1143
+#: getting_started_in_kicad.adoc:1157
 msgid ""
 "Go to *Preferences* -> *Component Libraries* and add both _tutorial1/library/"
 "_ in 'User defined search path' and _myLib.lib in_ 'Component library files'."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1149
+#: getting_started_in_kicad.adoc:1163
 msgid ""
 "Click on the 'Select working library' icon image:images/icons/library."
 "png[library_png]. In the Select Library window click on _myLib_ and click "
@@ -2091,7 +2091,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1158
+#: getting_started_in_kicad.adoc:1172
 msgid ""
 "Click on the 'Update current component in current library' icon image:images/"
 "icons/save_part_in_mem.png[save_part_in_mem_png] in the top toolbar. Save "
@@ -2103,7 +2103,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1162
+#: getting_started_in_kicad.adoc:1176
 msgid ""
 "You can now close the Component library editor window. You will return to "
 "the schematic editor window. Your new component will now be available to you "
@@ -2111,7 +2111,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1167
+#: getting_started_in_kicad.adoc:1181
 msgid ""
 "You can make any library _file.lib_ file available to you by adding it to "
 "the library path. From __Eeschema__, go to *Preferences* -> *Library* and "
@@ -2120,13 +2120,13 @@ msgid ""
 msgstr ""
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1169
+#: getting_started_in_kicad.adoc:1183
 #, no-wrap
 msgid "Export, import and modify library components"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1175
+#: getting_started_in_kicad.adoc:1189
 msgid ""
 "Instead of creating a library component from scratch it is sometimes easier "
 "to start from one already made and modify it. In this section we will see "
@@ -2135,7 +2135,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1183
+#: getting_started_in_kicad.adoc:1197
 msgid ""
 "From KiCad, start __Eeschema__, click on the 'Library Editor' icon image:"
 "images/icons/libedit.png[libedit_png], click on the 'Select working library' "
@@ -2146,7 +2146,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1187
+#: getting_started_in_kicad.adoc:1201
 msgid ""
 "Click on the 'Export component' icon image:images/icons/export."
 "png[export_png], navigate into the _library/_ folder and save the new "
@@ -2154,7 +2154,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1193
+#: getting_started_in_kicad.adoc:1207
 msgid ""
 "You can make this component and the whole library _myOwnLib.lib_ available "
 "to you by adding it to the library path. From __Eeschema__, go to "
@@ -2163,7 +2163,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1199
+#: getting_started_in_kicad.adoc:1213
 msgid ""
 "Click on the 'Select working library' icon image:images/icons/library."
 "png[library_png]. In the Select Library window click on _myOwnLib_ and click "
@@ -2172,7 +2172,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1203
+#: getting_started_in_kicad.adoc:1217
 msgid ""
 "Click on the 'Load component to edit from the current lib' icon image:images/"
 "icons/import_cmp_from_lib.png[import_cmp_from_lib_png] and import the "
@@ -2180,14 +2180,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1206
+#: getting_started_in_kicad.adoc:1220
 msgid ""
 "You can now modify the component as you like. Hover over the label "
 "'RELAY_2RT', press the e key and rename it 'MY_RELAY_2RT'."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1213
+#: getting_started_in_kicad.adoc:1227
 msgid ""
 "Click on 'Update current component in current library' icon image:images/"
 "icons/save_part_in_mem.png[save_part_in_mem_png] in the top toolbar. Save "
@@ -2196,13 +2196,13 @@ msgid ""
 msgstr ""
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1215
+#: getting_started_in_kicad.adoc:1229
 #, no-wrap
 msgid "Make schematic components with quicklib"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1220
+#: getting_started_in_kicad.adoc:1234
 msgid ""
 "This section presents an alternative way of creating the schematic component "
 "for MYCONN3 (see <<myconn3,MYCONN3>> above) using the Internet tool "
@@ -2210,20 +2210,20 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1223
+#: getting_started_in_kicad.adoc:1237
 msgid ""
 "Head to the _quicklib_ web page: http://kicad.rohrbacher.net/quicklib.php"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1226
+#: getting_started_in_kicad.adoc:1240
 msgid ""
 "Fill out the page with the following information: Component name: MYCONN3 "
 "Reference Prefix: J Pin Layout Style: SIL Pin Count, N: 3"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1230
+#: getting_started_in_kicad.adoc:1244
 msgid ""
 "Click on the 'Assign Pins' icon. Fill out the page with the following "
 "information: Pin 1: VCC Pin 2: input Pin 3: GND.  Type : Passive for all 3 "
@@ -2231,7 +2231,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1234
+#: getting_started_in_kicad.adoc:1248
 msgid ""
 "Click on the icon 'Preview it' and, if you are satisfied, click on the "
 "'Build Library Component'. Download the file and rename it __tutorial1/"
@@ -2239,7 +2239,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1240
+#: getting_started_in_kicad.adoc:1254
 msgid ""
 "Have a look at it using KiCad. From the KiCad project manager, start "
 "__Eeschema__, click on the 'Library Editor' icon image:images/icons/libedit."
@@ -2249,12 +2249,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1242
+#: getting_started_in_kicad.adoc:1256
 msgid "image:images/gsik_myconn3_quicklib.png[gsik_myconn3_quicklib_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1248
+#: getting_started_in_kicad.adoc:1262
 msgid ""
 "You can make this component and the whole library _myQuickLib.lib_ available "
 "to you by adding it to the KiCad library path. From __Eeschema__, go to "
@@ -2263,20 +2263,20 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1252
+#: getting_started_in_kicad.adoc:1266
 msgid ""
 "As you might guess, this method of creating library components can be quite "
 "effective when you want to create components with a large pin count."
 msgstr ""
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1254
+#: getting_started_in_kicad.adoc:1268
 #, no-wrap
 msgid "Make a high pin count schematic component"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1261
+#: getting_started_in_kicad.adoc:1275
 msgid ""
 "In the section titled _Make Schematic Components in quicklib_ we saw how to "
 "make a schematic component using the _quicklib_ web-based tool.  However, "
@@ -2286,7 +2286,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1267
+#: getting_started_in_kicad.adoc:1281
 msgid ""
 "Suppose that you want to create a schematic component for a device with 50 "
 "pins. It is common practise to draw it using multiple low pin-count "
@@ -2295,7 +2295,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1272
+#: getting_started_in_kicad.adoc:1286
 msgid ""
 "The best way to create our component is to use _quicklib_ to generate two 25-"
 "pin components separately, re-number their pins using a Python script and "
@@ -2304,7 +2304,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1278
+#: getting_started_in_kicad.adoc:1292
 msgid ""
 "You will find an example of a simple Python script below that can be used in "
 "conjunction with an _in.txt_ file and an _out.txt_ file to re-number the "
@@ -2313,13 +2313,13 @@ msgid ""
 msgstr ""
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:1279
+#: getting_started_in_kicad.adoc:1293
 #, no-wrap
 msgid "Simple script"
 msgstr ""
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1302
+#: getting_started_in_kicad.adoc:1316
 #, no-wrap
 msgid ""
 "#!/usr/bin/env python\n"
@@ -2345,7 +2345,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1308
+#: getting_started_in_kicad.adoc:1322
 msgid ""
 "While merging the two components into one, it is necessary to use the "
 "Library Editor from Eeschema to move the first component so that the second "
@@ -2354,13 +2354,13 @@ msgid ""
 msgstr ""
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:1309
+#: getting_started_in_kicad.adoc:1323
 #, no-wrap
 msgid "Contents of a *.lib file"
 msgstr ""
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1321
+#: getting_started_in_kicad.adoc:1335
 #, no-wrap
 msgid ""
 "EESchema-LIBRARY Version 2.3\n"
@@ -2376,13 +2376,13 @@ msgid ""
 msgstr ""
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1323
+#: getting_started_in_kicad.adoc:1337
 #, no-wrap
 msgid "...\n"
 msgstr ""
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1328
+#: getting_started_in_kicad.adoc:1342
 #, no-wrap
 msgid ""
 "X PIN49 49 750 -500 300 L 50 50 1 1 I\n"
@@ -2392,12 +2392,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1331
+#: getting_started_in_kicad.adoc:1345
 msgid "image:images/gsik_high_number_pins.png[gsik_high_number_pins_png]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1336
+#: getting_started_in_kicad.adoc:1350
 msgid ""
 "The Python script presented here is a very powerful tool for manipulating "
 "both pin numbers and pin labels. Mind, however, that all its power comes for "
@@ -2406,13 +2406,13 @@ msgid ""
 msgstr ""
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1338
+#: getting_started_in_kicad.adoc:1352
 #, no-wrap
 msgid "Make component footprints"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1344
+#: getting_started_in_kicad.adoc:1358
 msgid ""
 "Unlike other EDA software tools, which have one type of library that "
 "contains both the schematic symbol and the footprint variations, KiCad _."
@@ -2421,14 +2421,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1347
+#: getting_started_in_kicad.adoc:1361
 msgid ""
 "As for _.lib_ files, _.kicad_mod_ library files are text files that can "
 "contain anything from one to several parts."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1351
+#: getting_started_in_kicad.adoc:1365
 msgid ""
 "There is an extensive footprint library with KiCad, however on occasion you "
 "might find that the footprint you need is not in the KiCad library.  Here "
@@ -2436,13 +2436,13 @@ msgid ""
 msgstr ""
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1353
+#: getting_started_in_kicad.adoc:1367
 #, no-wrap
 msgid "Using Footprint Editor"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1359
+#: getting_started_in_kicad.adoc:1373
 msgid ""
 "From the KiCad project manager start the _Pcbnew_ tool. Click on the 'Open "
 "Footprint Editor' icon image:images/icons/edit_module.png[edit_module_png] "
@@ -2450,7 +2450,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1371
+#: getting_started_in_kicad.adoc:1385
 msgid ""
 "We are going to save the new footprint 'MYCONN3' in the new footprint "
 "library 'myfootprint'.  Create a new folder _myfootprint.pretty_ in the "
@@ -2464,7 +2464,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1380
+#: getting_started_in_kicad.adoc:1394
 msgid ""
 "Click on the 'New Footprint' icon image:images/icons/new_footprint."
 "png[new_footprint_png] on the top toolbar.  Type 'MYCONN3' as the 'footprint "
@@ -2475,7 +2475,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1385
+#: getting_started_in_kicad.adoc:1399
 msgid ""
 "Select the 'Add Pads' icon image:images/icons/pad.png[pad_png] on the right "
 "toolbar. Click on the working sheet to place the pad. Right click on the new "
@@ -2483,12 +2483,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1387
+#: getting_started_in_kicad.adoc:1401
 msgid "image:images/pad_properties.png[Pad Properties]"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1391
+#: getting_started_in_kicad.adoc:1405
 msgid ""
 "Set the 'Pad Num' to '1', 'Pad Shape' to 'Rect', 'Pad Type' to 'SMD', 'Shape "
 "Size X' to '0.4', and 'Shape Size Y' to '0.8'. Click OK.  Click on 'Add "
@@ -2496,21 +2496,21 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1395
+#: getting_started_in_kicad.adoc:1409
 msgid ""
 "If you want to change the grid size, *Right click* -> **Grid Select**. Be "
 "sure to select the appropriate grid size before laying down the components."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1398
+#: getting_started_in_kicad.adoc:1412
 msgid ""
 "Move the 'MYCONN3' label and the 'SMD' label out of the way so that it looks "
 "like the image shown above."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1405
+#: getting_started_in_kicad.adoc:1419
 msgid ""
 "When placing pads it is often necessary to measure relative distances. Place "
 "the cursor where you want the relative coordinate point _(0,0)_ to be and "
@@ -2520,7 +2520,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1410
+#: getting_started_in_kicad.adoc:1424
 msgid ""
 "Now add a footprint contour. Click on the 'Add graphic line or polygon' "
 "button image:images/icons/add_polygon.png[add_polygon_png] in the right "
@@ -2528,7 +2528,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1414
+#: getting_started_in_kicad.adoc:1428
 msgid ""
 "Click on the 'Save Footprint in Active Library' icon image:images/icons/"
 "save_library.png[save_library_png] on the top toolbar, using the default "
@@ -2536,20 +2536,20 @@ msgid ""
 msgstr ""
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1416
+#: getting_started_in_kicad.adoc:1430
 #, no-wrap
 msgid "Note about portability of KiCad project files"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1420
+#: getting_started_in_kicad.adoc:1434
 msgid ""
 "What files do you need to send to someone so that they can fully load and "
 "use your KiCad project?"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1427
+#: getting_started_in_kicad.adoc:1441
 msgid ""
 "When you have a KiCad project to share with somebody, it is important that "
 "the schematic file __.sch__, the board file __.kicad_pcb__, the project file "
@@ -2560,7 +2560,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1439
+#: getting_started_in_kicad.adoc:1453
 msgid ""
 "With KiCad schematics, people need the _.lib_ files that contain the "
 "symbols. Those library files need to be loaded in the _Eeschema_ "
@@ -2575,7 +2575,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1447
+#: getting_started_in_kicad.adoc:1461
 msgid ""
 "If someone sends you a _.kicad_pcb_ file with footprints you would like to "
 "use in another board, you can open the Footprint Editor, load a footprint "
@@ -2587,7 +2587,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1453
+#: getting_started_in_kicad.adoc:1467
 msgid ""
 "Bottom line, if the PCB is the only thing you want to distribute, then the "
 "board file _.kicad_pcb_ is enough. However, if you want to give people the "
@@ -2597,7 +2597,7 @@ msgid ""
 msgstr ""
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1471
+#: getting_started_in_kicad.adoc:1485
 #, no-wrap
 msgid ""
 "tutorial1/\n"
@@ -2619,13 +2619,13 @@ msgid ""
 msgstr ""
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1474
+#: getting_started_in_kicad.adoc:1488
 #, no-wrap
 msgid "More about KiCad documentation"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1479
+#: getting_started_in_kicad.adoc:1493
 msgid ""
 "This has been a quick guide on most of the features in KiCad. For more "
 "detailed instructions consult the help files which you can access through "
@@ -2633,19 +2633,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1482
+#: getting_started_in_kicad.adoc:1496
 msgid ""
 "KiCad comes with a pretty good set of multi-language manuals for all its "
 "four software components."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1484
+#: getting_started_in_kicad.adoc:1498
 msgid "The English version of all KiCad manuals are distributed with KiCad."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1490
+#: getting_started_in_kicad.adoc:1504
 msgid ""
 "In addition to its manuals, KiCad is distributed with this tutorial, which "
 "has been translated into other languages. All the different versions of this "
@@ -2655,14 +2655,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1493
+#: getting_started_in_kicad.adoc:1507
 msgid ""
 "For example, on Linux the typical locations are in the following "
 "directories, depending on your exact distribution:"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1496
+#: getting_started_in_kicad.adoc:1510
 #, no-wrap
 msgid ""
 " /usr/share/doc/kicad/help/en/\n"
@@ -2670,40 +2670,40 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1498
+#: getting_started_in_kicad.adoc:1512
 msgid "On Windows it is in:"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1500
+#: getting_started_in_kicad.adoc:1514
 #, no-wrap
 msgid " <installation directory>/share/doc/kicad/help/en\n"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1502
+#: getting_started_in_kicad.adoc:1516
 msgid "On OS X:"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1504
+#: getting_started_in_kicad.adoc:1518
 #, no-wrap
 msgid " /Library/Application Support/kicad/help/en\n"
 msgstr ""
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1506
+#: getting_started_in_kicad.adoc:1520
 #, no-wrap
 msgid "KiCad documentation on the Web"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1509
+#: getting_started_in_kicad.adoc:1523
 msgid ""
 "Latest KiCad documentations are available in multiple languages on the Web."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1511
+#: getting_started_in_kicad.adoc:1525
 msgid "http://kicad-pcb.org/help/documentation/"
 msgstr ""

--- a/src/getting_started_in_kicad/po/pl.po
+++ b/src/getting_started_in_kicad/po/pl.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.1\n"
-"POT-Creation-Date: 2016-01-06 23:55+0100\n"
+"POT-Creation-Date: 2016-01-07 20:18+0100\n"
 "PO-Revision-Date: 2015-12-23 16:17+0100\n"
 "Last-Translator: Kerusey Karyu <keruseykaryu@o2.pl>\n"
 "Language-Team: Polish KiCAD Team: Mateusz Skowroński, Krzysztof Kawa, "
@@ -794,7 +794,7 @@ msgstr ""
 "zaimplementowana."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:304
+#: getting_started_in_kicad.adoc:306
 #, fuzzy
 #| msgid ""
 #| "Hover the mouse over the component 'R' and press the r key. Notice how "
@@ -808,7 +808,7 @@ msgstr ""
 "jaki sposób komponent został obrócony."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:306
+#: getting_started_in_kicad.adoc:312
 msgid ""
 "If your mouse was also over the _Field Reference_ ('R') or the _Field Value_ "
 "('R?'), a menu will appear. You will see these 'Clarify Selection' menu "
@@ -818,7 +818,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:312
+#: getting_started_in_kicad.adoc:318
 #, fuzzy
 #| msgid ""
 #| "Right click in the middle of the component and select *Edit Component* -> "
@@ -841,12 +841,12 @@ msgstr ""
 "na możliwe klawisze skrótów wywołujące poszczególne akcje."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:314
+#: getting_started_in_kicad.adoc:320
 msgid "image:images/edit_component_dropdown.png[Edit component menu]"
 msgstr "image:images/pl/edit_component_dropdown.png[Menu edycji komponentu]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:317
+#: getting_started_in_kicad.adoc:323
 msgid ""
 "The Component value window will appear. Replace the current value 'R' with "
 "'1k'. Click OK."
@@ -855,7 +855,7 @@ msgstr ""
 "Kliknij OK."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:320
+#: getting_started_in_kicad.adoc:326
 #, fuzzy
 #| msgid ""
 #| "Do not change the Reference field (R?), this will be done automatically "
@@ -868,12 +868,12 @@ msgstr ""
 "automatu. Wartość wewnątrz rezystora od teraz powinna wynosić '1k'. "
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:322
+#: getting_started_in_kicad.adoc:328
 msgid "image:images/resistor_value.png[Resistor Value]"
 msgstr "image:images/resistor_value.png[Wartość rezystora]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:325
+#: getting_started_in_kicad.adoc:331
 msgid ""
 "To place another resistor, simply click where you want the resistor to "
 "appear. The Component Selection window will appear again."
@@ -882,7 +882,7 @@ msgstr ""
 "umieścić. Ponownie pojawi się okno Wybór symbolu."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:328
+#: getting_started_in_kicad.adoc:334
 #, fuzzy
 #| msgid ""
 #| "The resistor you previously chose is now in your history list, appearing "
@@ -895,12 +895,12 @@ msgstr ""
 "historią wyboru jako 'R'. Kliknij OK i umieść komponent."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:330
+#: getting_started_in_kicad.adoc:336
 msgid "image:images/component_history.png[Component history]"
 msgstr "image:images/pl/component_history.png[Wybór z historii]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:335
+#: getting_started_in_kicad.adoc:341
 #, fuzzy
 #| msgid ""
 #| "In case you make a mistake and want to delete a component, right click on "
@@ -919,7 +919,7 @@ msgstr ""
 "komponent który chcesz usunąć oraz nacisnąć klawisz *Del*."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:339
+#: getting_started_in_kicad.adoc:345
 #, fuzzy
 #| msgid ""
 #| "You can rename any default shortcut key by going to *Preferences* -> "
@@ -934,7 +934,7 @@ msgstr ""
 "zapisać nowych ustawień za pomocą *Ustawienia* -> **Zapisz ustawienia**."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:343
+#: getting_started_in_kicad.adoc:349
 msgid ""
 "You can also duplicate a component already on your schematic sheet by "
 "hovering over it and pressing the c key. Click where you want to place the "
@@ -945,7 +945,7 @@ msgstr ""
 "chciałbyś umieścić nowy, zduplikowany komponent."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:349
+#: getting_started_in_kicad.adoc:355
 #, fuzzy
 #| msgid ""
 #| "Right click on the second resistor. Select 'Drag Component'.  Reposition "
@@ -966,7 +966,7 @@ msgstr ""
 "pozwalają na przerzucanie elementu w pionie lub w poziomie."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:354
+#: getting_started_in_kicad.adoc:360
 #, fuzzy, no-wrap
 #| msgid ""
 #| "*Right-Click* -> *Move component* (equivalent to the m key option)\n"
@@ -986,7 +986,7 @@ msgstr ""
 "Zobaczymy później dlaczego jest to takie ważne.\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:358
+#: getting_started_in_kicad.adoc:364
 msgid ""
 "Edit the second resistor by hovering over it and pressing the v key.  "
 "Replace 'R' with '100'. You can undo any of your editing actions with the "
@@ -997,7 +997,7 @@ msgstr ""
 "pomocą klawisza *Ctrl+Z*."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:364
+#: getting_started_in_kicad.adoc:370
 #, fuzzy
 #| msgid ""
 #| "Change the grid size. You have probably noticed that on the schematic "
@@ -1018,7 +1018,7 @@ msgstr ""
 "schematów__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:366
+#: getting_started_in_kicad.adoc:374
 msgid ""
 "We are going to add a component from a library that isn't configured in the "
 "default project. In the menu, choose *Preferences* -> **Component "
@@ -1026,7 +1026,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:368
+#: getting_started_in_kicad.adoc:380
 msgid ""
 "You need to find where the official KiCad libraries are installed on your "
 "computer. Look for a `library` directory containing a hundred of `.dcm` and "
@@ -1036,7 +1036,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:372
+#: getting_started_in_kicad.adoc:384
 #, fuzzy
 #| msgid ""
 #| "Repeat the add-component steps, this time choosing the 'device' library "
@@ -1050,7 +1050,7 @@ msgstr ""
 "'device' a z niej komponent 'LED'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:377
+#: getting_started_in_kicad.adoc:389
 msgid ""
 "Hover the mouse over the microcontroller component. Press the y key or the x "
 "key on the keyboard. Notice how the component is flipped over its x axis or "
@@ -1061,7 +1061,7 @@ msgstr ""
 "osi Y. Naciskaj klawisze ponownie by wrócić do jego oryginalnego położenia."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:380
+#: getting_started_in_kicad.adoc:392
 msgid ""
 "Repeat the add-component steps, this time choosing the 'device' library and "
 "picking the 'LED' component from it."
@@ -1070,19 +1070,19 @@ msgstr ""
 "'device' a z niej komponent 'LED'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:382
+#: getting_started_in_kicad.adoc:394
 msgid "Organise all components on your schematic sheet as shown below."
 msgstr "Ułóż komponenty na twoim schemacie tak jak pokazano poniżej."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:384
+#: getting_started_in_kicad.adoc:396
 #, fuzzy
 #| msgid "image:images/gsik_tutorial1_080.png[gsik_tutorial1_080_png]"
 msgid "image:images/gsik_tutorial1_010.png[gsik_tutorial1_010_png]"
 msgstr "image:images/gsik_tutorial1_080.png[gsik_tutorial1_080_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:390
+#: getting_started_in_kicad.adoc:402
 #, fuzzy
 #| msgid ""
 #| "We now need to create the schematic component 'MYCONN3' for our 3-pin "
@@ -1102,7 +1102,7 @@ msgstr ""
 "komponent od zera i wrócić tu by kontynuować tworzenie płytki."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:393
+#: getting_started_in_kicad.adoc:405
 #, fuzzy
 #| msgid ""
 #| "You can now place the freshly made component. Press the a key and select "
@@ -1116,7 +1116,7 @@ msgstr ""
 "komponent 'MYCONN3'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:399
+#: getting_started_in_kicad.adoc:411
 #, fuzzy
 #| msgid ""
 #| "The component identifier 'J?' will appear under the 'MYCONN3' label.  If "
@@ -1139,12 +1139,12 @@ msgstr ""
 "mogą być przesuwane wokół, tyle razy ile zechcesz."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:401
+#: getting_started_in_kicad.adoc:413
 msgid "image:images/gsik_myconn3_s.png[gsik_myconn3_s_png]"
 msgstr "image:images/gsik_myconn3_s.png[gsik_myconn3_s_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:407
+#: getting_started_in_kicad.adoc:419
 #, fuzzy
 #| msgid ""
 #| "It is time to place the power and ground symbols. Click on the 'Place a "
@@ -1167,7 +1167,7 @@ msgstr ""
 "_Wybierz symbol_. Kliknij OK."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:413
+#: getting_started_in_kicad.adoc:425
 msgid ""
 "Click above the pin of the 1k resistor to place the VCC part. Click on the "
 "area above the microcontroller 'VDD'. In the 'Component Selection history' "
@@ -1181,7 +1181,7 @@ msgstr ""
 "'MYCONN3'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:418
+#: getting_started_in_kicad.adoc:430
 #, fuzzy
 #| msgid ""
 #| "Repeat the add-pin steps but this time select the GND part. Place a GND "
@@ -1200,21 +1200,21 @@ msgstr ""
 "schemat powinien teraz wyglądać mniej więcej tak:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:420
+#: getting_started_in_kicad.adoc:432
 #, fuzzy
 #| msgid "image:images/gsik_tutorial1_020.png[gsik_tutorial1_020_png]"
 msgid "image:images/gsik_tutorial1_020.png[gsik_tutorial1_020_png]"
 msgstr "image:images/gsik_tutorial1_020.png[gsik_tutorial1_020_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:424
+#: getting_started_in_kicad.adoc:436
 msgid ""
 "Next, we will wire all our components. Click on the 'Place wire' icon image:"
 "images/icons/add_line.png[Place wire] on the right toolbar."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:429
+#: getting_started_in_kicad.adoc:441
 #, fuzzy
 #| msgid ""
 #| "Next, we will wire all our components. Click on the 'Place wire' icon "
@@ -1235,7 +1235,7 @@ msgstr ""
 "używać magistral."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:433
+#: getting_started_in_kicad.adoc:445
 msgid ""
 "Click on the little circle at the end of pin 7 of the microcontroller and "
 "then click on the little circle on pin 2 of the LED.  You can zoom in while "
@@ -1246,7 +1246,7 @@ msgstr ""
 "przybliżyć widok podczas wstawiania tego połączenia."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:438
+#: getting_started_in_kicad.adoc:450
 #, fuzzy
 #| msgid ""
 #| "If you want to reposition wired components, it is important to use the g "
@@ -1265,12 +1265,12 @@ msgstr ""
 "zapomniałeś już jak przesuwać elementy spójrz jeszcze raz na krok numer _24_."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:440
+#: getting_started_in_kicad.adoc:452
 msgid "image:images/gsik_tutorial1_030.png[gsik_tutorial1_030_png]"
 msgstr "image:images/gsik_tutorial1_030.png[gsik_tutorial1_030_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:446
+#: getting_started_in_kicad.adoc:458
 #, fuzzy
 #| msgid ""
 #| "Repeat this process and wire up all the other components as shown below. "
@@ -1289,12 +1289,12 @@ msgstr ""
 "'VCC' oraz środka na górze w symbolu 'GND'. Zobacz poniższy obrazek."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:448
+#: getting_started_in_kicad.adoc:460
 msgid "image:images/gsik_tutorial1_040.png[gsik_tutorial1_040_png]"
 msgstr "image:images/gsik_tutorial1_040.png[gsik_tutorial1_040_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:453
+#: getting_started_in_kicad.adoc:465
 #, fuzzy
 #| msgid ""
 #| "We will now consider an alternative way of making a connection using "
@@ -1313,7 +1313,7 @@ msgstr ""
 "na prawym pasku narzędzi. Możesz także użyć klawisza *L*."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:456
+#: getting_started_in_kicad.adoc:468
 msgid ""
 "Click in the middle of the wire connected to pin 6 of the microcontroller. "
 "Name this label 'INPUT'."
@@ -1322,7 +1322,7 @@ msgstr ""
 "mikrokontrolera. Nazwij tą etykietę 'INPUT'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:465
+#: getting_started_in_kicad.adoc:477
 msgid ""
 "Follow the same procedure and place another label on line on the right of "
 "the 100 ohm resistor. Also name it 'INPUT'. The two labels, having the same "
@@ -1342,7 +1342,7 @@ msgstr ""
 "wyprowadzenia."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:471
+#: getting_started_in_kicad.adoc:483
 msgid ""
 "Labels can also be used to simply label wires for informative purposes. "
 "Place a label on pin 7 of the PIC. Enter the name 'uCtoLED'.  Name the wire "
@@ -1356,7 +1356,7 @@ msgstr ""
 "'INPUTtoR'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:474
+#: getting_started_in_kicad.adoc:486
 msgid ""
 "You do not have to label the VCC and GND lines because the labels are "
 "implied from the power objects they are connected to."
@@ -1365,19 +1365,19 @@ msgstr ""
 "tworzone domyślnie z nazw portów zasilania, do których są one połączone."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:476
+#: getting_started_in_kicad.adoc:488
 msgid "Below you can see what the final result should look like."
 msgstr "Poniżej możesz zobaczyć jak powinien wyglądać końcowy rezultat."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:478
+#: getting_started_in_kicad.adoc:490
 #, fuzzy
 #| msgid "image:images/gsik_tutorial1_020.png[gsik_tutorial1_020_png]"
 msgid "image:images/gsik_tutorial1_050.png[gsik_tutorial1_050_png]"
 msgstr "image:images/gsik_tutorial1_020.png[gsik_tutorial1_020_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:484
+#: getting_started_in_kicad.adoc:496
 msgid ""
 "Let's now deal with unconnected wires. Any pin or wire that is not connected "
 "will generate a warning when checked by KiCad. To avoid these warnings you "
@@ -1391,7 +1391,7 @@ msgstr ""
 "niepołączone."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:489
+#: getting_started_in_kicad.adoc:501
 #, fuzzy
 #| msgid ""
 #| "Click on the 'Place no connect flag' icon image:images/noconn."
@@ -1408,12 +1408,12 @@ msgstr ""
 "zamierzony."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:491
+#: getting_started_in_kicad.adoc:503
 msgid "image:images/gsik_tutorial1_060.png[gsik_tutorial1_060_png]"
 msgstr "image:images/gsik_tutorial1_060.png[gsik_tutorial1_060_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:498
+#: getting_started_in_kicad.adoc:510
 #, fuzzy
 #| msgid ""
 #| "Some components have power pins that are invisible. You can make them "
@@ -1436,7 +1436,7 @@ msgstr ""
 "ukrytych wyprowadzeń zasilania."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:504
+#: getting_started_in_kicad.adoc:516
 #, fuzzy
 #| msgid ""
 #| "It is now necessary to add a 'Power Flag' to indicate to KiCad that power "
@@ -1456,12 +1456,12 @@ msgstr ""
 "VCC, tak jak pokazano niżej."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:506
+#: getting_started_in_kicad.adoc:518
 msgid "image:images/gsik_tutorial1_070.png[gsik_tutorial1_070_png]"
 msgstr "image:images/gsik_tutorial1_070.png[gsik_tutorial1_070_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:509
+#: getting_started_in_kicad.adoc:521
 msgid ""
 "This will avoid the classic schematic checking warning: Warning Pin power_in "
 "not driven (Net xx)"
@@ -1470,7 +1470,7 @@ msgstr ""
 "*Ostrzeżenie* Wyprowadzenie power_in nie jest sterowany (Sieć xx)"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:513
+#: getting_started_in_kicad.adoc:525
 #, fuzzy
 #| msgid ""
 #| "Sometimes it is good to write comments here and there. To add comments on "
@@ -1487,7 +1487,7 @@ msgstr ""
 "narzędzi."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:518
+#: getting_started_in_kicad.adoc:531
 #, fuzzy
 #| msgid ""
 #| "All components now need to have unique identifiers. In fact, many of our "
@@ -1507,7 +1507,7 @@ msgstr ""
 "schematu]."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:525
+#: getting_started_in_kicad.adoc:538
 msgid ""
 "In the Annotate Schematic window, select 'Use the entire schematic' and "
 "click on the 'Annotation' button. Click OK in the confirmation message and "
@@ -1522,7 +1522,7 @@ msgstr ""
 "elementy zostały nazwane 'R1', 'R2', 'U1', 'D1' i 'J1'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:535
+#: getting_started_in_kicad.adoc:547
 #, fuzzy
 #| msgid ""
 #| "We will now check our schematic for errors. Click on the 'Perform "
@@ -1554,7 +1554,7 @@ msgstr ""
 "ponownie by otrzymać więcej informacji o błędach."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:537
+#: getting_started_in_kicad.adoc:551
 msgid ""
 "If you have a warning with \"No default editor found you must choose it\", "
 "try setting the path to `c:\\windows\\notepad.exe` (windows) or `/usr/bin/"
@@ -1562,7 +1562,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:542
+#: getting_started_in_kicad.adoc:556
 #, fuzzy
 #| msgid ""
 #| "The schematic is now finished. We can now create a Netlist file to which "
@@ -1583,7 +1583,7 @@ msgstr ""
 "kliknij na 'Zapisz'. Zapisz listę pod domyślną nazwą."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:547
+#: getting_started_in_kicad.adoc:561
 #, fuzzy
 #| msgid ""
 #| "You can now quit the schematic editor. From KiCad, click on the 'Run "
@@ -1601,7 +1601,7 @@ msgstr ""
 "OK."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:553
+#: getting_started_in_kicad.adoc:567
 #, fuzzy
 #| msgid ""
 #| "_Cvpcb_ allows you to link all the components in your schematic with "
@@ -1624,14 +1624,14 @@ msgstr ""
 "image:images/pl/cvpcb.png[Okno programu CvPcb]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:555
+#: getting_started_in_kicad.adoc:569
 #, fuzzy
 #| msgid "image:images/pcbnew_1.png[pcbnew_1_png]"
 msgid "image:images/icons/cvpcb.png[cvpcb_png]"
 msgstr "image:images/pl/pcbnew_1.png[pcbnew_1_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:563
+#: getting_started_in_kicad.adoc:577
 #, fuzzy
 #| msgid ""
 #| "It is possible that the pane on the right shows only a selected subgroup "
@@ -1654,7 +1654,7 @@ msgstr ""
 "wyłączyć ten filtr."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:567
+#: getting_started_in_kicad.adoc:581
 msgid ""
 "For 'IC1' select the 'Housings_DIP:DIP-8_W7.62mm' footprint.  For 'J1' "
 "select the 'Connect:Banana_Jack_3Pin' footprint.  For 'R1' and 'R2' select "
@@ -1662,7 +1662,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:578
+#: getting_started_in_kicad.adoc:592
 msgid ""
 "If you are interested in knowing what the footprint you are choosing looks "
 "like, you have two options. You can click on the 'View selected footprint' "
@@ -1683,7 +1683,7 @@ msgstr ""
 "wymiary modułów pasują do twoich elementów."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:587
+#: getting_started_in_kicad.adoc:601
 #, fuzzy
 #| msgid ""
 #| "You are done. You can now update your netlist file with all the "
@@ -1711,7 +1711,7 @@ msgstr ""
 "wyjaśnione później w jednym z dalszych rozdziałów."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:591
+#: getting_started_in_kicad.adoc:605
 #, fuzzy
 #| msgid ""
 #| "You can close _Cvpcb_ and go back to the _EESchema_ schematic editor. "
@@ -1727,12 +1727,12 @@ msgstr ""
 "Zamknij edytor schematów."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:593
+#: getting_started_in_kicad.adoc:607
 msgid "Switch to the KiCad project manager."
 msgstr "Przełącz się na menadżera projektu."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:597
+#: getting_started_in_kicad.adoc:611
 #, fuzzy
 #| msgid ""
 #| "The netlist file describes all components and their respective pin "
@@ -1748,7 +1748,7 @@ msgstr ""
 "który możesz łatwo podglądać, edytować lub drukować."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:600
+#: getting_started_in_kicad.adoc:614
 msgid ""
 "Library files (__*.lib__) are text files too and they are also easily "
 "editable or scriptable."
@@ -1757,7 +1757,7 @@ msgstr ""
 "łatwo edytować jak i wydrukować."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:607
+#: getting_started_in_kicad.adoc:621
 #, fuzzy
 #| msgid ""
 #| "To create a Bill Of Materials (BOM), go to the _EESchema_ schematic "
@@ -1775,7 +1775,7 @@ msgstr ""
 "bom.png[Ikona BOM] na górnym pasku narzędzi."
 
 #. type: delimited block =
-#: getting_started_in_kicad.adoc:612
+#: getting_started_in_kicad.adoc:626
 msgid ""
 "The *.xsl file is located in __plugins__ directory of the KiCad "
 "installation, which is located at: /usr/lib/kicad/plugins/."
@@ -1784,47 +1784,47 @@ msgstr ""
 "program KiCad. A w systemie GNU/Linux będzie to /usr/lib/kicad/plugins/."
 
 #. type: delimited block =
-#: getting_started_in_kicad.adoc:614
+#: getting_started_in_kicad.adoc:628
 msgid "Or get the file via:"
 msgstr "Lub pobierz plik za pomocą:"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:616
+#: getting_started_in_kicad.adoc:630
 #, no-wrap
 msgid "wget https://raw.githubusercontent.com/KiCad/kicad-source-mirror/master/eeschema/plugins/bom2csv.xsl\n"
 msgstr "wget https://raw.githubusercontent.com/KiCad/kicad-source-mirror/master/eeschema/plugins/bom2csv.xsl\n"
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:619
+#: getting_started_in_kicad.adoc:633
 #, no-wrap
 msgid "KiCad automatically generates the command, for example:"
 msgstr "KiCad automatycznie wygeneruje odpowiednią linię poleceń, przykładowo:"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:622
+#: getting_started_in_kicad.adoc:636
 #, no-wrap
 msgid "xsltproc -o \"%O\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 msgstr "xsltproc -o \"%O\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:624
+#: getting_started_in_kicad.adoc:638
 #, no-wrap
 msgid "You may want to add the extension, so change this command line to:"
 msgstr "Mógłbyś chcieć dodać rozszerzenie, zatem zmień tą linię poleceń w ten sposób:"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:627
+#: getting_started_in_kicad.adoc:641
 #, no-wrap
 msgid "xsltproc -o \"%O.csv\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 msgstr "xsltproc -o \"%O.csv\" \"/home/<user>/kicad/eeschema/plugins/bom2csv.xsl\" \"%I\"\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:630
+#: getting_started_in_kicad.adoc:644
 msgid "Press Help button for more info."
 msgstr "Naciśnij przycisk Pomoc by uzyskać pomoc."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:634
+#: getting_started_in_kicad.adoc:648
 #, fuzzy
 #| msgid ""
 #| "Now press 'Generate'. The file (same name as your project) is located in "
@@ -1838,7 +1838,7 @@ msgstr ""
 "umieszczoay w folderze projektu."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:638
+#: getting_started_in_kicad.adoc:652
 msgid ""
 "You are now ready to move to the PCB layout part, which is presented in the "
 "next section. However, before moving on let's take a quick look at how to "
@@ -1849,13 +1849,13 @@ msgstr ""
 "możliwości jakie dają magistrale w łączeniu wyprowadzeń."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:640
+#: getting_started_in_kicad.adoc:654
 #, no-wrap
 msgid "Bus connections in KiCad"
 msgstr "Magistrale w programie KiCad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:646
+#: getting_started_in_kicad.adoc:660
 msgid ""
 "Sometimes you might need to connect several sequential pins of component A "
 "with some other sequential pins of component B. In this case you have two "
@@ -1868,7 +1868,7 @@ msgstr ""
 "magistrali. Zobaczmy jak je zrobić."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:653
+#: getting_started_in_kicad.adoc:667
 #, fuzzy
 #| msgid ""
 #| "Let us suppose that you have three 4-pin connectors that you want to "
@@ -1891,7 +1891,7 @@ msgstr ""
 "przemianowana na 'a2'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:657
+#: getting_started_in_kicad.adoc:671
 #, fuzzy
 #| msgid ""
 #| "Press the Ins Key two more times. The Ins key corresponds to the action "
@@ -1907,7 +1907,7 @@ msgstr ""
 "polecenie, które może sprawić by twoje życie było łatwiejsze."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:668
+#: getting_started_in_kicad.adoc:682
 #, fuzzy
 #| msgid ""
 #| "Repeat the same labelling action on the two other connectors CONN_2 and "
@@ -1938,7 +1938,7 @@ msgstr ""
 "Rysunek 3. Pamiętaj jednak, że nie będzie to miało żadnego wpływu na PCB."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:672
+#: getting_started_in_kicad.adoc:686
 msgid ""
 "It should be pointed out that the short wire attached to the pins in Figure "
 "2 is not strictly necessary. In fact, the labels could have been applied "
@@ -1949,7 +1949,7 @@ msgstr ""
 "mogłyby zostać przypięte bezpośrednio do wyprowadzeń."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:679
+#: getting_started_in_kicad.adoc:693
 msgid ""
 "Let's take it one step further and suppose that you have a fourth connector "
 "named CONN_4 and, for whatever reason, its labelling happens to be a little "
@@ -1965,7 +1965,7 @@ msgstr ""
 "nich użyć etykiet na magistralach, po jednej na każdej z magistral."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:686
+#: getting_started_in_kicad.adoc:700
 msgid ""
 "Connect and label CONN_4 using the labelling method explained before. Name "
 "the pins b1, b2, b3 and b4. Connect the pin to a series of 'Wire to bus "
@@ -1981,7 +1981,7 @@ msgstr ""
 "magistralę]. Zobacz Rysunek 4."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:689
+#: getting_started_in_kicad.adoc:703
 msgid ""
 "Put a label (press the l key option) on the bus of CONN_4 and name it "
 "'b[1..4]'."
@@ -1990,7 +1990,7 @@ msgstr ""
 "nazwij ją 'b[1..4]'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:692
+#: getting_started_in_kicad.adoc:706
 msgid ""
 "Put a label (press the l key option) on the previous a bus and name it "
 "'a[1..4]'."
@@ -1999,7 +1999,7 @@ msgstr ""
 "'a[1..4]'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:695
+#: getting_started_in_kicad.adoc:709
 msgid ""
 "What we can now do is connect bus a[1..4] with bus b[1..4] using a bus line "
 "with the button image:images/icons/add_bus.png[add_bus_png]."
@@ -2009,7 +2009,7 @@ msgstr ""
 "add_bus.png[Ikona Dodaj magistralę]."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:699
+#: getting_started_in_kicad.adoc:713
 msgid ""
 "By connecting the two buses together, pin a1 will be automatically connected "
 "to pin b1, a2 will be connected to b2 and so on. Figure 4 shows what the "
@@ -2017,7 +2017,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:704
+#: getting_started_in_kicad.adoc:718
 #, fuzzy
 #| msgid ""
 #| "By connecting the two buses together, pin a1 will be automatically "
@@ -2044,7 +2044,7 @@ msgstr ""
 "łatwiejsza."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:708
+#: getting_started_in_kicad.adoc:722
 #, fuzzy
 #| msgid ""
 #| "The 'Repeat last action' option accessible via the Ins key has also been "
@@ -2061,18 +2061,18 @@ msgstr ""
 "magistrali]."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:710
+#: getting_started_in_kicad.adoc:724
 msgid "image:images/gsik_bus_connection.png[gsik_bus_connection_png]"
 msgstr "image:images/gsik_bus_connection.png[gsik_bus_connection_png]"
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:712
+#: getting_started_in_kicad.adoc:726
 #, no-wrap
 msgid "Layout printed circuit boards"
 msgstr "Trasowanie połączeń w obwodach drukowanych"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:716
+#: getting_started_in_kicad.adoc:730
 #, fuzzy
 #| msgid ""
 #| "It is now time to use the netlist file you generated to lay out the PCB.  "
@@ -2085,13 +2085,13 @@ msgstr ""
 "ścieżki na PCB. Tym zajmuje się narzędzie Pcbnew."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:718
+#: getting_started_in_kicad.adoc:732
 #, no-wrap
 msgid "Using Pcbnew"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:724
+#: getting_started_in_kicad.adoc:738
 #, fuzzy
 #| msgid ""
 #| "From the KiCad project manager, click on the 'PCBNew' icon image:images/"
@@ -2110,7 +2110,7 @@ msgstr ""
 "OK."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:728
+#: getting_started_in_kicad.adoc:742
 #, fuzzy
 #| msgid ""
 #| "Begin by entering some schematic information. Click on the 'Page "
@@ -2127,7 +2127,7 @@ msgstr ""
 "'Tute 1'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:737
+#: getting_started_in_kicad.adoc:751
 #, fuzzy
 #| msgid ""
 #| "It is a good idea to start by setting the *clearance* and the *minimum "
@@ -2156,12 +2156,12 @@ msgstr ""
 "milimetry."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:739
+#: getting_started_in_kicad.adoc:753
 msgid "image:images/design_rules.png[Design Rules Window]"
 msgstr "image:images/pl/design_rules.png[Okno Reguły projektowe]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:743
+#: getting_started_in_kicad.adoc:757
 msgid ""
 "Click on the 'Global Design Rules' tab and set 'Min track width' to 0.25'. "
 "Click the OK button to commit your changes and close the Design Rules Editor "
@@ -2172,7 +2172,7 @@ msgstr ""
 "reguł projektowych'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:749
+#: getting_started_in_kicad.adoc:763
 #, fuzzy
 #| msgid ""
 #| "Now we will import the netlist file. Click on the 'Read Netlist' icon "
@@ -2193,7 +2193,7 @@ msgstr ""
 "sieci'. Następnie kliknij przycisk Zamknij."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:752
+#: getting_started_in_kicad.adoc:766
 msgid ""
 "All components should now be visible in the top left hand corner just above "
 "the page. Scroll up if you cannot see them."
@@ -2202,7 +2202,7 @@ msgstr ""
 "ponad ramką z obrysem strony. Przesuń widok jeśli ich nie widzisz."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:756
+#: getting_started_in_kicad.adoc:770
 msgid ""
 "Select all components with the mouse and move them to the middle of the "
 "board. If necessary you can zoom in and out while you move the components."
@@ -2212,7 +2212,7 @@ msgstr ""
 "przesuwania komponentów."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:762
+#: getting_started_in_kicad.adoc:776
 #, fuzzy
 #| msgid ""
 #| "All components are connected via a thin group of wires called "
@@ -2234,14 +2234,14 @@ msgstr ""
 "przełącznikami; wciskając ten przycisk wyświetlasz nitki pomocnicze."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:765
+#: getting_started_in_kicad.adoc:779
 msgid ""
 "The tool-tip is backwards; pressing this button actually displays the "
 "ratsnest."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:769
+#: getting_started_in_kicad.adoc:783
 #, fuzzy
 #| msgid ""
 #| "You can also duplicate a component already on your schematic sheet by "
@@ -2257,7 +2257,7 @@ msgstr ""
 "chciałbyś umieścić nowy, zduplikowany komponent."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:774
+#: getting_started_in_kicad.adoc:788
 #, fuzzy
 #| msgid ""
 #| "You can move each component by hovering over it and pressing the g key. "
@@ -2281,12 +2281,12 @@ msgstr ""
 "pod klawiszem *G*."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:776
+#: getting_started_in_kicad.adoc:790
 msgid "image:images/gsik_tutorial1_080.png[gsik_tutorial1_080_png]"
 msgstr "image:images/gsik_tutorial1_080.png[gsik_tutorial1_080_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:783
+#: getting_started_in_kicad.adoc:797
 msgid ""
 "If the ratsnest disappears or the screen gets messy, right click and click "
 "'Redraw view'. Note how one pin of the 100 ohm resistor is connected to pin "
@@ -2301,7 +2301,7 @@ msgstr ""
 "ponieważ ich stosowanie powoduje lepszą czytelność schematu."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:791
+#: getting_started_in_kicad.adoc:805
 #, fuzzy
 #| msgid ""
 #| "Now we will define the edge of the PCB. Select 'PCB Edges' from the drop "
@@ -2327,7 +2327,7 @@ msgstr ""
 "rysunku a rysowanym właśnie obrysem PCB."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:795
+#: getting_started_in_kicad.adoc:809
 #, fuzzy
 #| msgid ""
 #| "Next, connect up all the wires except GND. In fact, we will connect all "
@@ -2343,7 +2343,7 @@ msgstr ""
 "pola miedzi umieszczonego na dolnej warstwie miedzi naszej płytki."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:799
+#: getting_started_in_kicad.adoc:813
 #, fuzzy
 #| msgid ""
 #| "Now we must choose which copper layer we want to work on. Select 'F.Cu "
@@ -2359,12 +2359,12 @@ msgstr ""
 "płytki, tzn. ta na której normalnie są elementy."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:801
+#: getting_started_in_kicad.adoc:815
 msgid "image:images/select_top_copper.png[Select the Front top copper layer]"
 msgstr "image:images/pl/layers.png[Wybór aktywnej warstwy]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:807
+#: getting_started_in_kicad.adoc:821
 #, fuzzy
 #| msgid ""
 #| "If you decide, for instance, to do a 4 layer PCB instead, go to *Design "
@@ -2386,7 +2386,7 @@ msgstr ""
 "warstw, wybieranych z menu 'Domyślne ustawienia warstw'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:815
+#: getting_started_in_kicad.adoc:829
 #, fuzzy
 #| msgid ""
 #| "Click on the 'Add Tracks and vias' icon image:images/add_tracks."
@@ -2411,12 +2411,12 @@ msgstr ""
 "Pamiętaj jednak, że aktualnie masz tylko jedną dostępną szerokość ścieżki:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:817
+#: getting_started_in_kicad.adoc:831
 msgid "image:images/pcbnew_1.png[pcbnew_1_png]"
 msgstr "image:images/pl/pcbnew_1.png[pcbnew_1_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:823
+#: getting_started_in_kicad.adoc:837
 msgid ""
 "If you would like to add more track widths go to: *Design Rules* -> *Design "
 "Rules* -> *Global Design Rules* tab and at the bottom right of this window "
@@ -2432,12 +2432,12 @@ msgstr ""
 "poniżej (jednostki w calach)."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:825
+#: getting_started_in_kicad.adoc:839
 msgid "image:images/custom_tracks_width.png[custom_tracks_width_png]"
 msgstr "image:images/pl/custom_tracks_width.png[Własne szerokości ścieżek]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:832
+#: getting_started_in_kicad.adoc:846
 #, fuzzy
 #| msgid ""
 #| "Alternatively, you can add a Net Class in which you specify a set of "
@@ -2463,7 +2463,7 @@ msgstr ""
 "użyj strzałek)."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:836
+#: getting_started_in_kicad.adoc:850
 msgid ""
 "If you want to change the grid size, *Right click* -> **Grid Select**. Be "
 "sure to select the appropriate grid size before or after laying down the "
@@ -2474,7 +2474,7 @@ msgstr ""
 "łączeniem ich z ich pomocą."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:839
+#: getting_started_in_kicad.adoc:853
 #, fuzzy
 #| msgid ""
 #| "Repeat this process until all wires, except pin 3 of J1, are connected. "
@@ -2488,12 +2488,12 @@ msgstr ""
 "wyglądać mniej więcej tak jak na poniższym przykładzie."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:841
+#: getting_started_in_kicad.adoc:855
 msgid "image:images/gsik_tutorial1_090.png[gsik_tutorial1_090_png]"
 msgstr "image:images/gsik_tutorial1_090.png[gsik_tutorial1_090_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:849
+#: getting_started_in_kicad.adoc:863
 #, fuzzy
 #| msgid ""
 #| "Let's now run a track on the other copper side of the PCB. Select 'Back' "
@@ -2518,7 +2518,7 @@ msgstr ""
 "wykonamy za pomocą pola miedzi, ale zrobimy ją dla przykładu."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:856
+#: getting_started_in_kicad.adoc:870
 #, fuzzy, no-wrap
 #| msgid ""
 #| "**Go from pin A to pin B by changing layer**. It is possible to\n"
@@ -2542,13 +2542,13 @@ msgstr ""
 "warstwę dolną gdzie ścieżka zostanie dokończona.\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:858
+#: getting_started_in_kicad.adoc:872
 #, no-wrap
 msgid "image:images/place_a_via.png[place_a_via_png]\n"
 msgstr "image:images/pl/route_menu.png[Menu kontekstowe]\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:864
+#: getting_started_in_kicad.adoc:878
 msgid ""
 "When you want to inspect a particular connection you can click on the 'Net "
 "highlight' icon image:images/icons/net_highlight.png[net_highlight_png] on "
@@ -2562,7 +2562,7 @@ msgstr ""
 "podświetlone."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:872
+#: getting_started_in_kicad.adoc:886
 msgid ""
 "Now we will make a ground plane that will be connected to all GND pins. "
 "Click on the 'Add Zones' icon image:images/icons/add_zone.png[add_zone_png] "
@@ -2579,7 +2579,7 @@ msgstr ""
 "'Opcje wypełniania' na 'Tylko poziomo, pionowo i 45 stopni', i kliknij OK."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:877
+#: getting_started_in_kicad.adoc:891
 #, fuzzy
 #| msgid ""
 #| "Trace around the outline of the board by clicking each corner in "
@@ -2599,12 +2599,12 @@ msgstr ""
 "i powinna wyglądać mniej więcej tak:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:879
+#: getting_started_in_kicad.adoc:893
 msgid "image:images/gsik_tutorial1_100.png[gsik_tutorial1_100_png]"
 msgstr "image:images/gsik_tutorial1_100.png[gsik_tutorial1_100_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:885
+#: getting_started_in_kicad.adoc:899
 #, fuzzy
 #| msgid ""
 #| "Run the design rules checker by clicking on the 'Perform Design Rules "
@@ -2625,7 +2625,7 @@ msgstr ""
 "niepołączonych ścieżek. Kliknij OK by zamknąć okno dialogowe  DRC."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:888
+#: getting_started_in_kicad.adoc:902
 #, fuzzy
 #| msgid ""
 #| "Save your file by clicking on *File* -> **Save**. To admire your board in "
@@ -2638,19 +2638,19 @@ msgstr ""
 "płytkę w 3D, kliknij na *Widok* -> **Widok 3D**."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:890
+#: getting_started_in_kicad.adoc:904
 #, fuzzy
 #| msgid "image:images/pcbnew_1.png[pcbnew_1_png]"
 msgid "image:images/pcbnew_3d_viewer.png[pcbnew_3d_viewer_png]"
 msgstr "image:images/pl/pcbnew_1.png[pcbnew_1_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:892
+#: getting_started_in_kicad.adoc:906
 msgid "You can drag your mouse around to rotate the PCB."
 msgstr "Możesz przeciągnąć myszą wokół by obracać płytką."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:895
+#: getting_started_in_kicad.adoc:909
 msgid ""
 "Your board is complete. To send it off to a manufacturer you will need to "
 "generate all Gerber files."
@@ -2659,13 +2659,13 @@ msgstr ""
 "wygenerować pliki Gerber."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:897
+#: getting_started_in_kicad.adoc:911
 #, no-wrap
 msgid "Generate Gerber files"
 msgstr "Generowanie plików Gerber"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:902
+#: getting_started_in_kicad.adoc:916
 msgid ""
 "Once your PCB is complete, you can generate Gerber files for each layer and "
 "send them to your favourite PCB manufacturer, who will make the board for "
@@ -2676,7 +2676,7 @@ msgstr ""
 "podstawie stworzy dla ciebie fizyczną płytkę drukowaną."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:906
+#: getting_started_in_kicad.adoc:920
 #, fuzzy
 #| msgid ""
 #| "From KiCad, open the _PCBNew_ software tool and load your board file by "
@@ -2690,7 +2690,7 @@ msgstr ""
 "ikonę image:images/icons/open_document.png[Ikona Wczytaj płytkę]."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:910
+#: getting_started_in_kicad.adoc:924
 #, fuzzy
 #| msgid ""
 #| "Click on *File* -> **Plot**. Select 'Gerber' as the 'Plot Format' and "
@@ -2704,14 +2704,14 @@ msgstr ""
 "oraz wybierz folder, do którego trafią wszystkie pliki Gerber."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:913
+#: getting_started_in_kicad.adoc:927
 msgid ""
 "These are the layers you need to select for making a typical 2-layer PCB:"
 msgstr ""
 "To są warstwy jakie potrzebujesz do wykonania typowej płytki dwustronnej:"
 
 #. type: delimited block |
-#: getting_started_in_kicad.adoc:924
+#: getting_started_in_kicad.adoc:938
 #, no-wrap
 msgid ""
 "|Layer |KiCad Layer Name |Old KiCad Layer Name |Default Gerber Extension\n"
@@ -2725,13 +2725,13 @@ msgid ""
 msgstr ""
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:927
+#: getting_started_in_kicad.adoc:941
 #, no-wrap
 msgid "Using GerbView"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:936
+#: getting_started_in_kicad.adoc:950
 #, fuzzy
 #| msgid ""
 #| "Proceed by clicking on the 'Plot' button. To view all your Gerber files "
@@ -2755,7 +2755,7 @@ msgstr ""
 "wyświetlane jedna na drugiej."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:939
+#: getting_started_in_kicad.adoc:953
 msgid ""
 "Use the menu on the right to select/deselect which layer to show.  Carefully "
 "inspect each layer before sending them for production."
@@ -2765,7 +2765,7 @@ msgstr ""
 "wysłaniem plików do produkcji."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:942
+#: getting_started_in_kicad.adoc:956
 #, fuzzy
 #| msgid ""
 #| "To generate the drill file, from _PCBNew_ go again for the *File* -> "
@@ -2778,13 +2778,13 @@ msgstr ""
 "**Rysuj**. Domyślne ustawienia powinny być dobre."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:944
+#: getting_started_in_kicad.adoc:958
 #, no-wrap
 msgid "Automatically route with FreeRouter"
 msgstr "Automatyczne prowadzenie ścieżek z wykorzystaniem FreeRouter-a"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:952
+#: getting_started_in_kicad.adoc:966
 msgid ""
 "Routing a board by hand is quick and fun, however, for a board with lots of "
 "components you might want to use an autorouter. Remember that you should "
@@ -2801,7 +2801,7 @@ msgstr ""
 "net__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:957
+#: getting_started_in_kicad.adoc:971
 msgid ""
 "Freerouter is a open source java application, and it is needed to build by "
 "yourself to use with KiCad.  Source code of Freerouter can be found on this "
@@ -2809,7 +2809,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:963
+#: getting_started_in_kicad.adoc:977
 #, fuzzy
 #| msgid ""
 #| "From _PCBNew_ click on *File* -> *Export* -> *Specctra DNS* and save the "
@@ -2832,7 +2832,7 @@ msgstr ""
 "Kliknij w 'Open Your Own Design', wybierz plik _.dsn_ oraz załaduj go."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:968
+#: getting_started_in_kicad.adoc:982
 msgid ""
 "The *Tools* -> *FreeRoute* dialog has a nice help button that opens a file "
 "viewer with a little document inside named **Freerouter Guidelines**. Please "
@@ -2840,7 +2840,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:974
+#: getting_started_in_kicad.adoc:988
 msgid ""
 "FreeRouter has some features that KiCad does not currently have, both for "
 "manual routing and for automatic routing. FreeRouter operates in two main "
@@ -2854,7 +2854,7 @@ msgstr ""
 "jednak możesz ją zatrzymać w każdej chwili."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:982
+#: getting_started_in_kicad.adoc:996
 msgid ""
 "You can start the automatic routing by clicking on the 'Autorouter' button "
 "on the top bar. The bottom bar gives you information about the on-going "
@@ -2872,7 +2872,7 @@ msgstr ""
 "krzyżujących się połączeń."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:987
+#: getting_started_in_kicad.adoc:1001
 msgid ""
 "Making a left-click on the mouse can stop the automatic routing and "
 "automatically start the optimisation process. Another left-click will stop "
@@ -2886,7 +2886,7 @@ msgstr ""
 "swoją pracę."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:991
+#: getting_started_in_kicad.adoc:1005
 #, fuzzy
 #| msgid ""
 #| "Click on the *File* -> *Export Specctra Session File* menu and save the "
@@ -2902,7 +2902,7 @@ msgstr ""
 "FreeRouter."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:996
+#: getting_started_in_kicad.adoc:1010
 #, fuzzy
 #| msgid ""
 #| "Back to __PCBnew__. You can import your freshly routed board by clicking "
@@ -2918,7 +2918,7 @@ msgstr ""
 "Session (*.ses)' by wybrać twój plik __.ses__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1001
+#: getting_started_in_kicad.adoc:1015
 msgid ""
 "If there is any routed trace that you do not like, you can delete it and re-"
 "route it again, using the del key and the routing tool, which is the 'Add "
@@ -2932,13 +2932,13 @@ msgstr ""
 "pasku narzędzi."
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1003
+#: getting_started_in_kicad.adoc:1017
 #, no-wrap
 msgid "Forward annotation in KiCad"
 msgstr "Renumeracja elementów w programie KiCad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1009
+#: getting_started_in_kicad.adoc:1023
 msgid ""
 "Once you have completed your electronic schematic, the footprint assignment, "
 "the board layout and generated the Gerber files, you are ready to send "
@@ -2949,7 +2949,7 @@ msgstr ""
 "wszystko do producenta PCB tak, aby płytka mogła stać się rzeczywistością."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1017
+#: getting_started_in_kicad.adoc:1031
 msgid ""
 "Often, this linear work-flow turns out to be not so uni-directional. For "
 "instance, when you have to modify/extend a board for which you or others "
@@ -2967,19 +2967,19 @@ msgstr ""
 "Zamiast tego, powinieneś zrobić to w ten sposób:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1020
+#: getting_started_in_kicad.adoc:1034
 msgid ""
 "Let's suppose that you want to replace a hypothetical connector CON1 with "
 "CON2."
 msgstr "Przypuśćmy, że hipotetycznie chcesz zamienić złącze CON1 przez CON2."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1022
+#: getting_started_in_kicad.adoc:1036
 msgid "You already have a completed schematic and a fully routed PCB."
 msgstr "Masz już w pełni stworzony schemat jak i płytkę."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1028
+#: getting_started_in_kicad.adoc:1042
 #, fuzzy
 #| msgid ""
 #| "From KiCad, start __EESchema__, make your modifications by deleting CON1 "
@@ -2999,7 +2999,7 @@ msgstr ""
 "pasku narzędzi."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1031
+#: getting_started_in_kicad.adoc:1045
 msgid ""
 "Click on 'Netlist' then on 'save'. Save to the default file name.  You have "
 "to rewrite the old one."
@@ -3008,7 +3008,7 @@ msgstr ""
 "nadpisując starą listę sieci."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1037
+#: getting_started_in_kicad.adoc:1051
 #, fuzzy
 #| msgid ""
 #| "Now assign a footprint to CON2. Click on the 'Run Cvpcb' icon image:"
@@ -3027,7 +3027,7 @@ msgstr ""
 "poprzednio im przypisane footprinty. Zamknij CvPcb."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1040
+#: getting_started_in_kicad.adoc:1054
 msgid ""
 "Back in the schematic editor, save the project by clicking on 'File' -> "
 "'Save Whole Schematic Project'. Close the schematic editor."
@@ -3036,7 +3036,7 @@ msgstr ""
 "cały projekt schematu**. Zamknij edytor schematów."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1043
+#: getting_started_in_kicad.adoc:1057
 #, fuzzy
 #| msgid ""
 #| "From the KiCad project manager, click on the 'PCBNew' icon. The 'PCBNew' "
@@ -3047,7 +3047,7 @@ msgid ""
 msgstr "Z menedżera projektu, kliknij w ikonę Pcbnew. Otworzy się okno Pcbnew."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1047
+#: getting_started_in_kicad.adoc:1061
 #, fuzzy
 #| msgid ""
 #| "The old, already routed, board should automatically open. Let's import "
@@ -3063,7 +3063,7 @@ msgstr ""
 "netlist.png[Ikona Lista sieci] na górnym pasku narzędzi."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1051
+#: getting_started_in_kicad.adoc:1065
 msgid ""
 "Click on the 'Browse Netlist Files' button, select the netlist file in the "
 "file selection dialogue, and click on 'Read Current Netlist'.  Then click "
@@ -3074,7 +3074,7 @@ msgstr ""
 "Następnie kliknij klawisz 'Zamknij'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1056
+#: getting_started_in_kicad.adoc:1070
 msgid ""
 "At this point you should be able to see a layout with all previous "
 "components already routed. On the top left corner you should see all "
@@ -3088,7 +3088,7 @@ msgstr ""
 "środek płytki."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1059
+#: getting_started_in_kicad.adoc:1073
 msgid ""
 "Place CON2 and route it. Once done, save and proceed with the Gerber file "
 "generation as usual."
@@ -3097,7 +3097,7 @@ msgstr ""
 "zapisz projekt i wygeneruj pliki Gerber tak jak zwykle."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1067
+#: getting_started_in_kicad.adoc:1081
 #, fuzzy
 #| msgid ""
 #| "The process described here can easily be repeated as many times as you "
@@ -3123,13 +3123,13 @@ msgstr ""
 "opisana."
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1069
+#: getting_started_in_kicad.adoc:1083
 #, no-wrap
 msgid "Make schematic components in KiCad"
 msgstr "Tworzenie symboli w programie KiCad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1076
+#: getting_started_in_kicad.adoc:1090
 msgid ""
 "Sometimes a component that you want to place on your schematic is not in the "
 "KiCad libraries. This is quite normal and there is no reason to worry. In "
@@ -3145,12 +3145,12 @@ msgstr ""
 "Intenet. Na przykład korzystając z tej witryny:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1078
+#: getting_started_in_kicad.adoc:1092
 msgid "http://per.launay.free.fr/kicad/kicad_php/composant.php"
 msgstr "http://per.launay.free.fr/kicad/kicad_php/composant.php"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1083
+#: getting_started_in_kicad.adoc:1097
 msgid ""
 "In KiCad, a component is a piece of text that starts with a 'DEF' and ends "
 "with 'ENDDEF'. One or more components are normally placed in a library file "
@@ -3164,13 +3164,13 @@ msgstr ""
 "wklej."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1085
+#: getting_started_in_kicad.adoc:1099
 #, no-wrap
 msgid "Using Component Library Editor"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1091
+#: getting_started_in_kicad.adoc:1105
 #, fuzzy
 #| msgid ""
 #| "We can use the _Component Library Editor_ (part of __EESchema__) to make "
@@ -3189,7 +3189,7 @@ msgstr ""
 "lib_ jak stworzymy nasz nowy komponent."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1106
+#: getting_started_in_kicad.adoc:1120
 #, fuzzy
 #| msgid ""
 #| "Now we can start creating our new component. From KiCad, start "
@@ -3221,7 +3221,7 @@ msgstr ""
 "kliknij na 'Tak'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1110
+#: getting_started_in_kicad.adoc:1124
 #, fuzzy
 #| msgid ""
 #| "In the Pin Properties window that appears, set the pin name to 'VCC', set "
@@ -3236,12 +3236,12 @@ msgstr ""
 "następnie kliknij OK. "
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1112
+#: getting_started_in_kicad.adoc:1126
 msgid "image:images/pin_properties.png[Pin Properties]"
 msgstr "image:images/pl/pin_prop.png[Właściwości pinu]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1115
+#: getting_started_in_kicad.adoc:1129
 msgid ""
 "Place the pin by clicking on the location you would like it to go, right "
 "below the 'MYCONN3' label."
@@ -3250,7 +3250,7 @@ msgstr ""
 "na prawo pod etykietą 'MYCONN3'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1119
+#: getting_started_in_kicad.adoc:1133
 #, fuzzy
 #| msgid ""
 #| "Repeat the place-pin steps, this time 'Pin name' should be 'INPUT', 'Pin "
@@ -3263,7 +3263,7 @@ msgstr ""
 "pinu_ nazwę 'INPUT', _Numer pinu_ na '2', a _Typ elektryczny_ na 'Wejście'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1125
+#: getting_started_in_kicad.adoc:1139
 #, fuzzy
 #| msgid ""
 #| "Repeat the place-pin steps, this time 'Pin name' should be 'GND', 'Pin "
@@ -3283,7 +3283,7 @@ msgstr ""
 "linie)."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1133
+#: getting_started_in_kicad.adoc:1147
 #, fuzzy
 #| msgid ""
 #| "Next, draw the contour of the component. Click on the 'Add rectangle' "
@@ -3307,12 +3307,12 @@ msgstr ""
 "dolny narożnik."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1135
+#: getting_started_in_kicad.adoc:1149
 msgid "image:images/gsik_myconn3_l.png[gsik_myconn3_l_png]"
 msgstr "image:images/gsik_myconn3_l.png[gsik_myconn3_l_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1140
+#: getting_started_in_kicad.adoc:1154
 #, fuzzy
 #| msgid ""
 #| "Save the component in your library __myLib.lib__. Click on the 'New "
@@ -3331,7 +3331,7 @@ msgstr ""
 "zapisz nowy plik biblioteki pod nazwą __myLib.lib__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1143
+#: getting_started_in_kicad.adoc:1157
 #, fuzzy
 #| msgid ""
 #| "Go to *Preferences* -> *Library* and add both _demo1/library/_ in 'User "
@@ -3345,7 +3345,7 @@ msgstr ""
 "symboli_."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1149
+#: getting_started_in_kicad.adoc:1163
 #, fuzzy
 #| msgid ""
 #| "Click on the 'Select working library' icon image:images/library."
@@ -3364,7 +3364,7 @@ msgstr ""
 "aktualnie w użyciu, powinien on teraz zawierać __myLib__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1158
+#: getting_started_in_kicad.adoc:1172
 #, fuzzy
 #| msgid ""
 #| "Click on the 'Update current component in current library' icon image:"
@@ -3392,7 +3392,7 @@ msgstr ""
 "wskazuje pasek tytułowy."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1162
+#: getting_started_in_kicad.adoc:1176
 msgid ""
 "You can now close the Component library editor window. You will return to "
 "the schematic editor window. Your new component will now be available to you "
@@ -3403,7 +3403,7 @@ msgstr ""
 "__myLib__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1167
+#: getting_started_in_kicad.adoc:1181
 #, fuzzy
 #| msgid ""
 #| "You can make any library _file.lib_ file available to you by adding it to "
@@ -3422,13 +3422,13 @@ msgstr ""
 "przeglądanych ścieżek_, jak i sam plik _file.lib_ w _Plik bibliotek symboli_."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1169
+#: getting_started_in_kicad.adoc:1183
 #, no-wrap
 msgid "Export, import and modify library components"
 msgstr "Eksportowanie, importowanie oraz modyfikacje składników bibliotek"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1175
+#: getting_started_in_kicad.adoc:1189
 msgid ""
 "Instead of creating a library component from scratch it is sometimes easier "
 "to start from one already made and modify it. In this section we will see "
@@ -3441,7 +3441,7 @@ msgstr ""
 "biblioteki _myOwnLib.lib_ a następnie go zmodyfikujemy."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1183
+#: getting_started_in_kicad.adoc:1197
 #, fuzzy
 #| msgid ""
 #| "From KiCad, start __EESchema__, click on the 'Library Editor' icon image:"
@@ -3466,7 +3466,7 @@ msgstr ""
 "Wczytaj symbol] i zaimportuj symbol 'RELAY_2RT'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1187
+#: getting_started_in_kicad.adoc:1201
 msgid ""
 "Click on the 'Export component' icon image:images/icons/export."
 "png[export_png], navigate into the _library/_ folder and save the new "
@@ -3477,7 +3477,7 @@ msgstr ""
 "nazwą _myOwnLib.lib_."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1193
+#: getting_started_in_kicad.adoc:1207
 #, fuzzy
 #| msgid ""
 #| "You can make this component and the whole library _myOwnLib.lib_ "
@@ -3496,7 +3496,7 @@ msgstr ""
 "lib_ w _Plik bibliotek symboli_."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1199
+#: getting_started_in_kicad.adoc:1213
 #, fuzzy
 #| msgid ""
 #| "Click on the 'Select working library' icon image:images/library."
@@ -3515,7 +3515,7 @@ msgstr ""
 "na aktywną bibliotekę _myOwnLib_."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1203
+#: getting_started_in_kicad.adoc:1217
 #, fuzzy
 #| msgid ""
 #| "Click on the 'Load component to edit from the current lib' icon image:"
@@ -3531,7 +3531,7 @@ msgstr ""
 "'RELAY_2RT'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1206
+#: getting_started_in_kicad.adoc:1220
 msgid ""
 "You can now modify the component as you like. Hover over the label "
 "'RELAY_2RT', press the e key and rename it 'MY_RELAY_2RT'."
@@ -3540,7 +3540,7 @@ msgstr ""
 "'RELAY_2RT', wciśnij klawisz *E* i zmień nazwę na 'MY_RELAY_2RT'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1213
+#: getting_started_in_kicad.adoc:1227
 #, fuzzy
 #| msgid ""
 #| "Click on 'Update current component in current library' icon image:images/"
@@ -3560,13 +3560,13 @@ msgstr ""
 "narzędzi."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1215
+#: getting_started_in_kicad.adoc:1229
 #, no-wrap
 msgid "Make schematic components with quicklib"
 msgstr "Tworzenie symboli za pomocą quicklib"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1220
+#: getting_started_in_kicad.adoc:1234
 #, fuzzy
 #| msgid ""
 #| "This section presents an alternative way of creating the schematic "
@@ -3581,7 +3581,7 @@ msgstr ""
 "używając do tego celu narzędzia on-line __quicklib__."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1223
+#: getting_started_in_kicad.adoc:1237
 #, fuzzy
 #| msgid ""
 #| "Head to the _quicklib_ we bpage: http://kicad.rohrbacher.net/quicklib.php"
@@ -3590,7 +3590,7 @@ msgid ""
 msgstr "Przejdź na stronę _quicklib_: http://kicad.rohrbacher.net/quicklib.php"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1226
+#: getting_started_in_kicad.adoc:1240
 #, fuzzy
 #| msgid ""
 #| "Fill out the page with the following information: Component name: MYCONN3 "
@@ -3603,7 +3603,7 @@ msgstr ""
 "MYCONN3 Reference Prefix: J Pin Layout Style: SIL Pin Count, N: 5"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1230
+#: getting_started_in_kicad.adoc:1244
 #, fuzzy
 #| msgid ""
 #| "Click on the 'Assign Pins' icon. Fill out the page with the following "
@@ -3617,7 +3617,7 @@ msgstr ""
 "1: VCC Pin 2: input Pin 3: GND"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1234
+#: getting_started_in_kicad.adoc:1248
 #, fuzzy
 #| msgid ""
 #| "Click on the icon 'Preview it' and, if you are satisfied, click on the "
@@ -3633,7 +3633,7 @@ msgstr ""
 "library/myLib.lib__. To wszystko!"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1240
+#: getting_started_in_kicad.adoc:1254
 #, fuzzy
 #| msgid ""
 #| "Have a look at it using KiCad. From the KiCad project manager, start "
@@ -3655,12 +3655,12 @@ msgstr ""
 "lib_."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1242
+#: getting_started_in_kicad.adoc:1256
 msgid "image:images/gsik_myconn3_quicklib.png[gsik_myconn3_quicklib_png]"
 msgstr "image:images/gsik_myconn3_quicklib.png[gsik_myconn3_quicklib_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1248
+#: getting_started_in_kicad.adoc:1262
 #, fuzzy
 #| msgid ""
 #| "You can make this component and the whole library _myOwnLib.lib_ "
@@ -3679,7 +3679,7 @@ msgstr ""
 "lib_ w _Plik bibliotek symboli_."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1252
+#: getting_started_in_kicad.adoc:1266
 msgid ""
 "As you might guess, this method of creating library components can be quite "
 "effective when you want to create components with a large pin count."
@@ -3689,13 +3689,13 @@ msgstr ""
 "wyprowadzeń. Ale jest też inny sposób."
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1254
+#: getting_started_in_kicad.adoc:1268
 #, no-wrap
 msgid "Make a high pin count schematic component"
 msgstr "Tworzenie symboli z dużą ilością wyprowadzeń"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1261
+#: getting_started_in_kicad.adoc:1275
 msgid ""
 "In the section titled _Make Schematic Components in quicklib_ we saw how to "
 "make a schematic component using the _quicklib_ web-based tool.  However, "
@@ -3710,7 +3710,7 @@ msgstr ""
 "wyprowadzeń). W programie KiCad nie jest to aż tak skomplikowane zadanie."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1267
+#: getting_started_in_kicad.adoc:1281
 msgid ""
 "Suppose that you want to create a schematic component for a device with 50 "
 "pins. It is common practise to draw it using multiple low pin-count "
@@ -3723,7 +3723,7 @@ msgstr ""
 "Taka reprezentacja symbolu pozwala na łatwiejsze łączenie wyprowadzeń."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1272
+#: getting_started_in_kicad.adoc:1286
 msgid ""
 "The best way to create our component is to use _quicklib_ to generate two 25-"
 "pin components separately, re-number their pins using a Python script and "
@@ -3736,7 +3736,7 @@ msgstr ""
 "kopiuj-wklej w jeden komponent zawarty pomiędzy 'DEF' a 'ENDDEF'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1278
+#: getting_started_in_kicad.adoc:1292
 msgid ""
 "You will find an example of a simple Python script below that can be used in "
 "conjunction with an _in.txt_ file and an _out.txt_ file to re-number the "
@@ -3749,13 +3749,13 @@ msgstr ""
 "600 300 R 50 50 1 1 I+, dla wszystkich linii w pliku __in.txt__."
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:1279
+#: getting_started_in_kicad.adoc:1293
 #, no-wrap
 msgid "Simple script"
 msgstr "Prosty skrypt"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1302
+#: getting_started_in_kicad.adoc:1316
 #, no-wrap
 msgid ""
 "#!/usr/bin/env python\n"
@@ -3801,7 +3801,7 @@ msgstr ""
 "# http://kicad.rohrbacher.net/quicklib.php\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1308
+#: getting_started_in_kicad.adoc:1322
 #, fuzzy
 #| msgid ""
 #| "While merging the two components into one, it is necessary to use the "
@@ -3820,13 +3820,13 @@ msgstr ""
 "jego reprezentację w Eeschema."
 
 #. type: Block title
-#: getting_started_in_kicad.adoc:1309
+#: getting_started_in_kicad.adoc:1323
 #, no-wrap
 msgid "Contents of a *.lib file"
 msgstr "Zawartość pliku *.lib"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1321
+#: getting_started_in_kicad.adoc:1335
 #, no-wrap
 msgid ""
 "EESchema-LIBRARY Version 2.3\n"
@@ -3852,13 +3852,13 @@ msgstr ""
 "X PIN1 1 -2550 600 300 R 50 50 1 1 I\n"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1323
+#: getting_started_in_kicad.adoc:1337
 #, no-wrap
 msgid "...\n"
 msgstr "...\n"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1328
+#: getting_started_in_kicad.adoc:1342
 #, no-wrap
 msgid ""
 "X PIN49 49 750 -500 300 L 50 50 1 1 I\n"
@@ -3872,12 +3872,12 @@ msgstr ""
 "#End Library\n"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1331
+#: getting_started_in_kicad.adoc:1345
 msgid "image:images/gsik_high_number_pins.png[gsik_high_number_pins_png]"
 msgstr "image:images/gsik_high_number_pins.png[gsik_high_number_pins_png]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1336
+#: getting_started_in_kicad.adoc:1350
 msgid ""
 "The Python script presented here is a very powerful tool for manipulating "
 "both pin numbers and pin labels. Mind, however, that all its power comes for "
@@ -3890,13 +3890,13 @@ msgstr ""
 "Regularnych: _http://gskinner.com/RegExr/_"
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1338
+#: getting_started_in_kicad.adoc:1352
 #, no-wrap
 msgid "Make component footprints"
 msgstr "Tworzenie footprint-ów"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1344
+#: getting_started_in_kicad.adoc:1358
 #, fuzzy
 #| msgid ""
 #| "Unlike other EDA software tools, which have one type of library that "
@@ -3916,7 +3916,7 @@ msgstr ""
 "modułów z powodzeniem stosowany jest program CvPcb."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1347
+#: getting_started_in_kicad.adoc:1361
 #, fuzzy
 #| msgid ""
 #| "As for _.lib_ files, _.mod_ library files are text files that can contain "
@@ -3929,7 +3929,7 @@ msgstr ""
 "wszystkie od jednej do kilku części."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1351
+#: getting_started_in_kicad.adoc:1365
 msgid ""
 "There is an extensive footprint library with KiCad, however on occasion you "
 "might find that the footprint you need is not in the KiCad library.  Here "
@@ -3941,13 +3941,13 @@ msgstr ""
 "w programie KiCad:"
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1353
+#: getting_started_in_kicad.adoc:1367
 #, no-wrap
 msgid "Using Footprint Editor"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1359
+#: getting_started_in_kicad.adoc:1373
 #, fuzzy
 #| msgid ""
 #| "From the KiCad project manager start the _PCBnew_ tool. Click on the "
@@ -3964,7 +3964,7 @@ msgstr ""
 "pasku narzędzi. Spowoduje to otwarcie 'Edytora Modułów'."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1371
+#: getting_started_in_kicad.adoc:1385
 msgid ""
 "We are going to save the new footprint 'MYCONN3' in the new footprint "
 "library 'myfootprint'.  Create a new folder _myfootprint.pretty_ in the "
@@ -3978,7 +3978,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1380
+#: getting_started_in_kicad.adoc:1394
 #, fuzzy
 #| msgid ""
 #| "Click on the 'New Module' icon image:images/new_footprint."
@@ -4004,7 +4004,7 @@ msgstr ""
 "_Pokazuj_ na _Niewidoczny_."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1385
+#: getting_started_in_kicad.adoc:1399
 #, fuzzy
 #| msgid ""
 #| "Select the 'Add Pads' icon image:images/icons/pad.png[pad_png] on the "
@@ -4022,12 +4022,12 @@ msgstr ""
 "pole'. Możesz też użyć klawisza *E*."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1387
+#: getting_started_in_kicad.adoc:1401
 msgid "image:images/pad_properties.png[Pad Properties]"
 msgstr "image:images/pl/pad_prop.png[Właściwości pola lutowniczego]"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1391
+#: getting_started_in_kicad.adoc:1405
 msgid ""
 "Set the 'Pad Num' to '1', 'Pad Shape' to 'Rect', 'Pad Type' to 'SMD', 'Shape "
 "Size X' to '0.4', and 'Shape Size Y' to '0.8'. Click OK.  Click on 'Add "
@@ -4038,7 +4038,7 @@ msgstr ""
 "na 'Dodaj pola lutownicze' ponownie i wstaw jeszcze dwa pola lutownicze."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1395
+#: getting_started_in_kicad.adoc:1409
 msgid ""
 "If you want to change the grid size, *Right click* -> **Grid Select**. Be "
 "sure to select the appropriate grid size before laying down the components."
@@ -4048,7 +4048,7 @@ msgstr ""
 "dalszych elementów modułu."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1398
+#: getting_started_in_kicad.adoc:1412
 msgid ""
 "Move the 'MYCONN3' label and the 'SMD' label out of the way so that it looks "
 "like the image shown above."
@@ -4057,7 +4057,7 @@ msgstr ""
 "mniej więcej w miejscach pokazanych na następnym obrazku."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1405
+#: getting_started_in_kicad.adoc:1419
 msgid ""
 "When placing pads it is often necessary to measure relative distances. Place "
 "the cursor where you want the relative coordinate point _(0,0)_ to be and "
@@ -4074,7 +4074,7 @@ msgstr ""
 "potrzebował określić dystans od jakiegoś wybranego punktu."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1410
+#: getting_started_in_kicad.adoc:1424
 msgid ""
 "Now add a footprint contour. Click on the 'Add graphic line or polygon' "
 "button image:images/icons/add_polygon.png[add_polygon_png] in the right "
@@ -4085,7 +4085,7 @@ msgstr ""
 "prawym pasku narzędzi. Narysuj obrys wokół pól lutowniczych."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1414
+#: getting_started_in_kicad.adoc:1428
 #, fuzzy
 #| msgid ""
 #| "Click on the 'Save Module in working directory' icon image:images/"
@@ -4101,13 +4101,13 @@ msgstr ""
 "domyślnej nazwy 'MYCONN3'."
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1416
+#: getting_started_in_kicad.adoc:1430
 #, no-wrap
 msgid "Note about portability of KiCad project files"
 msgstr "Uwagi na temat przenoszenia plików projektów wykonanych w programie KiCad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1420
+#: getting_started_in_kicad.adoc:1434
 msgid ""
 "What files do you need to send to someone so that they can fully load and "
 "use your KiCad project?"
@@ -4116,7 +4116,7 @@ msgstr ""
 "twojego projektu?"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1427
+#: getting_started_in_kicad.adoc:1441
 #, fuzzy
 #| msgid ""
 #| "When you have a KiCad project to share with somebody, it is important "
@@ -4140,7 +4140,7 @@ msgstr ""
 "będą miały wolną rękę w modyfikacji schematu lub obwodu drukowanego."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1439
+#: getting_started_in_kicad.adoc:1453
 #, fuzzy
 #| msgid ""
 #| "With KiCad schematics, people need the _.lib_ files that contain the "
@@ -4176,7 +4176,7 @@ msgstr ""
 "one także przy przypisywaniu symbolom modułów za pomocą programu CvPcb."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1447
+#: getting_started_in_kicad.adoc:1461
 #, fuzzy
 #| msgid ""
 #| "If someone sends you a _.kicad_pcb_ file with modules you would like to "
@@ -4204,7 +4204,7 @@ msgstr ""
 "modułami jakie znajdują się na płytce."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1453
+#: getting_started_in_kicad.adoc:1467
 msgid ""
 "Bottom line, if the PCB is the only thing you want to distribute, then the "
 "board file _.kicad_pcb_ is enough. However, if you want to give people the "
@@ -4219,7 +4219,7 @@ msgstr ""
 "(przykładowo) razem ze strukturą katalogów:"
 
 #. type: delimited block -
-#: getting_started_in_kicad.adoc:1471
+#: getting_started_in_kicad.adoc:1485
 #, fuzzy, no-wrap
 #| msgid ""
 #| "foxy_board/\n"
@@ -4266,13 +4266,13 @@ msgstr ""
 "    \\-- ...\n"
 
 #. type: Title ==
-#: getting_started_in_kicad.adoc:1474
+#: getting_started_in_kicad.adoc:1488
 #, no-wrap
 msgid "More about KiCad documentation"
 msgstr "Więcej na temat dokumentacji do programu KiCad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1479
+#: getting_started_in_kicad.adoc:1493
 #, fuzzy
 #| msgid ""
 #| "This has been a quick guide on most of the features in KiCad. For more "
@@ -4289,7 +4289,7 @@ msgstr ""
 "Klikając na przykład w *Pomoc* -> **Zawartość** lub **Podręcznik**."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1482
+#: getting_started_in_kicad.adoc:1496
 msgid ""
 "KiCad comes with a pretty good set of multi-language manuals for all its "
 "four software components."
@@ -4298,14 +4298,14 @@ msgstr ""
 "językach, dla wszystkich jego czterech podstawowych składników."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1484
+#: getting_started_in_kicad.adoc:1498
 msgid "The English version of all KiCad manuals are distributed with KiCad."
 msgstr ""
 "Polskie wersję podręczników do programu KiCad są również dostarczane razem z "
 "programem KiCad."
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1490
+#: getting_started_in_kicad.adoc:1504
 #, fuzzy
 #| msgid ""
 #| "In addition to its manuals, KiCad is distributed with this tutorial, "
@@ -4327,14 +4327,14 @@ msgstr ""
 "jak również instrukcje można znaleźć w następujących katalogach:"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1493
+#: getting_started_in_kicad.adoc:1507
 msgid ""
 "For example, on Linux the typical locations are in the following "
 "directories, depending on your exact distribution:"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1496
+#: getting_started_in_kicad.adoc:1510
 #, fuzzy, no-wrap
 #| msgid "/usr/share/doc/kicad/en/ /usr/share/doc/kicad/help/en/ /usr/local/kicad/doc/tutorials/en/ kicad/doc/tutorials/en/"
 msgid ""
@@ -4343,42 +4343,42 @@ msgid ""
 msgstr "/usr/share/doc/kicad/en/ /usr/share/doc/kicad/help/en/ /usr/local/kicad/doc/tutorials/en/ kicad/doc/tutorials/en/"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1498
+#: getting_started_in_kicad.adoc:1512
 msgid "On Windows it is in:"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1500
+#: getting_started_in_kicad.adoc:1514
 #, no-wrap
 msgid " <installation directory>/share/doc/kicad/help/en\n"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1502
+#: getting_started_in_kicad.adoc:1516
 msgid "On OS X:"
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1504
+#: getting_started_in_kicad.adoc:1518
 #, no-wrap
 msgid " /Library/Application Support/kicad/help/en\n"
 msgstr ""
 
 #. type: Title ===
-#: getting_started_in_kicad.adoc:1506
+#: getting_started_in_kicad.adoc:1520
 #, fuzzy, no-wrap
 #| msgid "More about KiCad documentation"
 msgid "KiCad documentation on the Web"
 msgstr "Więcej na temat dokumentacji do programu KiCad"
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1509
+#: getting_started_in_kicad.adoc:1523
 msgid ""
 "Latest KiCad documentations are available in multiple languages on the Web."
 msgstr ""
 
 #. type: Plain text
-#: getting_started_in_kicad.adoc:1511
+#: getting_started_in_kicad.adoc:1525
 #, fuzzy
 #| msgid "http://www.kicad-pcb.org/"
 msgid "http://kicad-pcb.org/help/documentation/"


### PR DESCRIPTION
With b89162c2f9a378e08130dbce1cdab9d7d9fefbff there are small regressions introduced, the numbering was interrupted  after that commit. Fixed.

Re formating the file getting_started_in_kicad.adoc to break up long lines after 78 characters. And depending on previous commits update of all po files in GSIK with finally updating the German translation.
