### PR TITLE
Fix mistranslation: "jokers" -> "wildcards"

### DIFF
--- a/src/eeschema/eeschema_creating_customized_netlists_and_bom_files.adoc
+++ b/src/eeschema/eeschema_creating_customized_netlists_and_bom_files.adoc
@@ -1090,7 +1090,7 @@ The libparts section has the delimiter <libparts>, and the content of
 this section is defined in the schematic libraries. The libparts section
 contains
 
-* The allowed footprints names (names use jokers) delimiter <fp>.
+* The allowed footprints names (names use wildcards) delimiter <fp>.
 * The fields defined in the library delimiter <fields>.
 * The list of pins delimiter <pins>.
 


### PR DESCRIPTION
The term "wildcards" is used elsewhere in the documentation:

 * https://github.com/KiCad/kicad-doc/blob/master/src/eeschema/eeschema_schematic_creation_and_editing.adoc
 * https://github.com/KiCad/kicad-doc/commit/4839aa873600c263db120b1e39cdb37745410ceb

While "jokers" may be "wildcards" in certain card games it's not a term I've ever seen applied to "*" ("globbing") before, so had me very confused until I realised the connection. :)