### PR TITLE
LED's ref is D? after all, not LED?.

### DIFF
--- a/src/getting_started_in_kicad/getting_started_in_kicad.adoc
+++ b/src/getting_started_in_kicad/getting_started_in_kicad.adoc
@@ -554,7 +554,7 @@ Warning Pin power_in not driven (Net xx)
     confirmation message and then click 'Close'. Notice how all the
     '?' have been replaced with numbers. Each identifier is now
     unique. In our example, they have been named 'R1', 'R2', 'U1',
-    'LED1' and 'J1'.
+    'D1' and 'J1'.
 
 47. We will now check our schematic for errors. Click on the 'Perform
     electrical rules check' icon image:images/icons/erc.png[erc_png] on the top
@@ -582,7 +582,7 @@ try setting the path to `c:\windows\notepad.exe` (windows) or `/usr/bin/gedit`
 
 50. _Cvpcb_ allows you to link all the components in your schematic
     with footprints in the KiCad library. The pane on the center shows
-    all the components used in your schematic. Here select 'LED1'. In
+    all the components used in your schematic. Here select 'D1'. In
     the pane on the right you have all the available footprints, here
     scroll down to 'LED_THT:LED-D5.0mm' and double click on it. 
 // missing image here?


### PR DESCRIPTION
Fixed this mistake in previous commit(s).