### PR TITLE
README: The language nl isn't available anymore

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -136,10 +136,10 @@ By default CMake will configure to build all languages available for each docume
 You can build just one or some of the languages by using the **LANGUAGES** option
 when configuring a build with CMake, e.g. `-DLANGUAGES="it;en;de"`, etc.
 
-Currently, the available languages are : `ca`, `de`, `en`, `es`, `fr`, `id`, `it`,
-`ja`, `nl`, `pl`, `ru`  and `zh`, however, any
-language code can be selected. Only translated documents will be built, so for
-some languages there may only be a partial documentation output.
+Currently, the available languages are : `ca`, `de`, `en`, `es`, `fr`, `id`,
+`it`, `ja`, `pl`, `ru`  and `zh`, however, any language code can be selected.
+Only translated documents will be built, so for some languages there may only
+be a partial documentation output.
 
 ==== SINGLE_LANGUAGE
 


### PR DESCRIPTION
The remaining file for the language nl was removed by commit
f50c918d07a5436c9baacf32e931cdb0bb974b6c.