### PR TITLE
Eeschema: fixed image references

### DIFF
--- a/src/eeschema/eeschema_component_library_editor.adoc
+++ b/src/eeschema/eeschema_component_library_editor.adoc
@@ -319,10 +319,7 @@ You will be asked to enter a new library name.
 New libraries are not automatically added to the current project.
 
 You must add any new library you wish to use in a schematic to the list
-of project libraries in Eeschema using the component configuration dialog.
-
-// FIXME OR DELETEME
-// image:images/en/libsettings.png[alt="Library settings",width="50%"]
+of project libraries in Eeschema using the <<manage-sym-lib-table,Symbol Library Table dialog>>.
 ====
 
 Click the 

--- a/src/eeschema/eeschema_general_top_toolbar.adoc
+++ b/src/eeschema/eeschema_general_top_toolbar.adoc
@@ -19,20 +19,6 @@ will not be automatically changed.
 [[options-of-the-schematic-editor]]
 === Options of the schematic editor
 
-[[general-options]]
-==== General options
-
-// FIXME OR DELETEME
-// image::images/en/options.png[alt="Schematic Editor Options",scaledwidth="60%"]
-
-[[template-fields-names]]
-==== Template fields names
-
-You can define custom fields that will exist by default in each component
-(even if left empty).
-
-image::images/en/template_field_names.png[alt="Template Field Names settings",scaledwidth="50%"]
-
 [[search-tool]]
 === Search tool
 

--- a/src/eeschema/eeschema_hierarchical_schematics.adoc
+++ b/src/eeschema/eeschema_hierarchical_schematics.adoc
@@ -67,16 +67,8 @@ Each sheet is reachable by clicking on its name. For quick access, right
 click on a sheet name, and choose to Enter Sheet or double click within
 the bounds of the sheet.
 
-You can quickly reach the root sheet or a sub-sheet by using the tool
-// FIXME OR DELETEME
-// image:images/icons/hierarchy_cursor.png[icons/hierarchy_cursor_png]
-of the right toolbar. After the navigation tool has been selected:
-
-* Click on a sheet name to select the sheet.
-* Click elsewhere to select the Root sheet.
-
 In order to exit the current sheet to the parent sheet, right click anywhere in the
-schematic whre there is no object and left click the "Leave Sheet" context menu entry
+schematic where there is no object and select "Leave Sheet" in the context menu
 or press Alt+Backspace.
 
 [[local-hierarchical-and-global-labels]]


### PR DESCRIPTION
- Modified a reference to library management dialog to refer to
corresponding chapter in the manual.
- Removed description of hierarchy navigation tool,
as it does not exist anymore.
- Removed description of options that most likely were accessible on
the top toolbar, but they are not there anymore.