### PR TITLE
Fix broken link to KiCad upgrade document

### DIFF
--- a/src/kicad/kicad_upgrading_from_v4_to_v5.adoc
+++ b/src/kicad/kicad_upgrading_from_v4_to_v5.adoc
@@ -21,7 +21,7 @@ would be searched and the first library that held the symbol name
 would be used.
 
 From v5, KiCad symbol names are prefixed with a nickname, and a
-link:../eeschema/eeschema_symbol_library_table.adoc[lookup table matching
+https://github.com/KiCad/kicad-doc/blob/master/src/kicad/kicad_upgrading_from_v4_to_v5.adoc[lookup table matching
 nicknames to library paths] is used to locate the library which holds the
 symbol. The table is called the 'symbol library table' and built from
 configuration files stored in the user's KiCad configuration directory


### PR DESCRIPTION
Relative links only work in the github-hosted repository.
In the html, pdf and epub documentation outputs this link was broken.

Replacing the relative link with an actual URL fixes this issue.

Fixes #615.