### PR TITLE
Added word internationalization

### DIFF
--- a/src/getting_started_in_kicad/getting_started_in_kicad.adoc
+++ b/src/getting_started_in_kicad/getting_started_in_kicad.adoc
@@ -34,7 +34,7 @@ Please direct any bug reports, suggestions or new versions to here:
 
 - About KiCad software: https://bugs.launchpad.net/kicad
 
-- About KiCad software i18n: https://github.com/KiCad/kicad-i18n/issues
+- About KiCad software internationalization (i18n): https://github.com/KiCad/kicad-i18n/issues
 
 [[publication_date]]
 *Publication date*


### PR DESCRIPTION
The term i18n is not a general usage term and being this is the getting started guide, I added the full word to make it more readable.