### PR TITLE
Updated bookmark/section title for Make Schematic Symbols in KiCad

### DIFF
--- a/src/getting_started_in_kicad/getting_started_in_kicad.adoc
+++ b/src/getting_started_in_kicad/getting_started_in_kicad.adoc
@@ -432,7 +432,7 @@ image::images/gsik_tutorial1_010.png[gsik_tutorial1_010_png]
 
 25. We now need to create the schematic component 'MYCONN3' for our
     3-pin connector. You can jump to the section titled
-    <<make-schematic-components-in-kicad,Make Schematic Components in KiCad>>
+    <<make-schematic-symbols-in-kicad,Make Schematic Symbols in KiCad>>
     to learn how to make this component from scratch and then return
     to this section to continue with the board.
 


### PR DESCRIPTION
Updated the section jump link and link text in "Using Eeschema", Step 25 to refer to the title "Make Schematic Symbols in KiCad" instead of "Make Schematic Components in KiCad"