### PR TITLE
Update plugins.adoc

### DIFF
--- a/src/plugins/plugins.adoc
+++ b/src/plugins/plugins.adoc
@@ -47,7 +47,7 @@ Published on January 29, 2016.
 The KiCad plugin system is a framework for extending the capabilities
 of KiCad using shared libraries. One of the main advantages of using
 a plugin is that it is not necessary to rebuild the KiCad suite while
-developing a plugin; in fact plugins can be built with the aid of a
+developing a plugin; in fact, plugins can be built with the aid of a
 very small set of headers from the KiCad source tree. Removing the
 requirement to build KiCad during plugin development greatly increases
 productivity by ensuring that the developer only compiles code directly
@@ -56,9 +56,9 @@ time required for each build and test cycle.
 
 Plugins were initially developed for the 3D model viewer to make it
 possible to support more types of 3D models without requiring major
-changes to the KiCad source for each new model supported. The plugin
-framework was later generalized so that in the future developers can
-create different classes of plugins.  Currently only 3D plugins are
+changes to the KiCad source for each new model type supported. The
+plugin framework was later generalized so that in the future developers
+can create different classes of plugins.  Currently only 3D plugins are
 implemented within KiCad but it is envisioned that a PCB plugin will
 eventually be developed to make it possible for users to implement
 data Importers and Exporters.
@@ -71,26 +71,26 @@ Plugins are divided into Plugin Classes since each plugin addresses
 problems in a specific domain and therefore requires an interface
 unique to that domain. For example, the 3D model plugins load 3D
 model data from files and translate that data into a format which
-can be displayed by the 3D viewer while a PCB Import/Export plugin
-would take PCB data and export to other electronics or mechanical
-data formats or translate a foreign format into a KiCad PCB. At
-the moment only the 3D Plugin Class has been developed and this
+can be displayed by the 3D viewer. A PCB Import/Export plugin
+would take PCB data and export to other electrical or mechanical
+data formats, or translate a foreign format into a KiCad PCB. At
+the moment only the 3D Plugin Class has been developed and it
 will be the focus of this document.
 
 Implementing a Plugin Class requires creating code within the KiCad
 source tree which manages the loading of plugin code. Within the
-KiCad source tree, the file plugins/ldr/pluginldr.h declares the
+KiCad source tree, the file *plugins/ldr/pluginldr.h* declares the
 base class for all plugin loaders.  This class declares the most
 basic functions which we would expect to find in any KiCad plugin
 (boilerplate code) and its implementation provides basic checks
 on version compatibility between the plugin loader and the
-available plugins. The header plugins/ldr/3d/pluginldr3D.h declares
+available plugins. The header *plugins/ldr/3d/pluginldr3D.h* declares
 a loader for the 3D Plugin Class. The loader is responsible for
 loading a given plugin and making its functions available to KiCad.
 Each instance of a plugin loader represents an actual plugin
-implementation and acts as a transparent bridge between kicad and
+implementation and acts as a transparent bridge between KiCad and
 the plugin's features. The loader is not the only code required within
-KiCad to support plugins; we also need code to discover the plugins
+KiCad to support plugins: we also need code to discover the plugins
 and code to invoke the functions of the plugins via the plugin loader.
 In the case of the 3D plugins the discovery and invocation functions
 are all contained within the S3D_CACHE class.
@@ -100,11 +100,11 @@ KiCad's internal code for managing plugins unless a new Plugin
 Class is being developed; a plugin only needs to define the functions
 declared by their specific plugin class.
 
-The header include/plugins/kicad_plugin.h declares the generic
+The header *include/plugins/kicad_plugin.h* declares the generic
 functions required of all KiCad plugins; these functions identify
 the Plugin Class, provide the name of the specific plugin, provide
 version information for the Plugin Class API, provide version
-information for the specific plugin, and provides a basic version
+information for the specific plugin, and provide a basic version
 compatibility check on the Plugin Class API. In brief, these
 functions are:
 
@@ -136,7 +136,7 @@ void GetPluginVersion( unsigned char* Major, unsigned char* Minor,
 [[REF:CLASS_PLUGIN_3D]]
 ==== Plugin Class: PLUGIN_3D
 
-The header include/plugins/3d/3d_plugin.h declares the functions
+The header *include/plugins/3d/3d_plugin.h* declares the functions
 which must be implemented by all 3D plugins and defines a number of
 functions which are required by the plugin and which the user must
 not reimplement. The defined functions which the user must not
@@ -201,26 +201,25 @@ PLUGIN_3D class and walks the user through the setup and building of
 the code.
 
 
-=== Tutorial: 3D Plugin, Demo 1
+=== Basic 3D Plugin
 
 This tutorial walks the user through the development of a very basic
-3D plugin named ``PLUGIN_3D_DEMO1''. The purpose of the tutorial is
+3D plugin named "PLUGIN_3D_DEMO1". The purpose of this tutorial is only
 to demonstrate the construction of a very basic 3D plugin which does
-nothing other than provide a few filter strings which permit the
-KiCad user to filter file names while browsing for 3D models. The
-code demonstrated here is the absolute minimum requirement for any
-3D plugin and can be used as a template for creating more functional
-plugins.
+nothing other than provide a few filter strings which permit the KiCad
+user to filter file names while browsing for 3D models. The code
+demonstrated here is the absolute minimum requirement for any 3D plugin
+and can be used as a template for creating more advanced plugins.
 
 In order to build the demo project we require the following:
 
-* CMake
+* https://cmake.org/[CMake]
 * KiCad plugin headers
-* KiCad Scene Graph library, kicad_3dsg
+* KiCad Scene Graph library `kicad_3dsg`
 
 To automatically detect the KiCad headers and library we shall use a
 CMake FindPackage script; the script supplied in this tutorial should
-work on Linux and MSWindows if the relevant header files are installed
+work on Linux and Windows if the relevant header files are installed
 to `${KICAD_ROOT_DIR}/kicad` and the KiCad Scene Graph library is
 installed in `${KICAD_ROOT_DIR}/lib`.
 
@@ -313,8 +312,8 @@ _EOF
 Kicad and its plugin headers must be installed; if they are installed
 to a user directory or under `/opt` on Linux, or you are using Windows,
 you will need to set the `KICAD_ROOT_DIR` environment variable to
-point to the directory containing the kicad `include` and `lib`
-directories. For OSX the FindPackage script presented here may require
+point to the directory containing the KiCad `include` and `lib`
+directories. For OS X the FindPackage script presented here may require
 some adjustments.
 
 To configure and build the tutorial code we will use CMake and
@@ -363,7 +362,7 @@ export DEMO_SRC=${PWD}
 
 Now we create the plugin source itself:
 
-.s3d_plugin_demo1.cpp
+*.s3d_plugin_demo1.cpp*
 [source,c]
 -----
 #include <iostream>
@@ -533,11 +532,11 @@ models but it can provide KiCad with a list of supported model
 file extensions and file extension filters to enhance the 3D
 model file selection dialog. Within KiCad the extension strings
 are used to select the plugins which may be used to load a
-specified model; for example if the plugin is `wrl` then KiCad
+specified model; for example, if the plugin is `wrl` then KiCad
 will invoke each plugin which claims to support the extension
-`wrl` in turn until a plugin returns visualization data. The
-file filters provided by each plugin are passed onto the 3D
-file selector dialogs to improve the browsing UI.
+`wrl` until a plugin returns visualization data. The file
+filters provided by each plugin are passed to the 3D file
+selector dialog to improve the browsing UI.
 
 To build the plugin:
 
@@ -549,16 +548,15 @@ mkdir build && cd build
 cmake .. && make
 -----
 
-The plugin will be built but not installed; you may copy the
-plugin to the same directory in which the kicad installation
-has its plugins if you wish to load the plugin.
+The plugin will be built but not installed; you must copy the
+plugin file to KiCad's plugin directory if you wish to load the plugin.
 
 
-=== Tutorial: 3D Plugin, Demo 2
+=== Advanced 3D Plugin
 
 This tutorial walks the user through the development of a 3D plugin
-named ``PLUGIN_3D_DEMO2''. The purpose of the tutorial is to demonstrate
-the construction of a very basic scene graph which the kicad previewer
+named "PLUGIN_3D_DEMO2". The purpose of this tutorial is to demonstrate
+the construction of a very basic scene graph which the KiCad previewer
 can render. The plugin claims to handle files of type `txt`. Although
 the file must exist in order for the cache manager to invoke the
 plugin, the file contents are not processed by this plugin; instead,
@@ -567,18 +565,18 @@ This tutorial assumes that the first tutorial had been completed and
 that the CMakeLists.txt and FindKICAD.cmake script files have been
 created.
 
-The new source file shall be placed in the same directory as the
-previous tutorial's source file and we shall extend the previous
-tutorial's CMakeLists.txt file to build this tutorial. Since this
-plugin will create a scene graph for KiCad we need to link to
-KiCad's scene graph library `kicad_3dsg`. KiCad's Scene Graph
-Library provides a set of classes which can be used to build the
-Scene Graph Object; the Scene Graph Object is an intermediate
-data visualization format used by the 3D Cache Manager. All plugins
-which support model visualization must translate the model data into
-a scene graph via this library.
+Place the new source file in the same directory as the previous
+tutorial's source file and we will extend the previous tutorial's
+CMakeLists.txt file to build this tutorial. Since this plugin will
+create a scene graph for KiCad we need to link to KiCad's scene
+graph library `kicad_3dsg`. KiCad's Scene Graph Library provides
+a set of classes which can be used to build the Scene Graph Object;
+the Scene Graph Object is an intermediate data visualization format
+used by the 3D Cache Manager. All plugins which support model
+visualization must translate the model data into a scene graph via
+this library.
 
-First step: extend CMakeLists.txt to build this tutorial project:
+The first step is to extend CMakeLists.txt to build this tutorial project:
 
 [source,bash]
 -----
@@ -599,7 +597,7 @@ Now we change to the source directory and create the source file:
 cd ${DEMO_SRC}
 -----
 
-.s3d_plugin_demo2.cpp
+*.s3d_plugin_demo2.cpp*
 [source,c]
 -----
 #include <cmath>
@@ -921,11 +919,11 @@ SCENEGRAPH* Load( char const* aFileName )
 Plugins are implemented via Application Programming Interface (API)
 implementations. Each Plugin Class has its specific API and in the
 3D Plugin tutorials we have seen examples of the implementation of
-the 3D Plugin API as declared by the header 3d_plugin.h. Plugins
+the 3D Plugin API as declared by the header *3d_plugin.h*. Plugins
 may also rely on other APIs defined within the KiCad source tree;
 in the case of 3D plugins, all plugins which support visualization
 of models must interact with the Scene Graph API as declared in
-the header ifsg_all.h and its included headers.
+the header *ifsg_all.h* and its included headers.
 
 This section describes the details of available Plugin Class APIs
 and other KiCad APIs which may be required for implementations of
@@ -933,10 +931,10 @@ plugin classes.
 
 === Plugin Class APIs
 
-There is currently only one plugin class declared for KiCad and
-this is the 3D Plugin Class. All KiCad plugin classes must implement
-a basic set of functions declared in the header file kicad_plugin.h;
-these declarations shall be referred to as the Base Kicad Plugin Class.
+There is currently only one plugin class declared for KiCad: the 3D
+Plugin Class. All KiCad plugin classes must implement
+a basic set of functions declared in the header file *kicad_plugin.h*;
+these declarations are referred to as the Base Kicad Plugin Class.
 No implementation of the Base Kicad Plugin Class exists; the header file
 exists purely to ensure that plugin developers implement these
 defined functions in each plugin implementation.
@@ -954,14 +952,14 @@ invoke each function on behalf of the user.
 
 ==== API: Base Kicad Plugin Class
 
-The Base Kicad Plugin Class is defined by the header file kicad_plugin.h.
+The Base Kicad Plugin Class is defined by the header file *kicad_plugin.h*.
 This header must be included in the declaration of all other plugin
-classes; for example see the 3D Plugin Class declaration in the
-header file 3d_plugin.h. The prototypes for these functions were briefly
+classes; for an example see the 3D Plugin Class declaration in the
+header file *3d_plugin.h*. The prototypes for these functions were briefly
 described in <<REF:PLUGIN_CLASSES,Plugin Classes>>. The API is implemented
-by the base plugin loader as defined in pluginldr.cpp.
+by the base plugin loader as defined in *pluginldr.cpp*.
 
-To help make sense of the functions required by the base kicad plugin header
+To help make sense of the functions required by the base KiCad plugin header
 we must look at what happens in the base Plugin Loader class. The Plugin
 Loader class declares a virtual function `Open()` which takes the full
 path to the plugin to be loaded. The implementation of the `Open()` function
@@ -978,14 +976,14 @@ Plugin Loader instance.
 . Plugin `GetClassVersion()` is invoked to retrieve the Plugin Class API Version
 implemented by the plugin.
 . Plugin Loader virtual `GetLoaderVersion()` function is invoked to retrieve the
-Plugin Class API Version implemented by the loader
+Plugin Class API Version implemented by the loader.
 . The Plugin Class API Version reported by the plugin and the loader are
 required to have the same Major Version number, otherwise they are
 considered incompatible. This is the most basic version test and it is
 enforced by the base plugin loader.
 . Plugin `CheckClassVersion()` is invoked with the Plugin Class API Version
 information of the Plugin Loader; if the Plugin supports the given version
-then it returns `true` to indicate success, in which case the loader creates
+then it returns `true` to indicate success. If successful the loader creates
 a PluginInfo string based on the results of `GetKicadPluginName()` and
 `GetPluginVersion()`, and the plugin loading procedure
 continues within the Plugin Loader's `Open()` implementation.
@@ -993,10 +991,10 @@ continues within the Plugin Loader's `Open()` implementation.
 
 ==== API: 3D Plugin Class
 
-The 3D Plugin Class is declared by the header file 3d_plugin.h and it
+The 3D Plugin Class is declared by the header file *3d_plugin.h* and it
 extends the required plugin functions as described in
 <<REF:CLASS_PLUGIN_3D, Plugin Class: PLUGIN_3D>>. The corresponding
-Plugin Loader is defined in pluginldr3D.cpp and the loader implements
+Plugin Loader is defined in *pluginldr3D.cpp* and the loader implements
 the following public functions in addition to the required API functions:
 
 [source,c]
@@ -1051,25 +1049,25 @@ void GetPluginInfo( std::string& aPluginInfo );
 
 In typical situations, the user would do the following:
 
-. Create an instance of `KICAD_PLUGIN_LDR_3D`
-. Invoke `Open( "/path/to/myplugin.so" )` to open a specific plugin;
-the return value must be checked to ensure that the plugin loaded
+. Create an instance of `KICAD_PLUGIN_LDR_3D`.
+. Invoke `Open( "/path/to/myplugin.so" )` to open a specific plugin.
+The return value must be checked to ensure that the plugin loaded
 as desired.
-. Invoke any of the 3D Plugin Class calls as exposed by `KICAD_PLUGIN_LDR_3D`
-. Invoke `Close()` to close (unlink) the plugin
-. Destroy the `KICAD_PLUGIN_LDR_3D` instance
+. Invoke any of the 3D Plugin Class calls as exposed by `KICAD_PLUGIN_LDR_3D`.
+. Invoke `Close()` to close (unlink) the plugin.
+. Destroy the `KICAD_PLUGIN_LDR_3D` instance.
 
 === Scenegraph Class APIs
 
-The Scenegraph Class API is defined by the header `ifsg_all.h` and its
+The Scenegraph Class API is defined by the header *ifsg_all.h* and its
 included headers. The API consists of a number of helper routines with
-the namespace `S3D` as defined in `ifsg_api.h` and wrapper classes defined
-by the various `ifsg_*.h` headers; the wrappers support the underlying
+the namespace `S3D` as defined in *ifsg_api.h* and wrapper classes defined
+by the various *ifsg_*.h* headers; the wrappers support the underlying
 scene graph classes which, taken together, form a scene graph structure
 which is compatible with VRML2.0 static scene graphs. The headers,
 structures, classes and their public functions are as follows:
 
-.sg_version.h
+*.sg_version.h*
 [source,c]
 -----
 /*
@@ -1086,7 +1084,7 @@ structures, classes and their public functions are as follows:
 -----
 
 
-.sg_types.h
+*.sg_types.h*
 [source,c]
 -----
 /*
@@ -1112,10 +1110,10 @@ namespace S3D
 };
 -----
 
-The `sg_base.h` header contains declarations of basic data types used
+The *sg_base.h* header contains declarations of basic data types used
 by the scenegraph classes.
 
-.sg_base.h
+*.sg_base.h*
 [source,c]
 -----
 /*
@@ -1186,7 +1184,7 @@ scenegraph objects implement the public functions of this class but in
 some cases a particular function may have no meaning for a specific
 class.
 
-.ifsg_node.h
+*.ifsg_node.h*
 [source,c]
 -----
 class IFSG_NODE
@@ -1280,7 +1278,7 @@ and any number of referenced IFSG_SHAPE and IFSG_TRANSFORM nodes.
 A valid scenegraph must have a single `IFSG_TRANSFORM` object
 as a root.
 
-.ifsg_transform.h
+*.ifsg_transform.h*
 [source,c]
 -----
 /**
@@ -1310,7 +1308,7 @@ public:
 a single child or reference FACESET node and may contain a
 single child or reference APPEARANCE node.
 
-.ifsg_shape.h
+*.ifsg_shape.h*
 [source,c]
 -----
 /**
@@ -1330,11 +1328,11 @@ public:
 -----
 
 
-`IFSG_APPEARANCE` is similar to a VRML2.0 Appearance node, however
+`IFSG_APPEARANCE` is similar to a VRML2.0 Appearance node, however,
 at the moment it only represents the equivalent of an Appearance
 node containing a Material node.
 
-.ifsg_appearance.h
+*.ifsg_appearance.h*
 [source,c]
 -----
 class IFSG_APPEARANCE : public IFSG_NODE
@@ -1386,11 +1384,11 @@ A simplistic normals calculation function is provided to aid
 the user in assigning normal values to surfaces. The deviations
 from the VRML2.0 analogue are as follows:
 
-. normals are always per-vertex
-. colors are always per vertex
-. the coordinate index set must describe triangular faces only
+. Normals are always per-vertex.
+. Colors are always per vertex.
+. The coordinate index set must describe triangular faces only.
 
-.ifsg_faceset.h
+*.ifsg_faceset.h*
 [source,c]
 -----
 /**
@@ -1412,7 +1410,7 @@ public:
 -----
 
 
-.ifsg_coords.h
+*.ifsg_coords.h*
 [source,c]
 -----
 /**
@@ -1447,11 +1445,11 @@ public:
 
 
 `IFSG_COORDINDEX` is similar to a VRML2.0 coordIdx[]
-set; however it must exclusively describe triangular
+set except it must exclusively describe triangular
 faces, which implies that the total number of indices
 is divisible by 3.
 
-.ifsg_coordindex.h
+*.ifsg_coordindex.h*
 [source,c]
 -----
 /**
@@ -1486,7 +1484,7 @@ public:
 
 `IFSG_NORMALS` is equivalent to a VRML2.0 Normals node.
 
-.ifsg_normals.h
+*.ifsg_normals.h*
 [source,c]
 -----
 /**
@@ -1521,7 +1519,7 @@ public:
 
 `IFSG_COLORS` is similar to a VRML2.0 colors[] set.
 
-.ifsg_colors.h
+*.ifsg_colors.h*
 [source,c]
 -----
 /**
@@ -1555,9 +1553,9 @@ public:
 -----
 
 
-The remaining API functions are defined in `ifsg_api.h` as follows:
+The remaining API functions are defined in *ifsg_api.h* as follows:
 
-.ifsg_api.h
+*.ifsg_api.h*
 [source,c]
 -----
 namespace S3D
@@ -1719,6 +1717,6 @@ namespace S3D
 };
 -----
 
-For examples of actual usage of the Scenegraph API see the
-3D Plugin DEMO2 tutorial and the kicad VRML1, VRML2, and X3D
-parsers.
+For actual usage examples of the Scenegraph API see the
+Advanced 3D Plugin tutorial above and the KiCad VRML1, VRML2,
+and X3D parsers.

--- a/src/plugins/plugins.adoc
+++ b/src/plugins/plugins.adoc
@@ -64,7 +64,7 @@ eventually be developed to make it possible for users to implement
 data Importers and Exporters.
 
 
-[[REF:PLUGIN_CLASSES]]
+[[plugin-classes]]
 === Plugin Classes
 
 Plugins are divided into Plugin Classes since each plugin addresses
@@ -79,12 +79,12 @@ will be the focus of this document.
 
 Implementing a Plugin Class requires creating code within the KiCad
 source tree which manages the loading of plugin code. Within the
-KiCad source tree, the file *plugins/ldr/pluginldr.h* declares the
+KiCad source tree, the file `plugins/ldr/pluginldr.h` declares the
 base class for all plugin loaders.  This class declares the most
 basic functions which we would expect to find in any KiCad plugin
 (boilerplate code) and its implementation provides basic checks
 on version compatibility between the plugin loader and the
-available plugins. The header *plugins/ldr/3d/pluginldr3D.h* declares
+available plugins. The header `plugins/ldr/3d/pluginldr3D.h` declares
 a loader for the 3D Plugin Class. The loader is responsible for
 loading a given plugin and making its functions available to KiCad.
 Each instance of a plugin loader represents an actual plugin
@@ -100,7 +100,7 @@ KiCad's internal code for managing plugins unless a new Plugin
 Class is being developed; a plugin only needs to define the functions
 declared by their specific plugin class.
 
-The header *include/plugins/kicad_plugin.h* declares the generic
+The header `include/plugins/kicad_plugin.h` declares the generic
 functions required of all KiCad plugins; these functions identify
 the Plugin Class, provide the name of the specific plugin, provide
 version information for the Plugin Class API, provide version
@@ -133,10 +133,10 @@ void GetPluginVersion( unsigned char* Major, unsigned char* Minor,
 -----
 
 
-[[REF:CLASS_PLUGIN_3D]]
+[[class-plugin-3d]]
 ==== Plugin Class: PLUGIN_3D
 
-The header *include/plugins/3d/3d_plugin.h* declares the functions
+The header `include/plugins/3d/3d_plugin.h` declares the functions
 which must be implemented by all 3D plugins and defines a number of
 functions which are required by the plugin and which the user must
 not reimplement. The defined functions which the user must not
@@ -201,6 +201,7 @@ PLUGIN_3D class and walks the user through the setup and building of
 the code.
 
 
+[[basic-3d-plugin]]
 === Basic 3D Plugin
 
 This tutorial walks the user through the development of a very basic
@@ -317,7 +318,7 @@ directories. For OS X the FindPackage script presented here may require
 some adjustments.
 
 To configure and build the tutorial code we will use CMake and
-create a CMakeLists.txt script file:
+create a `CMakeLists.txt` script file:
 
 [source,bash]
 -----
@@ -362,7 +363,7 @@ export DEMO_SRC=${PWD}
 
 Now we create the plugin source itself:
 
-*.s3d_plugin_demo1.cpp*
+.s3d_plugin_demo1.cpp
 [source,c]
 -----
 #include <iostream>
@@ -552,6 +553,7 @@ The plugin will be built but not installed; you must copy the
 plugin file to KiCad's plugin directory if you wish to load the plugin.
 
 
+[[advanced-3d-plugin]]
 === Advanced 3D Plugin
 
 This tutorial walks the user through the development of a 3D plugin
@@ -576,7 +578,7 @@ used by the 3D Cache Manager. All plugins which support model
 visualization must translate the model data into a scene graph via
 this library.
 
-The first step is to extend CMakeLists.txt to build this tutorial project:
+The first step is to extend `CMakeLists.txt` to build this tutorial project:
 
 [source,bash]
 -----
@@ -597,7 +599,7 @@ Now we change to the source directory and create the source file:
 cd ${DEMO_SRC}
 -----
 
-*.s3d_plugin_demo2.cpp*
+.s3d_plugin_demo2.cpp
 [source,c]
 -----
 #include <cmath>
@@ -919,11 +921,11 @@ SCENEGRAPH* Load( char const* aFileName )
 Plugins are implemented via Application Programming Interface (API)
 implementations. Each Plugin Class has its specific API and in the
 3D Plugin tutorials we have seen examples of the implementation of
-the 3D Plugin API as declared by the header *3d_plugin.h*. Plugins
+the 3D Plugin API as declared by the header `3d_plugin.h`. Plugins
 may also rely on other APIs defined within the KiCad source tree;
 in the case of 3D plugins, all plugins which support visualization
 of models must interact with the Scene Graph API as declared in
-the header *ifsg_all.h* and its included headers.
+the header `ifsg_all.h` and its included headers.
 
 This section describes the details of available Plugin Class APIs
 and other KiCad APIs which may be required for implementations of
@@ -933,7 +935,7 @@ plugin classes.
 
 There is currently only one plugin class declared for KiCad: the 3D
 Plugin Class. All KiCad plugin classes must implement
-a basic set of functions declared in the header file *kicad_plugin.h*;
+a basic set of functions declared in the header file `kicad_plugin.h`;
 these declarations are referred to as the Base Kicad Plugin Class.
 No implementation of the Base Kicad Plugin Class exists; the header file
 exists purely to ensure that plugin developers implement these
@@ -952,12 +954,12 @@ invoke each function on behalf of the user.
 
 ==== API: Base Kicad Plugin Class
 
-The Base Kicad Plugin Class is defined by the header file *kicad_plugin.h*.
+The Base Kicad Plugin Class is defined by the header file `kicad_plugin.h`.
 This header must be included in the declaration of all other plugin
 classes; for an example see the 3D Plugin Class declaration in the
-header file *3d_plugin.h*. The prototypes for these functions were briefly
-described in <<REF:PLUGIN_CLASSES,Plugin Classes>>. The API is implemented
-by the base plugin loader as defined in *pluginldr.cpp*.
+header file `3d_plugin.h`. The prototypes for these functions were briefly
+described in <<plugin-classes,Plugin Classes>>. The API is implemented
+by the base plugin loader as defined in `pluginldr.cpp`.
 
 To help make sense of the functions required by the base KiCad plugin header
 we must look at what happens in the base Plugin Loader class. The Plugin
@@ -991,10 +993,10 @@ continues within the Plugin Loader's `Open()` implementation.
 
 ==== API: 3D Plugin Class
 
-The 3D Plugin Class is declared by the header file *3d_plugin.h* and it
+The 3D Plugin Class is declared by the header file `3d_plugin.h` and it
 extends the required plugin functions as described in
-<<REF:CLASS_PLUGIN_3D, Plugin Class: PLUGIN_3D>>. The corresponding
-Plugin Loader is defined in *pluginldr3D.cpp* and the loader implements
+<<class-plugin-3d,Plugin Class: PLUGIN_3D>>. The corresponding
+Plugin Loader is defined in `pluginldr3D.cpp` and the loader implements
 the following public functions in addition to the required API functions:
 
 [source,c]
@@ -1059,15 +1061,15 @@ as desired.
 
 === Scenegraph Class APIs
 
-The Scenegraph Class API is defined by the header *ifsg_all.h* and its
+The Scenegraph Class API is defined by the header `ifsg_all.h` and its
 included headers. The API consists of a number of helper routines with
-the namespace `S3D` as defined in *ifsg_api.h* and wrapper classes defined
-by the various *ifsg_*.h* headers; the wrappers support the underlying
+the namespace `S3D` as defined in `ifsg_api.h` and wrapper classes defined
+by the various `ifsg_*.h` headers; the wrappers support the underlying
 scene graph classes which, taken together, form a scene graph structure
 which is compatible with VRML2.0 static scene graphs. The headers,
 structures, classes and their public functions are as follows:
 
-*.sg_version.h*
+.sg_version.h
 [source,c]
 -----
 /*
@@ -1084,7 +1086,7 @@ structures, classes and their public functions are as follows:
 -----
 
 
-*.sg_types.h*
+.sg_types.h
 [source,c]
 -----
 /*
@@ -1110,10 +1112,10 @@ namespace S3D
 };
 -----
 
-The *sg_base.h* header contains declarations of basic data types used
+The `sg_base.h` header contains declarations of basic data types used
 by the scenegraph classes.
 
-*.sg_base.h*
+.sg_base.h
 [source,c]
 -----
 /*
@@ -1184,7 +1186,7 @@ scenegraph objects implement the public functions of this class but in
 some cases a particular function may have no meaning for a specific
 class.
 
-*.ifsg_node.h*
+.ifsg_node.h
 [source,c]
 -----
 class IFSG_NODE
@@ -1278,7 +1280,7 @@ and any number of referenced IFSG_SHAPE and IFSG_TRANSFORM nodes.
 A valid scenegraph must have a single `IFSG_TRANSFORM` object
 as a root.
 
-*.ifsg_transform.h*
+.ifsg_transform.h
 [source,c]
 -----
 /**
@@ -1308,7 +1310,7 @@ public:
 a single child or reference FACESET node and may contain a
 single child or reference APPEARANCE node.
 
-*.ifsg_shape.h*
+.ifsg_shape.h
 [source,c]
 -----
 /**
@@ -1332,7 +1334,7 @@ public:
 at the moment it only represents the equivalent of an Appearance
 node containing a Material node.
 
-*.ifsg_appearance.h*
+.ifsg_appearance.h
 [source,c]
 -----
 class IFSG_APPEARANCE : public IFSG_NODE
@@ -1388,7 +1390,7 @@ from the VRML2.0 analogue are as follows:
 . Colors are always per vertex.
 . The coordinate index set must describe triangular faces only.
 
-*.ifsg_faceset.h*
+.ifsg_faceset.h
 [source,c]
 -----
 /**
@@ -1410,7 +1412,7 @@ public:
 -----
 
 
-*.ifsg_coords.h*
+.ifsg_coords.h
 [source,c]
 -----
 /**
@@ -1449,7 +1451,7 @@ set except it must exclusively describe triangular
 faces, which implies that the total number of indices
 is divisible by 3.
 
-*.ifsg_coordindex.h*
+.ifsg_coordindex.h
 [source,c]
 -----
 /**
@@ -1484,7 +1486,7 @@ public:
 
 `IFSG_NORMALS` is equivalent to a VRML2.0 Normals node.
 
-*.ifsg_normals.h*
+.ifsg_normals.h
 [source,c]
 -----
 /**
@@ -1519,7 +1521,7 @@ public:
 
 `IFSG_COLORS` is similar to a VRML2.0 colors[] set.
 
-*.ifsg_colors.h*
+.ifsg_colors.h
 [source,c]
 -----
 /**
@@ -1553,9 +1555,9 @@ public:
 -----
 
 
-The remaining API functions are defined in *ifsg_api.h* as follows:
+The remaining API functions are defined in `ifsg_api.h` as follows:
 
-*.ifsg_api.h*
+.ifsg_api.h
 [source,c]
 -----
 namespace S3D
@@ -1718,5 +1720,5 @@ namespace S3D
 -----
 
 For actual usage examples of the Scenegraph API see the
-Advanced 3D Plugin tutorial above and the KiCad VRML1, VRML2,
+<<advanced-3d-plugin,Advanced 3D Plugin tutorial>> above and the KiCad VRML1, VRML2,
 and X3D parsers.


### PR DESCRIPTION
Very minor editing to improve clarity (some may be subjective, like making file names bold, but it matches the other KiCad documentation I've seen). Gave the two tutorial sections simple but descriptive names instead of nondescript numbers. Fixed a few typos. Removed "shall" which was jarring and out-of-place with the plebian writing style.

Questions:
1. On line 539 I assume there's only one dialog for selection files, but maybe that's wrong?
2. There are references which don't work. Are these in another format and need to be changed to asciidoc? Does anyone know?
3. Different formatting for file names, classes, functions, etc. Maybe this is good, or maybe there's already a standard I haven't found?