### PR TITLE
Fix warnings

### DIFF
--- a/src/pcbnew/pcbnew_create_and_modify_board.adoc
+++ b/src/pcbnew/pcbnew_create_and_modify_board.adoc
@@ -169,7 +169,7 @@ corresponding change in the schematic.
 
 . Create a new netlist from the modified schematic.
 . If new components have been added, link these to their corresponding
-footprint in CvPcb.
+  footprint in CvPcb.
 . Read the new netlist in Pcbnew.
 
 ==== Deleting incorrect tracks

--- a/src/pcbnew/pcbnew_creating_editing_footprints.adoc
+++ b/src/pcbnew/pcbnew_creating_editing_footprints.adoc
@@ -404,13 +404,13 @@ image::images/Modedit_module_3d_options.png[scaledwidth="60%"]
 The buttons on the right have the following functions:
 
 * *Add 3D Shape* shows a 3D file selection dialog and creates a
-new model entry for the component.
+  new model entry for the component.
 * *Remove 3D Shape* deletes the selected model entry.
 * *Edit Filename* shows a text editor for manual entry of
-the model file name.
+  the model file name.
 * *Configure Paths* shows a configuration dialog which
-allows the user to edit the list of path aliases and
-alias values.
+  allows the user to edit the list of path aliases and
+  alias values.
 
 The _3D Settings_ tab contains a panel with a preview of the
 selected model and the scale, offset, and rotation data

--- a/src/pcbnew/pcbnew_installation.adoc
+++ b/src/pcbnew/pcbnew_installation.adoc
@@ -142,10 +142,10 @@ There are some rules for valid library table entries:
 
 * The colon `:` character cannot be used anywhere in the nickname.
 * Each library entry must have a valid path and/or file name depending on
-the type of library. Paths can be defined as absolute, relative, or by environment variable
-substitution (see below)
+  the type of library. Paths can be defined as absolute, relative, or by
+  environment variable substitution (see below)
 *  The appropriate plug in type must be selected in order for the library
-to be properly read.
+  to be properly read.
 
 There is also a description field to add a description of the library
 entry.  The option field contains special options that are plugin-specific


### PR DESCRIPTION

```
Scanning dependencies of target pcbnew_updatepo_ru
Parse input files... 
pcbnew_create_and_modify_board.adoc:172: It seems that you are adding unindented content to an item.
The "standard" allows this, but you may still want to fix your document.
pcbnew_creating_editing_footprints.adoc:407: It seems that you are adding unindented content to an item.
The "standard" allows this, but you may still want to fix your document.
pcbnew_creating_editing_footprints.adoc:410: It seems that you are adding unindented content to an item.
The "standard" allows this, but you may still want to fix your document.
pcbnew_creating_editing_footprints.adoc:412: It seems that you are adding unindented content to an item.
The "standard" allows this, but you may still want to fix your document.
pcbnew_creating_editing_footprints.adoc:413: It seems that you are adding unindented content to an item.
The "standard" allows this, but you may still want to fix your document.
pcbnew_installation.adoc:145: It seems that you are adding unindented content to an item.
The "standard" allows this, but you may still want to fix your document.
pcbnew_installation.adoc:146: It seems that you are adding unindented content to an item.
The "standard" allows this, but you may still want to fix your document.
pcbnew_installation.adoc:148: It seems that you are adding unindented content to an item.
The "standard" allows this, but you may still want to fix your document.
done.
Updating po/ru.po:
....................................................................................................................................................... done.
```