### PR TITLE
Getting Started: Spelling error fix in Bus connections

### DIFF
--- a/src/getting_started_in_kicad/getting_started_in_kicad.adoc
+++ b/src/getting_started_in_kicad/getting_started_in_kicad.adoc
@@ -745,7 +745,7 @@ connection. Let's see how to do it.
 7.  Put a label (press [l]) on the bus of CONN_4 and name
     it 'b[1..4]'.
 
-8.  Put a label (press [l]) on the previous a bus and name
+8.  Put a label (press [l]) on the previous bus and name
     it 'a[1..4]'.
 
 9.  What we can now do is connect bus a[1..4] with bus b[1..4] using a


### PR DESCRIPTION
"on the previous a bus" feels like a spelling error to me, "on the previous bus" is better. I'm not sure if 'a' was meant to refer to the name of the bus, but it's not good anyways.