### PR TITLE
small fixup for gui translation howto and adding German translation

### DIFF
--- a/src/gui_translation_howto/gui_translation_howto.adoc
+++ b/src/gui_translation_howto/gui_translation_howto.adoc
@@ -77,7 +77,7 @@ Files can be downloaded from Launchpad by using a tool named "bazaar"
 * Download KiCad sources using the command bzr branch lp:kicad
   <directory where sources files are copied>
 
-* You'll find this doc about translation and poedit configuration in
+* You'll find this doc about translation and PoEdit configuration in
   Documentation on http://docs.kicad-pcb.org/en/gui_translation_howto.html
 
 [[_download_existing_translations_and_docs]]
@@ -110,8 +110,8 @@ The rules are:
   language).
 
 The easier way to create and maintain the dictionary English->locale is
-to use, **poedit**. Poedit scans KiCad sources and allows you to enter
-translations. You must download KiCad sources and set poedit in order to
+to use, **poedit**. PoEdit scans KiCad sources and allows you to enter
+translations. You must download KiCad sources and set PoEdit in order to
 create translations.
 
 [[_kicad_tree_for_translations]]
@@ -188,7 +188,7 @@ found):
 In each directory there are 2 files **kicad/internat/xx**:
 
 * internat.po (the dictionary file
-* internat.mo (the poedit work file)
+* internat.mo (the PoEdit work file)
 
 [[_using_poedit]]
 == Using poedit
@@ -196,7 +196,7 @@ In each directory there are 2 files **kicad/internat/xx**:
 [[_installation]]
 === Installation
 
-Download and install poedit (https://www.poedit.net). Poedit exists on
+Download and install PoEdit (https://www.poedit.net). PoEdit exists on
 Windows, Linux and Mac OS X.
 
 Download and unzip KiCad sources.
@@ -214,7 +214,7 @@ One must add in KiCad the suitable directory for the dictionary
 **kicad/share/internat/fr**.
 
 [[_poedit_configuration]]
-=== Poedit Configuration
+=== PoEdit Configuration
 
 Run poedit.
 
@@ -257,7 +257,7 @@ Save the new projet in *kicad/share/internat/xx* with the name
 [[_create_or_edit_a_dictionary]]
 == Create or edit a dictionary
 
-Run poedit and load a project (here: **kicad.po**).
+Run PoEdit and load a project (here: **kicad.po**).
 
 image:images/poedit-settings-dict.png[images/poedit-settings-dict.png]
 

--- a/src/gui_translation_howto/gui_translation_howto.adoc
+++ b/src/gui_translation_howto/gui_translation_howto.adoc
@@ -12,9 +12,9 @@ _Reference manual_
 
 This document is Copyright (C) 2010-2015 by it's contributors as listed
 below. You may distribute it and/or modify it under the terms of either
-the GNU General Public License (http://www.gnu.org/licenses/gpl.html),
+the GNU General Public License (https://www.gnu.org/licenses/gpl.html),
 version 3 or later, or the Creative Commons Attribution License
-(http://creativecommons.org/licenses/by/3.0/), version 3.0 or later.
+(https://creativecommons.org/licenses/by/3.0/), version 3.0 or later.
 
 All trademarks within this guide belong to their legitimate owners.
 
@@ -59,7 +59,7 @@ MacOSX.
 [[_download_poedit]]
 === Download PoEdit
 
-See: http://www.poedit.net/
+See: https://www.poedit.net/
 
 [[_downloading_kicad_sources]]
 === Downloading KiCad sources
@@ -72,7 +72,7 @@ Files can be downloaded from Launchpad by using a tool named "bazaar"
 (bzr in commands). So:
 
 * Install, if not already done, the tool named bazaar (easy to install
-  under all platforms): see http://bazaar.canonical.com/
+  under all platforms): see https://bazaar.canonical.com/
 
 * Download KiCad sources using the command bzr branch lp:kicad
   <directory where sources files are copied>
@@ -196,7 +196,7 @@ In each directory there are 2 files **kicad/internat/xx**:
 [[_installation]]
 === Installation
 
-Download and install poedit (http://www.poedit.net). Poedit exists on
+Download and install poedit (https://www.poedit.net). Poedit exists on
 Windows, Linux and Mac OS X.
 
 Download and unzip KiCad sources.
@@ -270,7 +270,7 @@ window.
 == Adding a new language entry in KiCad source code (devs only)
 
 This step in NOT required. It is useful only for developers, and for
-testing purpose only
+testing purpose only.
 
 In KiCad we can force the used language.
 

--- a/src/gui_translation_howto/po/addendum.de
+++ b/src/gui_translation_howto/po/addendum.de
@@ -1,0 +1,7 @@
+PO4A-HEADER: mode=after; position=^\[\[contributors\]\]; beginboundary=\[\[
+[[translation]]
+*Übersetzung*
+
+//Translators put your names below here in the addendum file
+Carsten Schönert <c.schoenert@t-online.de>, 2016.
+

--- a/src/gui_translation_howto/po/de.po
+++ b/src/gui_translation_howto/po/de.po
@@ -1,0 +1,1078 @@
+# KiCad Manual German translation
+# Copyright (C) 2016 The KiCad documentation Team
+# This file is distributed under the same license as the KiCad documentation package.
+# Carsten Schoenert <c.schoenert@t-online.de>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: KiCad GUI Translation HOWTO\n"
+"PO-Revision-Date: \n"
+"Last-Translator: Carsten Schoenert <c.schoenert@t-online.de>\n"
+"Language-Team: \n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.9\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"POT-Creation-Date: \n"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:6
+#, no-wrap
+msgid "GUI Translation HOWTO"
+msgstr "GUI Translation HOWTO"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:9
+msgid "_Reference manual_"
+msgstr "_Referenz Handbuch_"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:12
+#, no-wrap
+msgid "*Copyright*\n"
+msgstr "*Copyright*\n"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:18
+msgid ""
+"This document is Copyright (C) 2010-2015 by it's contributors as listed "
+"below. You may distribute it and/or modify it under the terms of either the "
+"GNU General Public License (https://www.gnu.org/licenses/gpl.html), version "
+"3 or later, or the Creative Commons Attribution License (https://"
+"creativecommons.org/licenses/by/3.0/), version 3.0 or later."
+msgstr ""
+"Dieses Dokument ist geschützt (C) 2010-2015 durch deren Beitragende welche "
+"nachfolgend aufgeführt sind. Sie können es nach den Bedingungen der GNU "
+"General Public License (https://www.gnu.org/licenses/gpl.html), Version 3 "
+"oder später, oder der Creative Commons Attribution License (https://"
+"creativecommons.org/licenses/by/3.0/), Version 3.0 oder später verteilen "
+"oder verändern ."
+
+#. type: Plain text
+#: gui_translation_howto.adoc:20
+msgid "All trademarks within this guide belong to their legitimate owners."
+msgstr ""
+"Alle Markenrechtsnamen in diesem Guide gehören den rechtmäßigen Eigentümern."
+
+#. type: Plain text
+#: gui_translation_howto.adoc:23
+#, no-wrap
+msgid "*Contributors*\n"
+msgstr "*Beitragende*\n"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:25
+msgid "Jean-Pierre Charras, Fabrizio Tappero, Wayne Stambaugh."
+msgstr "Jean-Pierre Charras, Fabrizio Tappero, Wayne Stambaugh."
+
+#. type: Plain text
+#: gui_translation_howto.adoc:28
+#, no-wrap
+msgid "*Feedback*\n"
+msgstr "*Feedback*\n"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:30
+msgid "Please direct any bug reports, suggestions or new versions to here:"
+msgstr ""
+"Bitte alle Bug Reports, Vorschläge oder neue Versionen an folgende Adressen "
+"richten:"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:32
+msgid "About KiCad document: https://github.com/KiCad/kicad-doc/issues"
+msgstr "Zum KiCad-Dokument: https://github.com/KiCad/kicad-doc/issues"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:34
+msgid "About KiCad software: https://bugs.launchpad.net/kicad"
+msgstr "KiCad Software: https://bugs.launchpad.net/kicad"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:36
+msgid "About KiCad software i18n: https://github.com/KiCad/kicad-i18n/issues"
+msgstr ""
+"KiCad Software i18n Übersetzung: https://github.com/KiCad/kicad-i18n/issues"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:40
+#, no-wrap
+msgid "*Publication date and software version*\n"
+msgstr "*Datum der Veröffenlichung und Software-Version*\n"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:42
+msgid "Published on October 15, 2015."
+msgstr "Veröffentlicht am 15. October 2015."
+
+#. Since docbook "article" is more compact, I have to separate this page
+#. type: Plain text
+#: gui_translation_howto.adoc:45
+msgid "<<<<"
+msgstr "<<<<"
+
+#. type: Title ==
+#: gui_translation_howto.adoc:47
+#, no-wrap
+msgid "Needed files and tools"
+msgstr "Benötigte Dateien und Tools"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:51
+msgid ""
+"Creating and/or maintaining translations do not need any skill in C++ "
+"programming: *there is no change to do in KiCad files.*"
+msgstr ""
+"Zum Erstellen und/oder Bearbeiten der Übersetzungen werden keine C++ "
+"Programmierfähigkeiten benötigt: *Es sind keine Veränderungen in den KiCad "
+"Quelltextdateien nötig.*"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:58
+msgid ""
+"Translations are easy to do with a tool *PoEdit* that locate (in KiCad "
+"sources) sentences to translate and is able to create a dictionary for KiCad "
+"from translations created with this tool. So you need to install PoEdit, and "
+"get latest KiCad sources, and, for existing translations, get latest "
+"translations. Translations can be made under Linux, Window or MacOSX."
+msgstr ""
+"Übersetzungen können mit dem Tool *PoEdit* einfach bearbeitet werden. Dieses "
+"Tool sucht (im KiCad Quelltext) nach Abschnitten die übersetzt werden können "
+"und erstellt daraus einen Katalog mit den original Zeichenketten und den "
+"zugehörigen Übersetzungen. Für eine Mitarbeit an den Übersetzungen benötigen "
+"Sie PoEdit, den aktuellen KiCad Quelltext, und für die existierenden "
+"Übersetzungen den aktuellen Stand der Übersetzungen. Übersetzungen können "
+"unter Windows, Linux oder auch MacOS bearbeitet werden."
+
+#. type: Title ===
+#: gui_translation_howto.adoc:60
+#, no-wrap
+msgid "Download PoEdit"
+msgstr "PoEdit herunterladen"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:63
+msgid "See: https://www.poedit.net/"
+msgstr "Besuchen Sie die Webseite: https://www.poedit.net/"
+
+#. type: Title ===
+#: gui_translation_howto.adoc:65
+#, no-wrap
+msgid "Downloading KiCad sources"
+msgstr " KiCad Quellen herunterladen"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:68
+msgid "KiCad sources are currently hosted on Launchpad:"
+msgstr "Die KiCad Quellen sind aktuell auf Launchpad gehostet:"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:70
+msgid "https://launchpad.net/kicad"
+msgstr "https://launchpad.net/kicad"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:73
+msgid ""
+"Files can be downloaded from Launchpad by using a tool named \"bazaar\" (bzr "
+"in commands). So:"
+msgstr ""
+"Die Dateien können von Launchpad unter Verwendung des Tools \"Bazaar\" "
+"herunter geladen werden:"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:76
+msgid ""
+"Install, if not already done, the tool named bazaar (easy to install under "
+"all platforms): see https://bazaar.canonical.com/"
+msgstr ""
+"Sofern nicht schon erfolgt laden und installieren Sie das Tool Bazaar, "
+"dieses ist für Windows, Linux und MacOS erhältlich. Siehe https://bazaar."
+"canonical.com/"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:79
+msgid ""
+"Download KiCad sources using the command bzr branch lp:kicad <directory "
+"where sources files are copied>"
+msgstr ""
+"Herunterladen der KiCad Quellen mit dem Kommando 'bzr branch lp:kicad "
+"<Verzeichnis wo die Dateien abgelegt werden sollen>'"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:82
+msgid ""
+"You'll find this doc about translation and PoEdit configuration in "
+"Documentation on http://docs.kicad-pcb.org/en/gui_translation_howto.html"
+msgstr ""
+"Sie finden dieses Dokument über Übersetzungen und PoEdit Konfiguration auf "
+"der Webseite http://docs.kicad-pcb.org/de/gui_translation_howto.html"
+
+#. type: Title ===
+#: gui_translation_howto.adoc:84
+#, no-wrap
+msgid "Download existing translations and docs"
+msgstr "Existierenden Übersetzungen und Dokumente herunterladen"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:88
+msgid ""
+"KiCad translations and documentations are also hosted on github at: https://"
+"github.com/KiCad/kicad-i18n/"
+msgstr ""
+"KiCad Übersetzungen und Dokumentationen sind ebenso auf GitHub abgelegt: "
+"https://github.com/KiCad/kicad-i18n/"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:90
+msgid "Download translations using command:"
+msgstr "Herunterladen der Übersetzungen mit dem folgenden Kommando:"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:92
+#, no-wrap
+msgid "  git clone https://github.com/KiCad/kicad-i18n.git\n"
+msgstr "  git clone https://github.com/KiCad/kicad-i18n.git\n"
+
+#. type: Title ==
+#: gui_translation_howto.adoc:94
+#, no-wrap
+msgid "Find sentences to translate"
+msgstr "Auffinden von zu übersetzenden Abschnitten"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:100
+msgid ""
+"The different menus and tool tips in KiCad are internationalized, and can be "
+"easily translated into a local language __without source code "
+"modifications__."
+msgstr ""
+"Die verschiedenen Menüs und Tooltipps sind internationalisiert und können "
+"einfach __ohne Quelltextveränderungen__ in eine lokale Sprache übersetzt "
+"werden."
+
+#. type: Plain text
+#: gui_translation_howto.adoc:102
+msgid "The rules are:"
+msgstr "Es gelten folgende Regeln:"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:104
+msgid "They are written in English."
+msgstr "Die Originalzeichenkette ist in Englisch verfasst."
+
+#. type: Plain text
+#: gui_translation_howto.adoc:108
+msgid ""
+"All strings which must be translated are written like: **_(\"hello world"
+"\")**, and displayed \"hello world\" but if a dictionary is found translated "
+"into the locale language before displaying."
+msgstr ""
+"Alle Zeichenketten die übersetzt werden können sind in der Art **_(\"hello "
+"world\")** erstellt, diese werden dann als \"hello world\" angezeigt. Wird "
+"ein zugehöriger Wörterbucheintrag gefunden wird dieser anstatt der "
+"Originalzeichenkette verwendet."
+
+#. type: Plain text
+#: gui_translation_howto.adoc:111
+msgid ""
+"A dictionary English->locale handle translation (one dictionary by language)."
+msgstr ""
+"Es wird ein Wörterbuch Englisch - lokale Sprache für die Übersetzungen "
+"verwendet (ein Wörterbuch pro Sprache)."
+
+#. type: Plain text
+#: gui_translation_howto.adoc:116
+msgid ""
+"The easier way to create and maintain the dictionary English->locale is to "
+"use, **poedit**. PoEdit scans KiCad sources and allows you to enter "
+"translations. You must download KiCad sources and set PoEdit in order to "
+"create translations."
+msgstr ""
+"Ein einfacher Weg um das Wörterbuch Englisch - lokale Sprache zu bearbeiten "
+"ist das Tool **PoEdit**. PoEdit durchsucht die KiCad Quellen und erlaubt es "
+"Ihnen die Übersetzungen einzutragen. Die KiCad Quellen müssen vorhanden "
+"sein, ebenso muss PoEdit eingerichtet sein um die Übersetzungen bearbeiteten "
+"zu können."
+
+#. type: Title ==
+#: gui_translation_howto.adoc:118
+#, no-wrap
+msgid "KiCad tree for translations"
+msgstr "KiCad Verzeichnisbaum für Übersetzungen"
+
+#. type: Title ===
+#: gui_translation_howto.adoc:121
+#, no-wrap
+msgid "Dictionary tree"
+msgstr "Wörterbuch Baum"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:124
+msgid "The dictionary will be found by KiCad only if it is in a suitable path:"
+msgstr ""
+"Das Wörterbuch wird von KiCad nur gefunden wenn es in einem geeigneten "
+"Ordner abgelegt ist:"
+
+#. type: delimited block |
+#: gui_translation_howto.adoc:128
+#, no-wrap
+msgid ""
+"|image:images/i18n-tree.png[images/i18n-tree.png] a|\n"
+"The suitable path is **kicad/internat/xx**,\n"
+msgstr ""
+"|image:images/i18n-tree.png[images/i18n-tree.png] a|\n"
+"Der zugehörige Ordner ist **kicad/internat/xx**,\n"
+
+#. type: delimited block |
+#: gui_translation_howto.adoc:130
+#, no-wrap
+msgid "or *kicad/internat/xx_yy*\n"
+msgstr "oder *kicad/internat/xx_yy*\n"
+
+#. type: delimited block |
+#: gui_translation_howto.adoc:132
+#, no-wrap
+msgid "with: *xx* = normalised locale indicator (short form) like:\n"
+msgstr "mit: *xx* = normalisierter LANG Indikator (Kurzform) wie z.B.:\n"
+
+#. type: delimited block |
+#: gui_translation_howto.adoc:137
+#, no-wrap
+msgid ""
+"* fr = france\n"
+"* en = english\n"
+"* es = spanish\n"
+"* pt = portuguese\n"
+msgstr ""
+"* fr = französisch\n"
+"* en = englisch\n"
+"* es = spanisch\n"
+"* pt = portugiesisch\n"
+
+#. type: delimited block |
+#: gui_translation_howto.adoc:139
+#, no-wrap
+msgid "or: *xx_yy* = normalized locale indicator (long form) like:\n"
+msgstr "oder: *xx_yy* = normalisierter LANG_COUNTRY Indikator (Langform) wie z.B.:\n"
+
+#. type: delimited block |
+#: gui_translation_howto.adoc:143
+#, no-wrap
+msgid ""
+"* fr_FR\n"
+"* en_GB\n"
+"* en_US\n"
+msgstr ""
+"* fr_FR = französisch Frankreich\n"
+"* en_GB = englisch Großbritannien\n"
+"* en_US = englisch USA\n"
+"* de_CH = deutsch Schweiz\n"
+"\n"
+
+#. type: Title ===
+#: gui_translation_howto.adoc:147
+#, no-wrap
+msgid "Search path"
+msgstr "Suchpfad"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:150
+msgid "Dictionaries and on-line help files are searched in this order:"
+msgstr ""
+"Wörterbücher und OnLine Hilfedateien werden in dieser Reihenfolge gesucht:"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:153
+msgid ""
+"In the path in normalized locale indicator (long form)  (kicad/internat/"
+"xx_yy)"
+msgstr ""
+"Im Ordner mit normalisierter locale Indikation (Langform) (kicad/internat/"
+"xx_yy)"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:156
+msgid ""
+"In the path in normalized locale indicator (short form)  (kicad/internat/xx)"
+msgstr ""
+"Im Ordner mit normalisierter locale Indikation (Kurzform) (kicad/internat/xx)"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:158
+msgid "And for on-line help files search is made in:"
+msgstr "Für die OnLine Hilfe Dateien wird in folgenden Ordner gesucht:"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:161
+msgid ""
+"In the path in normalized locale indicator (long form)  (kicad/help/xx_yy)"
+msgstr ""
+"Im Ordner mit normalisierter locale Indikation (Langform) (kicad/help/xx_yy)"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:164
+msgid ""
+"In the path in normalized locale indicator (short form)  (kicad/help/xx)"
+msgstr ""
+"Im Ordner mit normalisierter locale Indikation (Kurzform) (kicad/help/xx)"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:166
+msgid "kicad/help/en"
+msgstr "kicad/help/en"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:168
+msgid "kicad/help/fr"
+msgstr "kicad/help/fr"
+
+#. type: delimited block =
+#: gui_translation_howto.adoc:173
+msgid ""
+"The main KiCad path in retrieved from the binary path, or (if not found):"
+msgstr ""
+"Der KiCad Hauptordner für Übersetzungen wird aus dem Ordner in dem das KiCad "
+"Programm liegt gebildet, oder (wenn nicht gefunden):"
+
+#. type: Block title
+#: gui_translation_howto.adoc:174
+#, no-wrap
+msgid "under windows:"
+msgstr "in Windows:"
+
+#. type: delimited block =
+#: gui_translation_howto.adoc:176
+msgid "c:\\kicad"
+msgstr "c:\\kicad"
+
+#. type: delimited block =
+#: gui_translation_howto.adoc:177
+msgid "d:\\kicad"
+msgstr "d:\\kicad"
+
+#. type: delimited block =
+#: gui_translation_howto.adoc:178
+msgid "c:\\Program Files\\kicad"
+msgstr "c:\\Program Files\\kicad"
+
+#. type: Block title
+#: gui_translation_howto.adoc:179
+#, no-wrap
+msgid "under linux:"
+msgstr "in Linux"
+
+#. type: delimited block =
+#: gui_translation_howto.adoc:181
+msgid "/usr/share/kicad"
+msgstr "/usr/share/kicad"
+
+#. type: delimited block =
+#: gui_translation_howto.adoc:182
+msgid "/usr/local/share/kicad"
+msgstr "/usr/local/share/kicad"
+
+#. type: delimited block =
+#: gui_translation_howto.adoc:183
+msgid "/usr/local/kicad/share/kicad"
+msgstr "/usr/local/kicad/share/kicad"
+
+#. type: delimited block =
+#: gui_translation_howto.adoc:184
+msgid "/usr/local/kicad"
+msgstr "/usr/local/kicad"
+
+#. type: Title ===
+#: gui_translation_howto.adoc:186
+#, no-wrap
+msgid "Files"
+msgstr "Dateien"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:189
+msgid "In each directory there are 2 files **kicad/internat/xx**:"
+msgstr "In jedem Ordner **kicad/internat/xx** sind zwei Dateien vorhanden :"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:191
+msgid "internat.po (the dictionary file"
+msgstr ""
+"internat.po, dies ist die Wörterbuchdatei die PoEdit zum Bearbeiten benutzt"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:192
+msgid "internat.mo (the PoEdit work file)"
+msgstr ""
+"internat.mo, dies ist die kompilierte *.po Arbeitsdatei welche von KiCad "
+"Programm später verwendet wird"
+
+#. type: Title ==
+#: gui_translation_howto.adoc:194
+#, no-wrap
+msgid "Using poedit"
+msgstr "PoEdit benutzen"
+
+#. type: Title ===
+#: gui_translation_howto.adoc:197
+#, no-wrap
+msgid "Installation"
+msgstr "Installation"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:201
+msgid ""
+"Download and install PoEdit (https://www.poedit.net). PoEdit exists on "
+"Windows, Linux and Mac OS X."
+msgstr ""
+"Herunterladen und Installieren von PoEdit (https://www.poedit.net). PoEdit "
+"ist erhältlich für Windows, Linux und Mac OS X."
+
+#. type: Plain text
+#: gui_translation_howto.adoc:203
+msgid "Download and unzip KiCad sources."
+msgstr "Herunterladen und entpacken der KiCad Quellen."
+
+#. type: Title ===
+#: gui_translation_howto.adoc:205
+#, no-wrap
+msgid "KiCad preparation"
+msgstr "KiCad Vorbereitungen"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:209
+msgid ""
+"KiCad sources: in this example files are in f:/kicad/. All the strings to "
+"translate are tagged like **_(\"string to translate\")**."
+msgstr ""
+"KiCad Quellen: In diesem Beispiel sind die Dateien in f:/kicad/. Alle "
+"Zeichenketten die übersetzt werdne können sind markiert wie z.B. "
+"**_(\"string to translate\")**."
+
+#. type: Plain text
+#: gui_translation_howto.adoc:211
+msgid "poedit must search the _ (underscore) symbol to locate these strings."
+msgstr ""
+"PoEdit muss nach dem Zeichen _ (Unterstrich) suchen um diese Zeichenketten "
+"zu erkennen."
+
+#. type: Plain text
+#: gui_translation_howto.adoc:215
+msgid ""
+"One must add in KiCad the suitable directory for the dictionary (**kicad/"
+"share/internat/xx**). In this example, the directory is **kicad/share/"
+"internat/fr**."
+msgstr ""
+"In KiCad muss das passende Verzeichnis für das Wörterbuch (**kicad/share/"
+"internat/xx**) hinzugefügt werden. In diesem Beispiel ist das Verzeichnis "
+"**kicad/share/internat/fr**."
+
+#. type: Title ===
+#: gui_translation_howto.adoc:217
+#, no-wrap
+msgid "PoEdit Configuration"
+msgstr "PoEdit Konfiguration"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:220
+msgid "Run poedit."
+msgstr "PoEdit starten."
+
+#. type: Plain text
+#: gui_translation_howto.adoc:222
+msgid "Run File/New catalog..."
+msgstr "Aufrufen von 'Datei -> Neu ...'"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:224
+msgid "You should see something like:"
+msgstr "Es sollte folgendes zu sehen sein:"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:226
+msgid "image:images/poedit-settings.png[images/poedit-settings.png]"
+msgstr "image:images/poedit-settings.png[images/poedit-settings.png]"
+
+#. type: Title ===
+#: gui_translation_howto.adoc:228
+#, no-wrap
+msgid "Project Configuration"
+msgstr "Projekt Konfiguration"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:231
+msgid "image:images/poedit-settings-fr.png[images/poedit-settings-fr.png]"
+msgstr "image:images/poedit-settings-fr.png[images/poedit-settings-fr.png]"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:234
+msgid ""
+"The source files are in English, so no need to choose something for source "
+"code."
+msgstr ""
+"Die Quellen sind in Englisch, es muss daher nichts für den Quelltext "
+"ausgewählt werden."
+
+#. type: Title ===
+#: gui_translation_howto.adoc:236
+#, no-wrap
+msgid "Path and files Configuration"
+msgstr "Ordner und Datei Konfiguration"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:239
+msgid ""
+"image:images/poedit-settings-paths.png[images/poedit-settings-paths.png]"
+msgstr ""
+"image:images/poedit-settings-paths.png[images/poedit-settings-paths.png]"
+
+#. type: Title ===
+#: gui_translation_howto.adoc:241
+#, no-wrap
+msgid "Keyword Configuration"
+msgstr "Schlüsselwort Konfiguration"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:244
+msgid ""
+"image:images/poedit-settings-keywords.png[images/poedit-settings-keywords."
+"png]"
+msgstr ""
+"image:images/poedit-settings-keywords.png[images/poedit-settings-keywords."
+"png]"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:246
+msgid "A couple of keywords to enter here:"
+msgstr "Es sind einige Schlüsselwörter hier einzutragen:"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:248
+msgid "_ (underscore) used as tag in generic source files"
+msgstr ""
+"_ (Unterstrich) wird als Tag in den generischen Quelltext Dateien benutzt"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:250
+msgid "_HKI used as a tag for the hotkeys description translation."
+msgstr ""
+"_HKI wird als Tag für die Beschreibungen der Hotkey Übersetzungen benutzt"
+
+#. type: Title ===
+#: gui_translation_howto.adoc:252
+#, no-wrap
+msgid "Save the project"
+msgstr "Abspeichern des Projektes"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:256
+msgid ""
+"Save the new projet in *kicad/share/internat/xx* with the name **kicad.po**."
+msgstr ""
+"Speichern Sie das Projekt in *kicad/share/internat/xx* mit dem Namen **kicad."
+"po**."
+
+#. type: Title ==
+#: gui_translation_howto.adoc:258
+#, no-wrap
+msgid "Create or edit a dictionary"
+msgstr "Erstellen oder Bearbeiten eines Wörterbuches"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:261
+msgid "Run PoEdit and load a project (here: **kicad.po**)."
+msgstr "Starten Sie PoEdit und laden Sie ein Projekt (hier **kicad.po**)."
+
+#. type: Plain text
+#: gui_translation_howto.adoc:263
+msgid "image:images/poedit-settings-dict.png[images/poedit-settings-dict.png]"
+msgstr "image:images/poedit-settings-dict.png[images/poedit-settings-dict.png]"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:265
+msgid "Run the command **Catalog/update from sources**."
+msgstr "Ausführen des Kommandos **Katalog -> Aus Quellen aktualisieren**."
+
+#. type: Plain text
+#: gui_translation_howto.adoc:268
+msgid ""
+"New strings (not yet translated) will be displayed on the top of the window."
+msgstr ""
+"Neue (noch  nicht übersetzte) Zeichenketten werden im oberen Teil des "
+"Fensters angezeigt."
+
+#. type: Title ==
+#: gui_translation_howto.adoc:270
+#, no-wrap
+msgid "Adding a new language entry in KiCad source code (devs only)"
+msgstr "Hinzufügen einer neuen Sprache in den KiCad Quellen (für Entwickler)"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:274
+msgid ""
+"This step in NOT required. It is useful only for developers, and for testing "
+"purpose only."
+msgstr ""
+"Dieser Schritt ist normaler Weise *nicht* notwendig. Er ist nur sinnvoll für "
+"Entwickler und für Testzwecke."
+
+#. type: Plain text
+#: gui_translation_howto.adoc:276
+msgid "In KiCad we can force the used language."
+msgstr "In KiCad kann die zu verwendete Sprache festgelegt werden."
+
+#. type: Plain text
+#: gui_translation_howto.adoc:278
+msgid "It is highly recommended to use the default language."
+msgstr ""
+"Es wird empfohlen die Standardsprache des verwendeten Betriebssystems zu "
+"benutzen."
+
+#. type: Plain text
+#: gui_translation_howto.adoc:281
+msgid ""
+"image:images/kicad-settings-language.png[images/kicad-settings-language.png]"
+msgstr ""
+"image:images/kicad-settings-language.png[images/kicad-settings-language.png]"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:284
+msgid ""
+"But because developers have to test translations, a new entry in the "
+"language list can be useful for testing purposes."
+msgstr ""
+"Da aber Entwickler Übersetzungen überprüfen wollen kann ein neuer Eintrag "
+"für eine Sprache sehr nützlich für Testzwecke sein."
+
+#. type: Title ===
+#: gui_translation_howto.adoc:286
+#, no-wrap
+msgid "Steps"
+msgstr "Ausführungsschritte"
+
+#. type: Title ====
+#: gui_translation_howto.adoc:289
+#, no-wrap
+msgid "Adding a new id in include/id.h."
+msgstr "Hinzufügen einer neuen ID in 'include/id.h'"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:293
+msgid "-> In include/id.h, locate the sequence like:"
+msgstr "-> In 'include/id.h', suchen der Sequenz:"
+
+#. type: delimited block -
+#: gui_translation_howto.adoc:303
+#, no-wrap
+msgid ""
+"ID_LANGUAGE_CHOICE,\n"
+"ID_LANGUAGE_DEFAULT,\n"
+"ID_LANGUAGE_ENGLISH,\n"
+"ID_LANGUAGE_FRENCH,\n"
+"ID_LANGUAGE_SPANISH,\n"
+"ID_LANGUAGE_GERMAN,\n"
+"ID_LANGUAGE_RUSSIAN,\n"
+"ID_LANGUAGE_PORTUGUESE,\n"
+msgstr ""
+"ID_LANGUAGE_CHOICE,\n"
+"ID_LANGUAGE_DEFAULT,\n"
+"ID_LANGUAGE_ENGLISH,\n"
+"ID_LANGUAGE_FRENCH,\n"
+"ID_LANGUAGE_SPANISH,\n"
+"ID_LANGUAGE_GERMAN,\n"
+"ID_LANGUAGE_RUSSIAN,\n"
+"ID_LANGUAGE_PORTUGUESE,\n"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:306
+msgid "and add a new entry in list (which will be used later in menus) like:"
+msgstr ""
+"Hinzufügen eines neuen Eintrages in die Liste (welcher später in den Menüs "
+"verwendet wird):"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:308
+msgid "ID_LANGUAGE_MY_LANGUAGE before ID_LANGUAGE_CHOICE_END."
+msgstr "ID_LANGUAGE_MY_LANGUAGE vor ID_LANGUAGE_CHOICE_END."
+
+#. type: Title ====
+#: gui_translation_howto.adoc:310
+#, no-wrap
+msgid "Adding a new icon (aesthetic purpose only)"
+msgstr "Hinzufügen eines neuen Icons (nur aus ästhetischen Gründen)"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:315
+msgid ""
+"-> Create a new icon in SVG (Using Inkscape for instance) format: usually "
+"the country flag. For instance lang_new.svg"
+msgstr ""
+"-> Erstellen eines neuen Icons im SVG Format (durch Inkscape z.B.): üblicher "
+"Weise eine Landesflagge. Zum Beispiel lang_new.svg"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:317
+msgid "Others language icons are in `common/bitmaps_png/source`"
+msgstr ""
+"Andere Icons für die Sprachen sind in `common/bitmaps_png/source` abgelegt"
+
+#. type: Title ====
+#: gui_translation_howto.adoc:319
+#, no-wrap
+msgid "Editing bitmaps_png/CMakeLists.txt"
+msgstr "Bearbeiten von bitmaps_png/CMakeLists.txt"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:323 gui_translation_howto.adoc:354
+msgid "-> locate the text:"
+msgstr "-> Suchen der Text Sequenz:"
+
+#. type: delimited block -
+#: gui_translation_howto.adoc:345
+#, no-wrap
+msgid ""
+"lang_catalan\n"
+"lang_chinese\n"
+"lang_bg\n"
+"lang_cs\n"
+"lang_def\n"
+"lang_de\n"
+"lang_en\n"
+"lang_es\n"
+"lang_fr\n"
+"lang_fi\n"
+"lang_gr\n"
+"lang_hu\n"
+"lang_it\n"
+"lang_jp\n"
+"lang_ko\n"
+"lang_nl\n"
+"lang_pl\n"
+"lang_pt\n"
+"lang_ru\n"
+"lang_sl\n"
+msgstr ""
+"lang_catalan\n"
+"lang_chinese\n"
+"lang_bg\n"
+"lang_cs\n"
+"lang_def\n"
+"lang_de\n"
+"lang_en\n"
+"lang_es\n"
+"lang_fr\n"
+"lang_fi\n"
+"lang_gr\n"
+"lang_hu\n"
+"lang_it\n"
+"lang_jp\n"
+"lang_ko\n"
+"lang_nl\n"
+"lang_pl\n"
+"lang_pt\n"
+"lang_ru\n"
+"lang_sl\n"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:348
+msgid "and add the new filename (without extension): lang_new"
+msgstr "Hinzufügen des neuen Dateinamen (ohne die Dateierweiterung): lang_new"
+
+#. type: Title ====
+#: gui_translation_howto.adoc:350
+#, no-wrap
+msgid "Editing include/bitmaps.h"
+msgstr "Bearbeiten von 'include/bitmaps.h'"
+
+#. type: delimited block -
+#: gui_translation_howto.adoc:376
+#, no-wrap
+msgid ""
+"EXTERN_BITMAP( lang_bg_xpm )\n"
+"EXTERN_BITMAP( lang_catalan_xpm )\n"
+"EXTERN_BITMAP( lang_chinese_xpm )\n"
+"EXTERN_BITMAP( lang_cs_xpm )\n"
+"EXTERN_BITMAP( lang_def_xpm )\n"
+"EXTERN_BITMAP( lang_de_xpm )\n"
+"EXTERN_BITMAP( lang_en_xpm )\n"
+"EXTERN_BITMAP( lang_es_xpm )\n"
+"EXTERN_BITMAP( lang_fr_xpm )\n"
+"EXTERN_BITMAP( lang_fi_xpm )\n"
+"EXTERN_BITMAP( lang_gr_xpm )\n"
+"EXTERN_BITMAP( lang_hu_xpm )\n"
+"EXTERN_BITMAP( lang_it_xpm )\n"
+"EXTERN_BITMAP( lang_jp_xpm )\n"
+"EXTERN_BITMAP( lang_ko_xpm )\n"
+"EXTERN_BITMAP( lang_nl_xpm )\n"
+"EXTERN_BITMAP( lang_pl_xpm )\n"
+"EXTERN_BITMAP( lang_pt_xpm )\n"
+"EXTERN_BITMAP( lang_ru_xpm )\n"
+"EXTERN_BITMAP( lang_sl_xpm )\n"
+msgstr ""
+"EXTERN_BITMAP( lang_bg_xpm )\n"
+"EXTERN_BITMAP( lang_catalan_xpm )\n"
+"EXTERN_BITMAP( lang_chinese_xpm )\n"
+"EXTERN_BITMAP( lang_cs_xpm )\n"
+"EXTERN_BITMAP( lang_def_xpm )\n"
+"EXTERN_BITMAP( lang_de_xpm )\n"
+"EXTERN_BITMAP( lang_en_xpm )\n"
+"EXTERN_BITMAP( lang_es_xpm )\n"
+"EXTERN_BITMAP( lang_fr_xpm )\n"
+"EXTERN_BITMAP( lang_fi_xpm )\n"
+"EXTERN_BITMAP( lang_gr_xpm )\n"
+"EXTERN_BITMAP( lang_hu_xpm )\n"
+"EXTERN_BITMAP( lang_it_xpm )\n"
+"EXTERN_BITMAP( lang_jp_xpm )\n"
+"EXTERN_BITMAP( lang_ko_xpm )\n"
+"EXTERN_BITMAP( lang_nl_xpm )\n"
+"EXTERN_BITMAP( lang_pl_xpm )\n"
+"EXTERN_BITMAP( lang_pt_xpm )\n"
+"EXTERN_BITMAP( lang_ru_xpm )\n"
+"EXTERN_BITMAP( lang_sl_xpm )\n"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:380
+msgid ""
+"and add a line to include the new icon name called lang_new_xpm (_xpm added "
+"to the filename)."
+msgstr ""
+"Hinzufügen einer Zeile um das neue Icon mit dem Namen lang_new_xpm (_xpm "
+"hinzugefügt zum Dateinamen) einzupflegen."
+
+#. type: Title ====
+#: gui_translation_howto.adoc:382
+#, no-wrap
+msgid "Editing common/edaappl.cpp"
+msgstr "Bearbeiten von 'common/edaappl.cpp'"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:386
+msgid "-> Locate:"
+msgstr "-> Suchen nach der Struktur 'struct LANGUAGE_DESCR'"
+
+#. type: delimited block -
+#: gui_translation_howto.adoc:397
+#, no-wrap
+msgid ""
+"struct LANGUAGE_DESCR\n"
+"{\n"
+"    int           m_WX_Lang_Identifier;                 // wxWidget locale identifier (see wxWidget doc)\n"
+"    int           m_KI_Lang_Identifier;                 // kicad identifier used in menu selection (see id.h)\n"
+"    const char**  m_Lang_Icon;                          // the icon used in menus\n"
+"    const wxChar* m_Lang_Label;                         // Label used in menus\n"
+"    bool          m_DoNotTranslate;                     // set to true if the m_Lang_Label must not be translated\n"
+"};\n"
+msgstr ""
+"struct LANGUAGE_DESCR\n"
+"{\n"
+"    int           m_WX_Lang_Identifier;                 // wxWidget locale identifier (see wxWidget doc)\n"
+"    int           m_KI_Lang_Identifier;                 // kicad identifier used in menu selection (see id.h)\n"
+"    const char**  m_Lang_Icon;                          // the icon used in menus\n"
+"    const wxChar* m_Lang_Label;                         // Label used in menus\n"
+"    bool          m_DoNotTranslate;                     // set to true if the m_Lang_Label must not be translated\n"
+"};\n"
+
+#. type: delimited block -
+#: gui_translation_howto.adoc:420
+#, no-wrap
+msgid ""
+"#define LANGUAGE_DESCR_COUNT 14\n"
+"static struct LANGUAGE_DESCR s_Language_List[LANGUAGE_DESCR_COUNT] =\n"
+"{\n"
+"    {\n"
+"        wxLANGUAGE_DEFAULT,\n"
+"        ID_LANGUAGE_DEFAULT,\n"
+"        lang_def_xpm,\n"
+"        _( \"Default\" )\n"
+"    },\n"
+"    {\n"
+"        wxLANGUAGE_ENGLISH,\n"
+"        ID_LANGUAGE_ENGLISH,\n"
+"        lang_en_xpm,\n"
+"        wxT( \"English\" ),\n"
+"        true;\n"
+"    },\n"
+"    {\n"
+"        wxLANGUAGE_FRENCH,\n"
+"        ID_LANGUAGE_FRENCH,\n"
+"        lang_fr_xpm,\n"
+"        _( \"French\" )\n"
+"    },\n"
+msgstr ""
+"#define LANGUAGE_DESCR_COUNT 14\n"
+"static struct LANGUAGE_DESCR s_Language_List[LANGUAGE_DESCR_COUNT] =\n"
+"{\n"
+"    {\n"
+"        wxLANGUAGE_DEFAULT,\n"
+"        ID_LANGUAGE_DEFAULT,\n"
+"        lang_def_xpm,\n"
+"        _( \"Default\" )\n"
+"    },\n"
+"    {\n"
+"        wxLANGUAGE_ENGLISH,\n"
+"        ID_LANGUAGE_ENGLISH,\n"
+"        lang_en_xpm,\n"
+"        wxT( \"English\" ),\n"
+"        true;\n"
+"    },\n"
+"    {\n"
+"        wxLANGUAGE_FRENCH,\n"
+"        ID_LANGUAGE_FRENCH,\n"
+"        lang_fr_xpm,\n"
+"        _( \"French\" )\n"
+"    },\n"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:423
+msgid "and add a new entry like:"
+msgstr "Hinzufügen eines neuen Eintrages:"
+
+#. type: delimited block -
+#: gui_translation_howto.adoc:432
+#, no-wrap
+msgid ""
+"    {\n"
+"        wxLANGUAGE_MY_LANGUAGE,\n"
+"        ID_LANGUAGE_MY_LANGUAGE,\n"
+"        lang_new_xpm,\n"
+"        _( \"My_language\" )\n"
+"    },\n"
+msgstr ""
+"    {\n"
+"        wxLANGUAGE_MY_LANGUAGE,\n"
+"        ID_LANGUAGE_MY_LANGUAGE,\n"
+"        lang_new_xpm,\n"
+"        _( \"My_language\" )\n"
+"    },\n"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:436
+msgid ""
+"_wxLANGUAGE_MY_LANGUAGE_ is the wxWidgets language identifier for the "
+"country (see wxWidget doc)."
+msgstr ""
+"_wxLANGUAGE_MY_LANGUAGE_ ist die wxWidgets Sprachidentifizierung für das "
+"Land (siehe wxWidget Dokumentation)."
+
+#. type: Title ====
+#: gui_translation_howto.adoc:438
+#, no-wrap
+msgid "Recompiling"
+msgstr "Neu übersetzen"
+
+#. type: Plain text
+#: gui_translation_howto.adoc:444
+msgid ""
+"You should be a PNG Maintainer (see bitmaps_png/CMakeLists.txt file), i.e "
+"compile KiCad with the option MAINTAIN_PNGS on Obviously, this is the next "
+"and last step."
+msgstr ""
+"Das neue Übersetzen der Quelltextdateien muss mit gesetzter Variable "
+"MAINTAIN_PNGS (cmake .... -DMAINTAIN_PNGS ...) erfolgen, siehe auch "
+"'bitmaps_png/CMakeLists.txt'. Dieser Schritt ist der nächste und auch der "
+"letzte."
+
+#. type: Plain text
+#: gui_translation_howto.adoc:446
+msgid "'''''"
+msgstr "'''''"


### PR DESCRIPTION
Hi,

I have done some initial work on translating the gui_translation_howto into German. The translation is mostly complete but the screenshots from the original English source are a little bit mixed up from different languages and OS systems, also seems a little bit outdated. So I skipped to create new localized screenshots. Also the Bazaar parts in the English manual needs to be adopted to the actual Git status quo first.

While working on the German translation I realized some small issues in the English original text like not uniformed usage of the word PoEdit and usage of http URLs there https instead is possible. So I changed those issues first and afterwards going further with the German translation.

If something is not clear please let me know.