### PR TITLE
Getting Started: Removed the old layer names

### DIFF
--- a/src/getting_started_in_kicad/getting_started_in_kicad.adoc
+++ b/src/getting_started_in_kicad/getting_started_in_kicad.adoc
@@ -964,16 +964,16 @@ board for you.
 3.  These are the layers you need to select for making a typical 2-layer
     PCB:
 
-[width="100%",cols="20%,20%,20%,20%,20%",options="header"]
+[width="100%",cols="25%,25%,25%,25%",options="header"]
 |=========================================================
-|Layer |KiCad Layer Name |Old KiCad Layer Name |Default Gerber Extension
+|Layer |KiCad Layer Name |Default Gerber Extension
     |"Use Protel filename extensions" is enabled
-|Bottom Layer |B.Cu |Copper |.GBR |.GBL
-|Top Layer |F.Cu |Component |.GBR |.GTL
-|Top Overlay |F.SilkS |SilkS_Cmp |.GBR |.GTO
-|Bottom Solder Resist |B.Mask |Mask_Cop |.GBR |.GBS
-|Top Solder Resist |F.Mask |Mask_Cmp |.GBR |.GTS
-|Edges |Edge.Cuts |Edges_Pcb |.GBR |.GM1
+|Bottom Layer |B.Cu |.GBR |.GBL
+|Top Layer |F.Cu |.GBR |.GTL
+|Top Overlay |F.SilkS |.GBR |.GTO
+|Bottom Solder Resist |B.Mask |.GBR |.GBS
+|Top Solder Resist |F.Mask |.GBR |.GTS
+|Edges |Edge.Cuts |.GBR |.GM1
 |=========================================================
 
 [[using-gerbview]]


### PR DESCRIPTION
It must have been quite many years since the old layer names were used. I believe they aren't needed here and only confuse or distract newcomers.