### PR TITLE
Correct Copr reference

### DIFF
--- a/src/getting_started_in_kicad/getting_started_in_kicad.adoc
+++ b/src/getting_started_in_kicad/getting_started_in_kicad.adoc
@@ -139,7 +139,7 @@ Under Fedora the easiest way to install an unstable nightly build is via __copr_
 To install KiCad via copr type the following in to copr:
 
 ----
-sudo dnf copr enable mangelajo/kicad
+sudo dnf copr enable @kicad/kicad
 sudo dnf install kicad
 ----
 

--- a/src/getting_started_in_kicad/po/ca.po
+++ b/src/getting_started_in_kicad/po/ca.po
@@ -385,11 +385,11 @@ msgstr ""
 #. type: delimited block -
 #: getting_started_in_kicad.adoc:144
 #, fuzzy, no-wrap
-#| msgid "sudo dnf copr enable mangelajo/kicad"
+#| msgid "sudo dnf copr enable @kicad/kicad"
 msgid ""
-"sudo dnf copr enable mangelajo/kicad\n"
+"sudo dnf copr enable @kicad/kicad\n"
 "sudo dnf install kicad\n"
-msgstr "sudo dnf copr enable mangelajo/kicad"
+msgstr "sudo dnf copr enable @kicad/kicad"
 
 #. type: Plain text
 #: getting_started_in_kicad.adoc:148

--- a/src/getting_started_in_kicad/po/de.po
+++ b/src/getting_started_in_kicad/po/de.po
@@ -366,10 +366,10 @@ msgstr ""
 #: getting_started_in_kicad.adoc:144
 #, no-wrap
 msgid ""
-"sudo dnf copr enable mangelajo/kicad\n"
+"sudo dnf copr enable @kicad/kicad\n"
 "sudo dnf install kicad\n"
 msgstr ""
-"sudo dnf copr enable mangelajo/kicad\n"
+"sudo dnf copr enable @kicad/kicad\n"
 "sudo dnf install kicad\n"
 
 #. type: Plain text

--- a/src/getting_started_in_kicad/po/es.po
+++ b/src/getting_started_in_kicad/po/es.po
@@ -380,11 +380,11 @@ msgstr ""
 #. type: delimited block -
 #: getting_started_in_kicad.adoc:144
 #, fuzzy, no-wrap
-#| msgid "sudo dnf copr enable mangelajo/kicad"
+#| msgid "sudo dnf copr enable @kicad/kicad"
 msgid ""
-"sudo dnf copr enable mangelajo/kicad\n"
+"sudo dnf copr enable @kicad/kicad\n"
 "sudo dnf install kicad\n"
-msgstr "sudo dnf copr enable mangelajo/kicad"
+msgstr "sudo dnf copr enable @kicad/kicad"
 
 #. type: Plain text
 #: getting_started_in_kicad.adoc:148

--- a/src/getting_started_in_kicad/po/fr.po
+++ b/src/getting_started_in_kicad/po/fr.po
@@ -386,11 +386,11 @@ msgstr ""
 #. type: delimited block -
 #: getting_started_in_kicad.adoc:144
 #, fuzzy, no-wrap
-#| msgid "sudo dnf copr enable mangelajo/kicad"
+#| msgid "sudo dnf copr enable @kicad/kicad"
 msgid ""
-"sudo dnf copr enable mangelajo/kicad\n"
+"sudo dnf copr enable @kicad/kicad\n"
 "sudo dnf install kicad\n"
-msgstr "sudo dnf copr enable mangelajo/kicad"
+msgstr "sudo dnf copr enable @kicad/kicad"
 
 #. type: Plain text
 #: getting_started_in_kicad.adoc:148

--- a/src/getting_started_in_kicad/po/id.po
+++ b/src/getting_started_in_kicad/po/id.po
@@ -333,11 +333,11 @@ msgstr ""
 #. type: delimited block -
 #: getting_started_in_kicad.adoc:144
 #, fuzzy, no-wrap
-#| msgid "sudo dnf copr enable mangelajo/kicad"
+#| msgid "sudo dnf copr enable @kicad/kicad"
 msgid ""
-"sudo dnf copr enable mangelajo/kicad\n"
+"sudo dnf copr enable @kicad/kicad\n"
 "sudo dnf install kicad\n"
-msgstr "sudo dnf copr enable mangelajo/kicad"
+msgstr "sudo dnf copr enable @kicad/kicad"
 
 #. type: Plain text
 #: getting_started_in_kicad.adoc:148

--- a/src/getting_started_in_kicad/po/it.po
+++ b/src/getting_started_in_kicad/po/it.po
@@ -346,10 +346,10 @@ msgstr ""
 #: getting_started_in_kicad.adoc:144
 #, no-wrap
 msgid ""
-"sudo dnf copr enable mangelajo/kicad\n"
+"sudo dnf copr enable @kicad/kicad\n"
 "sudo dnf install kicad\n"
 msgstr ""
-"sudo dnf copr enable mangelajo/kicad\n"
+"sudo dnf copr enable @kicad/kicad\n"
 "sudo dnf install kicad\n"
 
 #. type: Plain text

--- a/src/getting_started_in_kicad/po/ja.po
+++ b/src/getting_started_in_kicad/po/ja.po
@@ -345,10 +345,10 @@ msgstr ""
 #: getting_started_in_kicad.adoc:144
 #, no-wrap
 msgid ""
-"sudo dnf copr enable mangelajo/kicad\n"
+"sudo dnf copr enable @kicad/kicad\n"
 "sudo dnf install kicad\n"
 msgstr ""
-"sudo dnf copr enable mangelajo/kicad\n"
+"sudo dnf copr enable @kicad/kicad\n"
 "sudo dnf install kicad\n"
 
 #. type: Plain text

--- a/src/getting_started_in_kicad/po/pl.po
+++ b/src/getting_started_in_kicad/po/pl.po
@@ -352,10 +352,10 @@ msgstr ""
 #: getting_started_in_kicad.adoc:144
 #, no-wrap
 msgid ""
-"sudo dnf copr enable mangelajo/kicad\n"
+"sudo dnf copr enable @kicad/kicad\n"
 "sudo dnf install kicad\n"
 msgstr ""
-"sudo dnf copr enable mangelajo/kicad\n"
+"sudo dnf copr enable @kicad/kicad\n"
 "sudo dnf install kicad\n"
 
 #. type: Plain text

--- a/src/getting_started_in_kicad/po/ru.po
+++ b/src/getting_started_in_kicad/po/ru.po
@@ -354,10 +354,10 @@ msgstr ""
 #: getting_started_in_kicad.adoc:144
 #, no-wrap
 msgid ""
-"sudo dnf copr enable mangelajo/kicad\n"
+"sudo dnf copr enable @kicad/kicad\n"
 "sudo dnf install kicad\n"
 msgstr ""
-"sudo dnf copr enable mangelajo/kicad\n"
+"sudo dnf copr enable @kicad/kicad\n"
 "sudo dnf install kicad\n"
 
 #. type: Plain text

--- a/src/getting_started_in_kicad/po/zh.po
+++ b/src/getting_started_in_kicad/po/zh.po
@@ -326,10 +326,10 @@ msgstr ""
 #: getting_started_in_kicad.adoc:144
 #, no-wrap
 msgid ""
-"sudo dnf copr enable mangelajo/kicad\n"
+"sudo dnf copr enable @kicad/kicad\n"
 "sudo dnf install kicad\n"
 msgstr ""
-"sudo dnf copr enable mangelajo/kicad\n"
+"sudo dnf copr enable @kicad/kicad\n"
 "sudo dnf install kicad\n"
 
 #. type: Plain text


### PR DESCRIPTION
The copr reference currently points to mangelajo/kicad, but it should be @kicad/kicad.