### PR TITLE
Initial fix for Issue #403

### DIFF
--- a/src/pl_editor/pl_editor.adoc
+++ b/src/pl_editor/pl_editor.adoc
@@ -42,7 +42,7 @@ may 23, 2015.
 <<<<<
 
 [[introduction-to-pl_editor]]
-== Introduction to *Pl_Editor*
+== Introduction
 
 Pl_Editor is a page layout editor tool to create custom title blocks,
 and frame references.
@@ -50,6 +50,25 @@ and frame references.
 The title block, associated to frame references, and other graphic items
 (logos) is called here a page layout.
 
+Pl_Editor reads or writes page layout description files *.kicad_wks
+(KiCad worksheet).
+
+An internal default page layout description to display the default
+KiCad title block is used until a file is read.
+
+The current page layout description can be written in a **.kicad_wks*
+file, using the S-expression format, which is widely used in KiCad.
+
+This file can be used to show the custom page layout in Eeschema and/or
+Pcbnew.
+
+Pl_Editor is typically invoked from a command line, or from the KiCad
+manager.
+
+From a command line, the syntax is pl_editor <*.kicad_wks file to open>.
+
+[[basic-layout-elements]]
+=== Basic layout elements
 Basic page layout items are:
 
 * *Lines*
@@ -59,54 +78,6 @@ Basic page layout items are:
 * *Texts* (with format symbols, that will be replaced by the actual text,
   like the date, page number...) in Eeschema or Pcbnew.
 
-* *Poly-polygons* (mainly to place logos and special graphic shapes)
-
-* *Bitmaps*.
-
-WARNING: Bitmaps can be plotted only by few plotters (PDF and
-PS only) Therefore, for other plotters, only a bounding box will be
-plotted.
-
-* Items can be repeated, and texts and poly_polygons can be rotated.
-
-[[pl_editor-files]]
-== Pl_Editor files
-
-[[input-file-and-default-title-block]]
-=== Input file and default title block
-
-Pl_Editor reads or writes page layout description files *.kicad_wks
-(KiCad worksheet).
-
-An internal default page layout description to display the default KiCad
-title block is used until a file is read.
-
-[[output-file]]
-=== Output file
-
-The current page layout description can be written in a **.kicad_wks*
-file, using the S-expression format, which is widely used in KiCad.
-
-This file can be used to show the custom page layout in Eeschema and/or
-Pcbnew.
-
-<<<<<
-
-[[theory-of-operations]]
-== Theory of operations
-
-[[basic-page-layout-items-properties]]
-=== Basic page layout items properties:
-
-Basic page layout items are:
-
-* *Lines*
-
-* *Rectangles*
-
-* *Texts* (with format symbols, with will be replaced by the actual
-  text, like the date, page number...) in Eeschema or Pcbnew.
-
 * *Poly-polygons* (mainly to place logos and special graphic shapes).
   These poly polygons are created by **Bitmap2component**, and cannot be
   built inside pl_editor, because it is not possible to create such shapes
@@ -114,7 +85,9 @@ Basic page layout items are:
 
 * *Bitmaps* to place logos.
 
-WARNING: Bitmaps can be plotted only by few plotters: PDF and PS only.
+WARNING: Bitmaps can be plotted only by few plotters (PDF and
+PS only) Therefore, for other plotters, only a bounding box will be
+plotted.
 
 Therefore:
 
@@ -130,8 +103,8 @@ These basic items can be repeated.
 Texts which are repeated accept also an increment value for labels (has
 meaning only if the text is one letter or one digit).
 
-[[coordinates-definition]]
-=== Coordinates definition
+[[coordinates-definition-reference-corners]]
+=== Coordinates defintion and reference corners
 
 Each position, start point and end point of items is always relative to
 a page corner.
@@ -139,9 +112,7 @@ a page corner.
 **This feature ensure you can define a page layout which is not
 dependent on the paper size**.
 
-[[reference-corners-and-coordinates]]
-=== Reference corners and coordinates:
-
+Reference corners:
 image:images/en/page_property_1.png[]
 
 * When the page size is changed, the position of the item, relative to
@@ -155,38 +126,330 @@ has its reference corner.
 
 <<<<<
 
-[[rotation]]
-=== Rotation
+[[pl_editor-interface]]
+== Interface
 
-Items which have a position defined by just one point (texts and
-poly-polygons) can be rotated:
+[[main-screen]]
+=== Main window
 
-Normal: Rotation = 0
+The image below shows the main window of Pl_Editor.
 
-image::images/en/text_noriented.png[scaledwidth="50%"]
+image::images/en/main_window.png[scaledwidth="95%"]
 
-Rotated: Rotation = 20 and 10 degrees.
+The left pane contains the list of basic items.
 
-image::images/en/text_rotated.png[scaledwidth="50%"]
-
-<<<<<
-
-[[repeat-option]]
-=== Repeat option
-
-Items can be repeated:
-
-This is useful to create grid and grid labels.
-
-image::images/en/page_property_2.png[scaledwidth="95%"]]
+The right pane is the item settings editor.
 
 <<<<<
 
-[[texts-and-formats]]
-== Texts and formats
+[[main-window-toolbar]]
+=== Main toolbar
+
+image:images/en/main_toolbar.png[]
+
+The top toolbar allows for easy access to the following commands:
+
+[width="100%",cols="28%,72%",]
+|=======================================================================
+|image:images/icons/pagelayout_new.png[]
+|Select the net list file to be processed.
+
+|image:images/icons/pagelayout_load.png[]
+|Load a page layout description file.
+
+|image:images/icons/save.png[]
+|Save the current page layout description in a .kicad_wks file.
+
+|image:images/icons/sheetset.png[]
+|Display the page size selector and the title block user data editor.
+
+|image:images/icons/print_button.png[]
+|Prints the current page.
+
+|image:images/icons/delete.png[]
+|Delete the currently selected item.
+
+|image:images/icons/undo.png[] image:images/icons/redo.png[]
+|Undo/redo tools.
+
+|image:images/icons/zoom_in.png[] image:images/icons/zoom_out.png[]
+ image:images/icons/zoom_redraw.png[] image:images/icons/zoom_fit_in_page.png[] 
+|Zoom in, out, redraw and auto, respectively.
+
+|image:images/icons/pagelayout_normal_view_mode.png[]
+|Show the page layout in user mode: texts are shown like in Eeschema or Pcbnew:
+text format symbols are replaced by the user texts.
+
+|image:images/icons/pagelayout_special_view_mode.png[]
+|Show the page layout in native mode: texts are displayed "as is", with the
+contained formats, without any replacement.
+
+|image:images/en/set_base_corner.png[width="70%"]
+|Reference corner selection, for coordinates displayed to the status bar.
+
+|image:images/en/set_current_page.png[width="85%"]
+|Selection of the page number (page & or other pages).
+
+This selection has meaning only if some items than have a page option,
+are not shown on all pages (in a schematic for instance, which contains
+more than one page).
+
+|=======================================================================
+
+
+[[status-bar-information]]
+=== Status bar
+
+The status bar is located at the bottom of the Pl_Editor and provides
+useful information to the user.
+
+image::images/en/pl_status_bar.png[scaledwidth="95%"]
+
+Coordinates are *always relative to the corner* selected as
+**reference**.
+
+<<<<<
+
+[[left-window]]
+=== Left window
+
+The left windows shows the list of layout items.
+
+One can select a given item (left clicking on the line) or, when right
+clicking on the line, display a pop up menu.
+
+This menu allows basic operations: add a new item, or delete the
+selected item.
+
+**-> A selected item is also drawn in a different color on draw panel**.
+
+Design tree: the item 19 is selected, and shown in highlighted on the
+draw panel.
+
+image::images/en/project_tree.png[scaledwidth="40%"]
+
+<<<<<
+
+[[right-window]]
+=== Right window
+
+The right window is the edit window.
+
+[width="100%",cols="50%,50%",]
+|=======================================================================
+|image:images/en/property_none.png[width="50%"]
+|image:images/en/property_main.png[width="50%"]
+|=======================================================================
+
+On this dialog you can set the page property and the item property of the
+current item.
+
+<<<<<
+
+Displayed settings depend on the selected item:
+
+[width="100%",cols="50%,50%",]
+|=======================================================================
+|Settings for lines and rectangles
+|Settings for texts
+
+|image:images/en/property_line.png[width="50%"]
+|image:images/en/property_text.png[width="50%"]
+
+|Settings for poly-polygons
+|Setting for bitmaps
+
+|image:images/en/property_polyline.png[width="50%"]
+|image:images/en/property_bitmap.png[width="50%"]
+
+|=======================================================================
+
+<<<<<
+
+[[keyboard-commands]]
+=== Keyboard commands
+
+[width="100%",cols="20%,80%",]
+|==================================================================
+|F1 |Zoom In
+|F2 |Zoom Out
+|F3 |Refresh Display
+|F4 |Move cursor to center of display window
+|Home |Fit footprint into display window
+|Space Bar |Set relative coordinates to the current cursor position
+|Right Arrow |Move cursor right one grid position
+|Left Arrow |Move cursor left one grid position
+|Up Arrow |Move cursor up one grid position
+|Down Arrow |Move cursor down one grid position
+|==================================================================
+
+[[mouse-commands]]
+=== Mouse commands
+
+[width="100%",cols="32%,68%",]
+|============================================================
+|Scroll Wheel |Zoom in and out at the current cursor position
+|Ctrl + Scroll Wheel |Pan right and left
+|Shift + Scroll Wheel |Pan up and down
+|Right Button Click |Open context menu
+|============================================================
+
+[[context-menu]]
+=== Context menu
+
+Displayed by right-clicking the mouse:
+
+* Add Line
+
+* Add Rectangle
+
+* Add Text
+
+* Append Page Layout Descr File
+
+Are commands to add a basic layout item to the current page layout
+description.
+
+* Zoom selection: direct selection of the display zoom.
+
+* Grid selection: direct selection of the grid.
+
+[NOTE]
+====
+_Append Page Layout Descr File_ is intended to add poly polygons to make
+logos.
+
+Because usually a logo it needs hundred of vertices, you cannot create a
+polygon by hand. But you can append a description file, created by
+Bitmap2Component.
+====
+
+[[item-selection]]
+=== Item selection
+
+An item can be selected:
+
+* From the Design tree.
+
+* By Left clicking on it.
+
+* By Right clicking on it (and a pop up menu will be displayed).
+
+When selected, this item is drawn in yellow.
+
+[width="100%",cols="50%,50%",]
+|=======================================================================
+|image:images/edit_line.png[width="70%"]
+|The starting point (image:images/edit_line_start.png[])
+and the ending point (image:images/edit_line_end.png[])
+are highlighted.
+|=======================================================================
+
+When right clicking on the item, a pop-up menu is displayed.
+
+The pop menu options slightly depend on the selection:
+
+[width="100%",cols="34%,33%,33%",]
+|=======================================================================
+|image:images/en/context_line_move_start.png[width="50%"]
+|image:images/en/context_line_move_end.png[width="50%"]
+|image:images/en/context_line_move.png[width="50%"]
+|=======================================================================
+
+<<<<<
+
+If more than one item is found, a menu clarification will be shown, to
+select the item:
+
+image::images/en/dialog_select_element.png[scaledwidth="50%"]
+
+[width="100%",cols="50%,50%",]
+|=======================================================================
+|image:images/drag_element.png[width="70%"]
+|Once selected, the item, or one of its end points, can be moved by
+moving the mouse and placed (right clicking on the mouse).
+|=======================================================================
+
+<<<<<
+
+[[adding-elements]]
+== Adding elements
+
+To add a new item, right click the mouse button when the cursor is on
+the left window or the draw area.
+
+A popup menu is displayed:
+
+Pop up menu in left window
+
+image::images/en/context_createnew.png[scaledwidth="35%"]
+
+Pop up menu in draw area.
+
+image::images/en/context_createnew2.png[scaledwidth="35%"]
+
+
+Lines, rectangles and texts are added just by clicking on the
+corresponding menu item.
+
+Logos must first be created by Bitmap2component, which creates a page
+layout description file.
+
+The Append Page Layout Descr File option append this file, to insert the
+logo (a poly polygon).
+
+[[adding-lines-rectangles]]
+=== Adding lines and rectangles
+
+When clicking on the option, a dialog is opened:
+
+image::images/en/dialog_newline.png[scaledwidth="35%"]
+
+Position of end points, and corner reference can be defined here.
+
+However they can be defined later, from the right window, or by moving
+the item, or one of its end points.
+
+Most of time the corner reference is the same for both points.
+
+If this is not the case, define the corner reference at creation is
+better, because if a corner reference is changed later, the geometry of
+the item will be a bit strange.
+
+When an item is created, if is put in move mode, and you can refine its
+position (this is very useful for texts and small lines or rectangles)
+
+[[adding-text]]
+=== Adding text
+
+Text is created nearly the same as lines and rectangles:
+
+image::images/en/dialog_newtext.png[scaledwidth="35%"]
+
+[[page-1-text]]
+==== Page 1 text
+
+When using Eeschema, the full schematic often uses more than one page.
+
+Usually page layout items are displayed on all pages.
+
+But if a user want some items to be displayed only on page 1, or not on
+page 1, the "page 1 option" this is possible by setting this option:
+
+image:images/en/display_options.png[]
+
+Page 1 option:
+
+* None: no constraint.
+
+* Page 1 only: the items is visible only on page 1.
+
+* Not on page 1: the items is visible on all pages but the page 1.
+
+<<<<<
 
 [[format-symbols]]
-=== Format symbols:
+==== Format symbols
 
 Texts can be simple strings or can include format symbols.
 
@@ -243,7 +506,7 @@ image::images/en/show_fields_codes.png[scaledwidth="70%"]
 <<<<<
 
 [[multi-line-texts]]
-=== Multi-line texts:
+==== Multi-line text
 
 Texts can be multi-line.
 
@@ -265,9 +528,6 @@ Output
 image::images/en/multi_line.png[scaledwidth="65%"]
 
 <<<<<
-
-[[multi-line-texts-in-page-setup-dialog]]
-=== Multi-line texts in Page Setup dialog:
 
 In the page setup dialog, text controls do not accept a multi-line text.
 
@@ -292,33 +552,8 @@ image:images/en/multi_line_3.png[]
 
 <<<<<
 
-[[constraints]]
-== Constraints
-
-[[page-1-constraint]]
-=== Page 1 constraint
-
-When using Eeschema, the full schematic often uses more than one page.
-
-Usually page layout items are displayed on all pages.
-
-But if a user want some items to be displayed only on page 1, or not on
-page 1, the "page 1 option" this is possible by setting this option:
-
-image:images/en/display_options.png[]
-
-Page 1 option:
-
-* None: no constraint.
-
-* Page 1 only: the items is visible only on page 1.
-
-* Not on page 1: the items is visible on all pages but the page 1.
-
-<<<<<
-
 [[text-full-size-constraint]]
-=== Text full size constraint
+==== Full-size text
 
 image:images/en/constraint_options.png[]
 
@@ -360,322 +595,6 @@ image:images/en/block_constraints.png[]
 
 <<<<<
 
-[[invoking-pl_editor]]
-== Invoking Pl_Editor
-
-Pl_Editor is typically invoked from a command line, or from the KiCad
-manager.
-
-From a command line, the syntax is pl_editor <*.kicad_wks file to open>.
-
-[[pl_editor-commands]]
-== Pl_Editor Commands
-
-[[main-screen]]
-=== Main Screen
-
-The image below shows the main window of Pl_Editor.
-
-image::images/en/main_window.png[scaledwidth="95%"]
-
-The left pane contains the list of basic items.
-
-The right pane is the item settings editor.
-
-<<<<<
-
-[[main-window-toolbar]]
-=== Main Window Toolbar
-
-image:images/en/main_toolbar.png[]
-
-The top toolbar allows for easy access to the following commands:
-
-[width="100%",cols="28%,72%",]
-|=======================================================================
-|image:images/icons/pagelayout_new.png[]
-|Select the net list file to be processed.
-
-|image:images/icons/pagelayout_load.png[]
-|Load a page layout description file.
-
-|image:images/icons/save.png[]
-|Save the current page layout description in a .kicad_wks file.
-
-|image:images/icons/sheetset.png[]
-|Display the page size selector and the title block user data editor.
-
-|image:images/icons/print_button.png[]
-|Prints the current page.
-
-|image:images/icons/delete.png[]
-|Delete the currently selected item.
-
-|image:images/icons/undo.png[] image:images/icons/redo.png[]
-|Undo/redo tools.
-
-|image:images/icons/zoom_in.png[] image:images/icons/zoom_out.png[]
- image:images/icons/zoom_redraw.png[] image:images/icons/zoom_fit_in_page.png[] 
-|Zoom in, out, redraw and auto, respectively.
-
-|image:images/icons/pagelayout_normal_view_mode.png[]
-|Show the page layout in user mode: texts are shown like in Eeschema or Pcbnew:
-text format symbols are replaced by the user texts.
-
-|image:images/icons/pagelayout_special_view_mode.png[]
-|Show the page layout in native mode: texts are displayed "as is", with the
-contained formats, without any replacement.
-
-|image:images/en/set_base_corner.png[width="70%"]
-|Reference corner selection, for coordinates displayed to the status bar.
-
-|image:images/en/set_current_page.png[width="85%"]
-|Selection of the page number (page & or other pages).
-
-This selection has meaning only if some items than have a page option,
-are not shown on all pages (in a schematic for instance, which contains
-more than one page).
-
-|=======================================================================
-
-[[commands-in-drawing-area-draw-panel]]
-=== Commands in drawing area (draw panel)
-
-[[keyboard-commands]]
-==== Keyboard Commands
-
-[width="100%",cols="20%,80%",]
-|==================================================================
-|F1 |Zoom In
-|F2 |Zoom Out
-|F3 |Refresh Display
-|F4 |Move cursor to center of display window
-|Home |Fit footprint into display window
-|Space Bar |Set relative coordinates to the current cursor position
-|Right Arrow |Move cursor right one grid position
-|Left Arrow |Move cursor left one grid position
-|Up Arrow |Move cursor up one grid position
-|Down Arrow |Move cursor down one grid position
-|==================================================================
-
-[[mouse-commands]]
-==== Mouse Commands
-
-[width="100%",cols="32%,68%",]
-|============================================================
-|Scroll Wheel |Zoom in and out at the current cursor position
-|Ctrl + Scroll Wheel |Pan right and left
-|Shift + Scroll Wheel |Pan up and down
-|Right Button Click |Open context menu
-|============================================================
-
-[[context-menu]]
-==== Context Menu
-
-Displayed by right-clicking the mouse:
-
-* Add Line
-
-* Add Rectangle
-
-* Add Text
-
-* Append Page Layout Descr File
-
-Are commands to add a basic layout item to the current page layout
-description.
-
-* Zoom selection: direct selection of the display zoom.
-
-* Grid selection: direct selection of the grid.
-
-[NOTE]
-====
-_Append Page Layout Descr File_ is intended to add poly polygons to make
-logos.
-
-Because usually a logo it needs hundred of vertices, you cannot create a
-polygon by hand. But you can append a description file, created by
-Bitmap2Component.
-====
-
-
-[[status-bar-information]]
-=== Status Bar Information
-
-The status bar is located at the bottom of the Pl_Editor and provides
-useful information to the user.
-
-image::images/en/pl_status_bar.png[scaledwidth="95%"]
-
-Coordinates are *always relative to the corner* selected as
-**reference**.
-
-<<<<<
-
-[[left-window]]
-== Left window
-
-The left windows shows the list of layout items.
-
-One can select a given item (left clicking on the line) or, when right
-clicking on the line, display a pop up menu.
-
-This menu allows basic operations: add a new item, or delete the
-selected item.
-
-**-> A selected item is also drawn in a different color on draw panel**.
-
-Design tree: the item 19 is selected, and shown in highlighted on the
-draw panel.
-
-image::images/en/project_tree.png[scaledwidth="40%"]
-
-<<<<<
-
-[[right-window]]
-== Right window
-
-The right window is the edit window.
-
-[width="100%",cols="50%,50%",]
-|=======================================================================
-|image:images/en/property_none.png[width="50%"]
-|image:images/en/property_main.png[width="50%"]
-|=======================================================================
-
-On this dialog you can set the page property and the item property of the
-current item.
-
-<<<<<
-
-Displayed settings depend on the selected item:
-
-[width="100%",cols="50%,50%",]
-|=======================================================================
-|Settings for lines and rectangles
-|Settings for texts
-
-|image:images/en/property_line.png[width="50%"]
-|image:images/en/property_text.png[width="50%"]
-
-|Settings for poly-polygons
-|Setting for bitmaps
-
-|image:images/en/property_polyline.png[width="50%"]
-|image:images/en/property_bitmap.png[width="50%"]
-
-|=======================================================================
-
-<<<<<
-
-[[interactive-edition]]
-== Interactive edition
-
-[[item-selection]]
-=== Item selection
-
-An item can be selected:
-
-* From the Design tree.
-
-* By Left clicking on it.
-
-* By Right clicking on it (and a pop up menu will be displayed).
-
-When selected, this item is drawn in yellow.
-
-[width="100%",cols="50%,50%",]
-|=======================================================================
-|image:images/edit_line.png[width="70%"]
-|The starting point (image:images/edit_line_start.png[])
-and the ending point (image:images/edit_line_end.png[])
-are highlighted.
-|=======================================================================
-
-When right clicking on the item, a pop-up menu is displayed.
-
-The pop menu options slightly depend on the selection:
-
-[width="100%",cols="34%,33%,33%",]
-|=======================================================================
-|image:images/en/context_line_move_start.png[width="50%"]
-|image:images/en/context_line_move_end.png[width="50%"]
-|image:images/en/context_line_move.png[width="50%"]
-|=======================================================================
-
-<<<<<
-
-If more than one item is found, a menu clarification will be shown, to
-select the item:
-
-image::images/en/dialog_select_element.png[scaledwidth="50%"]
-
-[width="100%",cols="50%,50%",]
-|=======================================================================
-|image:images/drag_element.png[width="70%"]
-|Once selected, the item, or one of its end points, can be moved by
-moving the mouse and placed (right clicking on the mouse).
-|=======================================================================
-
-<<<<<
-
-[[item-creation]]
-=== Item creation
-
-To add a new item, right click the mouse button when the cursor is on
-the left window or the draw area.
-
-A popup menu is displayed:
-
-Pop up menu in left window
-
-image::images/en/context_createnew.png[scaledwidth="35%"]
-
-Pop up menu in draw area.
-
-image::images/en/context_createnew2.png[scaledwidth="35%"]
-
-
-Lines, rectangles and texts are added just by clicking on the
-corresponding menu item.
-
-Logos must first be created by Bitmap2component, which creates a page
-layout description file.
-
-The Append Page Layout Descr File option append this file, to insert the
-logo (a poly polygon).
-
-<<<<<
-
-[[adding-lines-rectangles-and-texts]]
-=== Adding lines, rectangles and texts
-
-When clicking on the option, a dialog is opened:
-
-Adding line or rectangle
-
-image::images/en/dialog_newline.png[scaledwidth="35%"]
-
-Adding text
-
-image::images/en/dialog_newtext.png[scaledwidth="35%"]
-
-
-Position of end points, and corner reference can be defined here.
-
-However they can be defined later, from the right window, or by moving
-the item, or one of its end points.
-
-Most of time the corner reference is the same for both points.
-
-If this is not the case, define the corner reference at creation is
-better, because if a corner reference is changed later, the geometry of
-the item will be a bit strange.
-
-When an item is created, if is put in move mode, and you can refine its
-position (this is very useful for texts and small lines or rectangles)
-
 [[adding-logos]]
 === Adding logos
 
@@ -711,3 +630,29 @@ You can add an image bitmap using most of bitmap formats (PNG, JPEG, BMP
   and can have a noticeable draw or plot time.
 
 A bitmap can be repeated, **but not rotated**.
+
+
+[[rotation]]
+=== Rotating elements
+
+Items which have a position defined by just one point (texts and
+poly-polygons) can be rotated:
+
+Normal: Rotation = 0
+
+image::images/en/text_noriented.png[scaledwidth="50%"]
+
+Rotated: Rotation = 20 and 10 degrees.
+
+image::images/en/text_rotated.png[scaledwidth="50%"]
+
+<<<<<
+
+[[repeat-option]]
+=== Repeating elements
+
+Items can be repeated:
+
+This is useful to create grid and grid labels.
+
+image::images/en/page_property_2.png[scaledwidth="95%"]


### PR DESCRIPTION
Moved and re-named sections without changing content; fixed link for page_property_2.png image.

Recall that, like PR #407 , only the section names and section flow should be reviewed now. I've made no effort to change the content of sections, but I will embark on that next with the goal being to avoid changing text (for translation reasons) where possible. Right now, just look at the sections and other patches will be submitted for content later before the PR is ready to merge.

My thoughts/questions:
1. Is the "Basic layout elements" section helpful? I don't think so. Any unique information could be moved to the relevant section for that element type at the bottom.
2. I question if the "Context menu" section has any value to learning/using Pl Editor.
3. Under the "Adding elements" section, should the main subsections start with "Adding" as well?
4. Rotating is so common and simple that I'm not sure it has any benefit. Repeating is a nice tip, at least, but the rotation section seems superfluous to me.