### PR TITLE
Edited Overview section

### DIFF
--- a/src/getting_started_in_kicad/getting_started_in_kicad.adoc
+++ b/src/getting_started_in_kicad/getting_started_in_kicad.adoc
@@ -184,59 +184,56 @@ If you have ideas, remarks or questions, or if you just need help:
 == KiCad Workflow
 
 Despite its similarities with other PCB software tools, KiCad is
-characterised by an interesting work-flow in which schematic components
-and footprints are actually two separate entities. This is often the
-subject of discussion on Internet forums.
+characterised by an interesting workflow in which choosing a schematic
+component does not also select a footprint. Instead, KiCad allows
+creating the schematic and then assigning footprints to the schematic
+symbols. This is often the subject of discussion on Internet forums.
 
 [[kicad-work-flow-overview]]
-=== KiCad Workflow overview
+=== Overview
 
-The KiCad work-flow is comprised of two main tasks: making the schematic
+The KiCad workflow is comprised of two main tasks: making the schematic
 and laying out the board. Both a component library and a footprint
-library are necessary for these two tasks. KiCad has plenty of both.
-Just in case that is not enough, KiCad also has the tools necessary to
-make new ones.
+library are necessary for these two tasks. KiCad includes an extensive
+library. Just in case that is not enough, KiCad also has the tools necessary
+to make new components and footprints.
 
-In the picture below, you see a flowchart representing the KiCad work-flow.
+In the picture below, you see a flowchart representing the KiCad workflow.
 The picture explains which steps you need to take, in which order.
 When applicable, the icon is added as well for convenience.
 
 image::images/kicad_flowchart.png["KiCad Flowchart"]
 
 For more information about creating a component, see the section of this
-document titled <<make-schematic-components-in-kicad,Make schematic components in KiCad>>. And for more
+document titled <<making-schematic-components-in-kicad,Making schematic components in KiCad>>. And for more
 information about how to create a new footprint, see the section of this document
-titled <<make-component-footprints,Make component footprints>>.
+titled <<making-component-footprints,Making component footprints>>.
 
-On the following site:
-
-http://kicad.rohrbacher.net/quicklib.php
-
-You will find an example of use of a tool that allows you to quickly
-create KiCad library components. For more information about quicklib,
-refer to the section of this document titled
-<<make-schematic-components-with-quicklib,Make Schematic Components
-With quicklib>>.
+http://kicad.rohrbacher.net/quicklib.php[Quicklib] is a tool that
+allows you to quickly create KiCad library components in a web browser.
+For more information about Quicklib, refer to the section of this document titled
+<<making-schematic-components-with-quicklib,Making schematic components with quicklib>>.
 
 [[forward-and-backward-annotation]]
 === Forward and backward annotation
 
 Once an electronic schematic has been fully drawn, the next step is to
-transfer it to a PCB following the KiCad work-flow. Once the board
+transfer it to a PCB following the KiCad workflow. Once the board
 layout process has been partially or completely done, additional
 components or nets might need to be added, parts moved around and much
 more. This can be done in two ways: Backward Annotation and Forward
 Annotation.
 
+Forward Annotation is the process of sending schematic changes to a
+corresponding PCB layout, either the first time a schematic is created
+or when schematic changes have been made. This is a fundamental feature
+because you do not really want to re-do the layout of the whole PCB every
+time you make a modification to your schematic. Forward Annotation is
+discussed in the section titled <<forward-annotation-in-kicad,Forward Annotation>>.
+
 Backward Annotation is the process of sending a PCB layout change back
 to its corresponding schematic. Some do not consider this particular
 feature especially useful.
-
-Forward Annotation is the process of sending schematic changes to a
-corresponding PCB layout. This is a fundamental feature because you do
-not really want to re-do the layout of the whole PCB every time you make
-a modification to your schematic. Forward Annotation is discussed in the
-section titled <<forward-annotation-in-kicad,Forward Annotation>>.
 
 [[draw-electronic-schematics]]
 == Draw electronic schematics
@@ -396,7 +393,7 @@ image::images/gsik_tutorial1_010.png[gsik_tutorial1_010_png]
 
 25. We now need to create the schematic component 'MYCONN3' for our
     3-pin connector. You can jump to the section titled
-    <<make-schematic-components-in-kicad,Make Schematic Components in KiCad>>
+    <<making-schematic-components-in-kicad,Making Schematic Components in KiCad>>
     to learn how to make this component from scratch and then return
     to this section to continue with the board.
 
@@ -1078,8 +1075,8 @@ those modifications in your schematic and netlist file. The Backward
 Annotation method, however, is not that useful and is therefore not
 described here.
 
-[[make-schematic-components-in-kicad]]
-== Make schematic components in KiCad
+[[making-schematic-components-in-kicad]]
+== Making schematic components in KiCad
 
 Sometimes a component that you want to place on your schematic is not 
 in a KiCad library. This is quite normal and there is no reason to
@@ -1229,8 +1226,8 @@ will see how to export a component from the KiCad standard library
     image:images/icons/save_library.png[save_library_png] in the top
     toolbar.
 
-[[make-schematic-components-with-quicklib]]
-=== Make schematic components with quicklib
+[[making-schematic-components-with-quicklib]]
+=== Making schematic components with quicklib
 
 This section presents an alternative way of creating the schematic
 component for MYCONN3 (see <<myconn3,MYCONN3>> above) using the
@@ -1268,10 +1265,10 @@ As you might guess, this method of creating library components can be
 quite effective when you want to create components with a large pin
 count.
 
-[[make-a-high-pin-count-schematic-component]]
-=== Make a high pin count schematic component
+[[making-a-high-pin-count-schematic-component]]
+=== Making a high pin count schematic component
 
-In the section titled _Make Schematic Components in quicklib_ we saw how
+In the section titled _Making Schematic Components in quicklib_ we saw how
 to make a schematic component using the _quicklib_ web-based tool.
 However, you will occasionally find that you need to create a schematic
 component with a high number of pins (some hundreds of pins). In KiCad,
@@ -1352,8 +1349,8 @@ image::images/gsik_high_number_pins.png[gsik_high_number_pins_png]
     all its power comes for the arcane and yet amazingly useful
     Regular Expression syntax: _http://gskinner.com/RegExr/._
 
-[[make-component-footprints]]
-== Make component footprints
+[[making-component-footprints]]
+== Making component footprints
 
 Unlike other EDA software tools, which have one type of library that
 contains both the schematic symbol and the footprint variations, KiCad


### PR DESCRIPTION
Changed section names to present participle form, moved forward annotation above backward since it always must come first, and removed the "-" where used in "workflow" to align the spelling