### PR TITLE
Update packages to install for Debian/Ubuntu

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -48,21 +48,21 @@ package.
 
 === Debian / Ubuntu
 
-To install the dependencies on Debian / Ubuntu  run the following (requires
+To install the dependencies on Debian / Ubuntu run the following (requires
 about 1.5GiB of space):
 
     sudo apt-get install asciidoc cmake dblatex fonts-freefont-ttf \
     fonts-vlgothic gettext git make pandoc po4a source-highlight \
-    texlive-lang-cyrillic texlive-lang-dutch texlive-lang-english \
+    texlive-lang-cyrillic texlive-lang-english texlive-lang-european \
     texlive-lang-french texlive-lang-german texlive-lang-italian \
     texlive-lang-japanese texlive-lang-other texlive-lang-polish \
-    texlive-xetex
+    texlive-lang-spanish texlive-xetex
 
 NOTE: in Ubuntu 14:04 there is no texlive-lang-japanese. Install
 texlive-lang-cjk instead.
 
-NOTE: in Debian Jessie the package texlive-lang-dutch is a transitional
-package, Install texlive-lang-european instead.
+NOTE: Debian Jessie has no package texlive-lang-european, install the package
+texlive-lang-dutch instead.
 
 or, if you do not have space problems:
 


### PR DESCRIPTION
The old list of needed packages isn't reflecting the current state for
Debian Stable (Stretch) / Testing and Ubuntu 18.04 as well.
For Spanish documentation there is also texlive-lang-spanish needed, if
texlive-lang-all is used. texlive-lang-dutch isn't existing in current
Debian based distributions so remove this package from the list and use
the successor package texlive-lang-european.