### PR TITLE
[4.0] Fix warning

### DIFF
--- a/src/pcbnew/pcbnew_create_and_modify_board.adoc
+++ b/src/pcbnew/pcbnew_create_and_modify_board.adoc
@@ -169,7 +169,7 @@ corresponding change in the schematic.
 
 . Create a new netlist from the modified schematic.
 . If new components have been added, link these to their corresponding
-footprint in CvPcb.
+  footprint in CvPcb.
 . Read the new netlist in Pcbnew.
 
 ==== Deleting incorrect tracks


### PR DESCRIPTION
Correct various indentation of numbered lists   
    Asciidoc allows of course the usage of numbered lists [1]. Due some
    line breaks of long items within the source without a indentation of any
    text line after a line break the asciidoc processor is showing a warning
    message like this:

    ---%<---
    pcbnew_create_and_modify_board.adoc:172: It seems that you are adding unindented content to an item.
    The 'standard' allows this, but you may still want to fix your document.
    --->%---

    It's possible that such warnings can be moved to a error later in future
    versions of asciidoc. The warning is easy solvable, we just need to
    intend the following lines. This change fixes the warnings of the
    asciidoc processor but also increases the readability of the *.adoc
    files a bit.

    [1] http://asciidoctor.org/docs/asciidoc-writers-guide/#ordering-the-things