### PR TITLE
Remove dblatex dependency when building HTML or EPUB only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,24 +40,28 @@ add_a2x_option( --no-xmllint )
 add_a2x_option( -f pdf )
 #add_a2x_option( --verbose )
 
-# Add a2x options depending on which PDF generator we're using
-if( ${PDF_GENERATOR} MATCHES DBLATEX )
-    set_dblatex_common_options()
-    find_package( DBLATEX REQUIRED )
-endif()
+if( "${BUILD_FORMATS}" MATCHES "(p|P)(d|D)(f|F)" )
 
-if( ${PDF_GENERATOR} MATCHES FOP )
-    add_a2x_option( --fop )
-    add_a2x_option( --xsl-file ${PROJECT_SOURCE_DIR}/xsl/kicad.xsl )
-    find_package( FOP REQUIRED )
-endif()
+    # Add a2x options depending on which PDF generator we're using
+    if( ${PDF_GENERATOR} MATCHES DBLATEX )
+        set_dblatex_common_options()
+        find_package( DBLATEX REQUIRED )
+    endif()
 
-if( ${PDF_GENERATOR} MATCHES ASCIIDOCTORPDF )
-    message( FATAL_ERROR "AsciiDoctor-pdf is not currently supported!" )
+    if( ${PDF_GENERATOR} MATCHES FOP )
+        add_a2x_option( --fop )
+        add_a2x_option( --xsl-file ${PROJECT_SOURCE_DIR}/xsl/kicad.xsl )
+        find_package( FOP REQUIRED )
+    endif()
 
-    # Discover if the AsciiDoctor toolchain is available
-    # find_package( ASCIIDOCTOR )
-    # find_package( ASCIIDOCTORPDF )
+    if( ${PDF_GENERATOR} MATCHES ASCIIDOCTORPDF )
+        message( FATAL_ERROR "AsciiDoctor-pdf is not currently supported!" )
+
+        # Discover if the AsciiDoctor toolchain is available
+        # find_package( ASCIIDOCTOR )
+        # find_package( ASCIIDOCTORPDF )
+
+    endif()
 
 endif()
 
@@ -135,5 +139,3 @@ endif()
 set( CPACK_GENERATOR "TGZ" )
 set( CPACK_PACKAGE_FILE_NAME "kicad-doc${PACKAGE_BUILD_FORMAT}${PACKAGE_LANGUAGE}-${CPACK_PACKAGE_VERSION}" )
 include( CPack )
-
-


### PR DESCRIPTION
Cmake always evaluates the PDF_GENERATOR build option, which defaults to "DBLATEX". As a consequence, dblatex and its dependencies need to be installed to build kicad-doc. One can add something like `-DPDF_GENERATOR=none` to the command line to avoid this. Instead, PDF_GENERATOR should only be evaluated if "pdf" (or "PDF", "Pdf", etc.) is included in BUILD_FORMATS.