### PR TITLE
[pcb_calc] TransLIne references

### DIFF
--- a/src/pcb_calculator/pcb_calculator.adoc
+++ b/src/pcb_calculator/pcb_calculator.adoc
@@ -110,7 +110,26 @@ image::images/en/electricalspacing.png[alt="Electrical-Spacing",scaledwidth="80%
 
 Transmission line theory is a cornerstone in the teaching of RF and microwave engineering.
 
-In the Calculator you can choose different sorts of Line Types and their special Parameters.
+In the calculator you can choose different sorts of Line Types and their special parameters. The models implemented are frequency-dependent, so they disagree with simpler models at high _enough_ frequencies.
+
+This calculator is heavilly based on http://transcalc.sourceforge.net/[Transcalc].
+
+The transmission line types and the reference of their mathematical models are listed below:
+
+* Microstrip line:
+** H. A. Atwater, “Simplified Design Equations for Microstrip Line Parameters”, Microwave Journal, pp. 109-115, November 1989.
+* Coplanar wave guide.
+* Coplanar wave guide with ground plane.
+* Rectangular waveguide:
+** S. Ramo, J. R. Whinnery and T. van Duzer, "Fields and Waves in Communication Electronics", Wiley-India, 2008, ISBN: 9788126515257.
+* Coaxial line.
+* Coupled microstrip line:
+** H. A. Atwater, “Simplified Design Equations for Microstrip Line Parameters”, Microwave Journal, pp. 109-115, November 1989.
+** M. Kirschning and R. H. Jansen, "Accurate Wide-Range Design Equations for the Frequency-Dependent Characteristic of Parallel Coupled Microstrip Lines," in IEEE Transactions on Microwave Theory and Techniques, vol. 32, no. 1, pp. 83-90, Jan. 1984. doi: 10.1109/TMTT.1984.1132616.
+** Rolf Jansen, "High-Speed Computation of Single and Coupled Microstrip Parameters Including Dispersion, High-Order Modes, Loss and Finite Strip Thickness", IEEE Trans. MTT, vol. 26, no. 2, pp. 75-82, Feb. 1978.
+** S. March, "Microstrip Packaging: Watch the Last Step", Microwaves, vol. 20, no. 13, pp. 83.94, Dec. 1981.
+* Stripline.
+* Twisted pair.
 
 
 image::images/en/transline.png[alt="TransLine",scaledwidth="80%"]


### PR DESCRIPTION
I found some of the references for the models used in the Transmission Line Calculator. Some of them are in the source code and some I found in the forums, but I couldn't find all of them. This might be helpful for other people as well.