### PR TITLE
Shift-click when adding vias

### DIFF
--- a/src/pcbnew/pcbnew_interactive_router.adoc
+++ b/src/pcbnew/pcbnew_interactive_router.adoc
@@ -60,7 +60,7 @@ simply press **Esc**.
 Pressing *V* or selecting _Place Through Via_ from the context menu
 while routing a track attaches a via at the end of the trace being
 routed. Pressing *V* again disables via placement. Clicking in any spot
-establishes the via and continues routing.
+establishes the via and continues routing (unless 'Shift' is held).
 
 Pressing */* or selecting _Switch Track Posture_ from the context menu
 toggles the direction of the initial track segment between straight or

--- a/src/pcbnew/pcbnew_layers.adoc
+++ b/src/pcbnew/pcbnew_layers.adoc
@@ -138,7 +138,8 @@ layers used for vias.
 image::images/Pcbnew_via_layer_pair_dialog.png[scaledwidth="40%"]
 
 When a via is placed the working (active) layer is automatically
-switched to the alternate layer of the layer pair used for the vias.
+switched to the alternate layer of the layer pair used for the vias
+(unless 'Shift' is held when adding the via).
 
 One can also switch to another active layer by hot keys, and if a
 track is in progress, a via will be inserted.

--- a/src/pcbnew/pcbnew_routing.adoc
+++ b/src/pcbnew/pcbnew_routing.adoc
@@ -234,7 +234,14 @@ image:images/Pcbnew_routing_posture.png[]
 
 Holding 'Ctrl' while routing in the non-legacy canvases constrains the
 routing to a single horizontal or vertical segment. Switching posture
-changes to a single diagonal segment.
+changes to a single diagonal segment. Holding 'Shift' while routing
+removes the gravity pulling the route in a particular direction.
+
+Holding 'Shift' while adding a via, the routing ends as soon as the
+mouse button is clicked, and the active layer doesn't change. This is
+useful when adding a connection to a plane in which you wouldn't want
+to have the active layer change and wouldn't want to continue adding 
+trace.
 
 When creating a new track, Pcbnew shows links to nearest
 unconnected pads.

--- a/src/pcbnew/pcbnew_routing.adoc
+++ b/src/pcbnew/pcbnew_routing.adoc
@@ -235,7 +235,7 @@ image:images/Pcbnew_routing_posture.png[]
 Holding 'Ctrl' while routing in the non-legacy canvases constrains the
 routing to a single horizontal or vertical segment. Switching posture
 changes to a single diagonal segment. Holding 'Shift' while routing
-removes the gravity pulling the route in a particular direction.
+removes the 'snap to object' gravity.
 
 When creating a new track, Pcbnew shows links to nearest
 unconnected pads.

--- a/src/pcbnew/pcbnew_routing.adoc
+++ b/src/pcbnew/pcbnew_routing.adoc
@@ -261,11 +261,10 @@ A via can be inserted only when a track is in progress:
 
 * By switching to a new copper layer using the appropriate hotkey.
 
-Holding 'Shift' while adding a via, the routing ends as soon as the
-mouse button is clicked, and the active layer doesn't change. This is
-useful when adding a connection to a plane in which you wouldn't want
-to have the active layer change and wouldn't want to continue adding 
-trace.
+Holding 'Shift' while adding a via ends routing as soon as the via 
+is placed. This is useful when adding a connection to a plane, so
+the active layer doesn't change and no extra keys need be pressed
+to exit routing.
 
 === Select/edit the track width and via size
 

--- a/src/pcbnew/pcbnew_routing.adoc
+++ b/src/pcbnew/pcbnew_routing.adoc
@@ -263,7 +263,7 @@ A via can be inserted only when a track is in progress:
 
 Holding 'Shift' while adding a via ends routing as soon as the via 
 is placed. This is useful when adding a connection to a plane, so
-the active layer doesn't change and no extra keys need be pressed
+the active layer doesn't change and no extra key need be pressed
 to exit routing.
 
 === Select/edit the track width and via size

--- a/src/pcbnew/pcbnew_routing.adoc
+++ b/src/pcbnew/pcbnew_routing.adoc
@@ -237,12 +237,6 @@ routing to a single horizontal or vertical segment. Switching posture
 changes to a single diagonal segment. Holding 'Shift' while routing
 removes the gravity pulling the route in a particular direction.
 
-Holding 'Shift' while adding a via, the routing ends as soon as the
-mouse button is clicked, and the active layer doesn't change. This is
-useful when adding a connection to a plane in which you wouldn't want
-to have the active layer change and wouldn't want to continue adding 
-trace.
-
 When creating a new track, Pcbnew shows links to nearest
 unconnected pads.
 
@@ -266,6 +260,12 @@ A via can be inserted only when a track is in progress:
 * By the hotkey 'V'.
 
 * By switching to a new copper layer using the appropriate hotkey.
+
+Holding 'Shift' while adding a via, the routing ends as soon as the
+mouse button is clicked, and the active layer doesn't change. This is
+useful when adding a connection to a plane in which you wouldn't want
+to have the active layer change and wouldn't want to continue adding 
+trace.
 
 === Select/edit the track width and via size
 


### PR DESCRIPTION
This new add via behavior hasn't been documented anywhere, but is something everyone should appreciate.  I found descriptions of adding vias in many places, so edited those to include the 'Shift' add behavior.

I noticed that the 'Shift' route behavior is described elsewhere in the documentation, but not under 'Creating Tracks' under Manual routing, so added it there.