### PR TITLE
Typos that partially fix issue #342

### DIFF
--- a/src/kicad/kicad.adoc
+++ b/src/kicad/kicad.adoc
@@ -170,7 +170,7 @@ Pcbnew needs the support of OpenGL v2.1 or more.
 A default configuration file named _kicad.pro_ is supplied in
 kicad/template. It serves as a template for any new project.
 
-If an other default configuration file named _fp-lib-table_ exists,
+If another default configuration file named _fp-lib-table_ exists,
 it will be used only once to create a footprint library list.
 (or else, this list will be created from scratch)
 
@@ -508,7 +508,7 @@ image::images/menu_file.png[scaledwidth="70%"]
   template/kicad.pro to the current folder.
 - *Project from Template* Opens the template selection dialog. The
   template selection dialog has a list of icons, and a display window. A
-  single click on a template's icon on the top will load that templates
+  single click on a template's icon on the top will load that template's
   info.html metadata file and display it in the display window. A click on
   the OK button starts the new project creation. The template will be
   copied to the new project location (excluding METADIR as mentioned


### PR DESCRIPTION
- [x] 2.2, 1st paragraph, 2nd line, “If an other default...” Should be “If another default...”

- [x] Page 13, bottom of page, “Project from Template”, 2nd line, near the end, “...will load that templates
info.html...” Should be “...will load that template's info.html...”

- [ ] Page 14, last figure at bottom of page, “Templates path”. Should be “Template's path” unless you're
talking about multiple templates, in which case I think it would be “templates' path”.

This last item is about a screenshot so it will be fixed in the KiCad sources first.