### PR TITLE
Getting Started: "component" has been replaced with "symbol" in KiCad.

### DIFF
--- a/src/getting_started_in_kicad/getting_started_in_kicad.adoc
+++ b/src/getting_started_in_kicad/getting_started_in_kicad.adoc
@@ -1111,21 +1111,20 @@ those modifications in your schematic and netlist file. The Backward
 Annotation method, however, is not that useful and is therefore not
 described here.
 
-[[make-schematic-components-in-kicad]]
-== Make schematic components in KiCad
+[[make-schematic-symbols-in-kicad]]
+== Make schematic symbols in KiCad
 
-Sometimes a component that you want to place on your schematic is not 
+Sometimes a symbol that you want to place on your schematic is not 
 in a KiCad library. This is quite normal and there is no reason to
-worry. In this section we will see how a new schematic component can be
+worry. In this section we will see how a new schematic symbol can be
 quickly created with KiCad. Nevertheless, remember that you can always
-find KiCad components on the Internet. For instance from here:
+find KiCad components on the Internet.
 
-http://per.launay.free.fr/kicad/kicad_php/composant.php
-
-In KiCad, a component is a piece of text that starts with a 'DEF' and
-ends with 'ENDDEF'. One or more components are normally placed in a
-library file with the extension __.lib__. If you want to add components
-to a library file you can just use the cut and paste commands.
+In KiCad, a symbol is a piece of text that starts with 'DEF' and
+ends with 'ENDDEF'. One or more symbols are normally placed in a
+library file with the extension __.lib__. If you want to add symbols
+to a library file you can just use the cut and paste commands of
+a text editor.
 
 [[using-component-library-editor]]
 === Using Component Library Editor


### PR DESCRIPTION
Another small changes: removed internet link. Added "text editor" to
remove ambiguity.

The link was problematic: the site includes dead links. The search results are also at least partly dead. Unfortunately there aren't good simple alternatives for symbols. There are some commercial alternatives like digikey, ultralibrarian or snapeda with free offerings. Do we want to mention them? We should rather have an up-to-date maintained list in KiCad web page or in forums and give a link to that. I didn't find any for symbols. There's https://github.com/monostable/kicad_footprints for footprints and seems to include some symbol libraries, too.