### PR TITLE
README.adoc: sort also second Debian/Ubuntu package list

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -51,8 +51,8 @@ package.
 To install the dependencies on Debian / Ubuntu  run the following (requires
 about 1.5GiB of space):
 
-    sudo apt-get install asciidoc cmake dblatex fonts-vlgothic \
-    fonts-freefont-ttf gettext git make pandoc po4a source-highlight \
+    sudo apt-get install asciidoc cmake dblatex fonts-freefont-ttf \
+    fonts-vlgothic gettext git make pandoc po4a source-highlight \
     texlive-lang-cyrillic texlive-lang-dutch texlive-lang-english \
     texlive-lang-french texlive-lang-german texlive-lang-italian \
     texlive-lang-japanese texlive-lang-other texlive-lang-polish \
@@ -66,8 +66,9 @@ package, Install texlive-lang-european instead.
 
 or, if you do not have space problems:
 
-    sudo apt-get install git make cmake asciidoc pandoc gettext po4a dblatex \
-    texlive-xetex fonts-vlgothic source-highlight texlive-lang-all
+    sudo apt-get install asciidoc cmake dblatex fonts-freefont-ttf \
+    fonts-vlgothic gettext git make pandoc po4a source-highlight \
+    texlive-lang-all texlive-xetex
 
 === Fedora
 


### PR DESCRIPTION
This is a supplement for d14a73f4. Sorting the second list also
alphabetical and adding the needed font package 'fonts-freefont-ttf' to
the list too.
Fix a small sorting issue an the list above to keep entries really
alphabetical.