### PR TITLE
Change "OS X" to "macOS"

### DIFF
--- a/src/getting_started_in_kicad/getting_started_in_kicad.adoc
+++ b/src/getting_started_in_kicad/getting_started_in_kicad.adoc
@@ -88,7 +88,7 @@ http://www.kicad-pcb.org/
 [[download-and-install-kicad]]
 === Downloading and installing KiCad
 
-KiCad runs on GNU/Linux, Apple OS X and Windows.
+KiCad runs on GNU/Linux, Apple macOS and Windows.
 You can find the most up to date instructions and download links at:
 
 http://www.kicad-pcb.org/download/
@@ -133,9 +133,9 @@ Alternatively, you can download and install a pre-compiled version of
 KiCad, or directly download the source code, compile and install KiCad.
 
 [[under-apple-os-x]]
-==== Under Apple OS X
+==== Under Apple macOS
 
-Stable builds of KiCad for OS X can be found at:
+Stable builds of KiCad for macOS can be found at:
 http://downloads.kicad-pcb.org/osx/stable/
 
 Unstable nightly development builds can be found at:

--- a/src/kicad/kicad.adoc
+++ b/src/kicad/kicad.adoc
@@ -80,7 +80,7 @@ Being open source (GPL licensed), KiCad represents the ideal tool for
 projects oriented towards the creation of electronic hardware with an
 open-source flavour.
 
-KiCad is available for Linux, Windows and Apple OS X.
+KiCad is available for Linux, Windows and Apple macOS.
 
 === KiCad files and folders
 


### PR DESCRIPTION
Apple changes their desktop OS name, so it seems to me we should follow suit. The main KiCad website (http://kicad-pcb.org/download/osx/) hasn't updated their terminology, though.