### PR TITLE
Remove libre office meta tags from template creation

### DIFF
--- a/src/kicad/kicad.adoc
+++ b/src/kicad/kicad.adoc
@@ -500,9 +500,6 @@ Here is a sample *info.html* file:
 <META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html;
 charset=windows-1252">
 <TITLE>Raspberry Pi - Expansion Board</TITLE>
-<META NAME="GENERATOR" CONTENT="LibreOffice 3.6 (Windows)">
-<META NAME="CREATED" CONTENT="0;0">
-<META NAME="CHANGED" CONTENT="20121015;19015295">
 </HEAD>
 <BODY LANG="fr-FR" DIR="LTR">
 <P>This project template is the basis of an expansion board for the


### PR DESCRIPTION
Fixes #704 


I also noticed that the html body tag sets the language to french. (But the text is clearly english.)
Is this also ignored by kicad (meaning we can remove this as well) or should we change it to english.