### PR TITLE
Update "Making schematic components" link

### DIFF
--- a/src/getting_started_in_kicad/getting_started_in_kicad.adoc
+++ b/src/getting_started_in_kicad/getting_started_in_kicad.adoc
@@ -181,7 +181,7 @@ When applicable, the icon is added for convenience.
 image::images/kicad_flowchart.png["KiCad Flowchart"]
 
 For more information about creating a component, read
-<<make-schematic-components-in-kicad,Making schematic components>>.
+<<make-schematic-symbols-in-kicad,Making schematic symbols>>.
 And for information about how to create a new footprint, see
 <<make-component-footprints,Making component footprints>>.
 


### PR DESCRIPTION
"2.1. Overview" has a "Making schematic components" link that points to "getting_started_in_kicad.html#make-schematic-components-in-kicad", which doesn't exist.
It is the wrong name and link for "7. Make schematic symbols in KiCad" at "getting_started_in_kicad.html#make-schematic-symbols-in-kicad".