### PR TITLE
Revert "fix cmake for update po files"

### DIFF
--- a/CMakeModules/KiCadDocumentation.cmake
+++ b/CMakeModules/KiCadDocumentation.cmake
@@ -29,11 +29,6 @@ macro( KiCadDocumentation DOCNAME )
         list( APPEND DOCCHAPTERS "${CNAME}" )
     endforeach()
 
-    foreach( DOC ${DOCCHAPTERFILES} )
-        set( DOCCHAPTERMASTERS "${DOCCHAPTERMASTERS} -m ${DOC}" )
-    endforeach()
-    separate_arguments( DOCCHAPTERMASTERS )
-
     # If we're not building a specific language, glob all languages
     if( "${SINGLE_LANGUAGE}" STREQUAL "" )
         # Get a list of all po translation files so we know what languages can be built
@@ -93,15 +88,9 @@ macro( KiCadDocumentation DOCNAME )
             # as well as an "all" target. Do not include updating the translations in the
             # default all target
             add_custom_target( ${DOCNAME}_updatepo_${LANGUAGE}
-                COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} &&
-                        ${PO4A_COMMAND}-updatepo -f asciidoc -v -M utf-8
-                            -m ${DOCNAME}.adoc ${DOCCHAPTERMASTERS}
-                            -p po/${LANGUAGE}.po )
+                COMMAND ${PO4A_COMMAND}-updatepo -f asciidoc -v -M utf-8 -m ${CMAKE_CURRENT_SOURCE_DIR}/${DOCNAME}.adoc -p ${CMAKE_CURRENT_SOURCE_DIR}/po/${LANGUAGE}.po )
 
             add_dependencies( ${DOCNAME}_updatepo_all ${DOCNAME}_updatepo_${LANGUAGE} )
-
-            add_dependencies( updatepo_${LANGUAGE} ${DOCNAME}_updatepo_${LANGUAGE} )
-            add_dependencies( updatepo_all ${DOCNAME}_updatepo_${LANGUAGE} )
 
             add_custom_target( ${DOCNAME}_translate_${LANGUAGE}
                 COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,23 +5,6 @@
 # (c)2015 Brian Sidebotham <brian.sidebotham@gmail.com>
 #
 
-add_custom_target( updatepo_all )
-
-file( GLOB ALLPO RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/*/po/*.po )
-
-foreach( PO ${ALLPO} )
-    string( REGEX REPLACE ".*/po/([a-z][a-z]).po" "\\1" LANG "${PO}" )
-    list( APPEND LANGS "${LANG}" )
-endforeach()
-
-list( REMOVE_DUPLICATES LANGS )
-list( SORT LANGS )
-
-foreach( LANG ${LANGS} )
-    add_custom_target( updatepo_${LANG} )
-endforeach()
-
 add_subdirectory( cvpcb )
 add_subdirectory( eeschema )
 add_subdirectory( gerbview )


### PR DESCRIPTION
Reverts KiCad/kicad-doc#350

from the build dir

 cmake .. 

gives:
CMake Error at CMakeModules/KiCadDocumentation.cmake:103 (add_dependencies):
  Cannot add target-level dependencies to non-existent target "updatepo_it".

  The add_dependencies works for top-level logical targets created by the
  add_executable, add_library, or add_custom_target commands.  If you want to
  add file-level dependencies see the DEPENDS option of the add_custom_target
  and add_custom_command commands.
Call Stack (most recent call first):
  src/idf_exporter/CMakeLists.txt:8 (KiCadDocumentation)

