### PR TITLE
Fix code block formatting error

### DIFF
--- a/src/pcbnew/pcbnew_python_scripting.adoc
+++ b/src/pcbnew/pcbnew_python_scripting.adoc
@@ -187,7 +187,7 @@ for idx in range(0, pcb.GetAreaCount()):
 
 print ""
 print "NetClasses:", pcb.GetNetClasses().GetCount(),
----------
+----------
 
 === Examples
 
@@ -215,7 +215,7 @@ for p in pads:
     if id<15: p.SetLocalSolderPasteMargin(0)
 
 pcb.Save("mod_"+filename)
----------
+----------
 
 [[Footprint_Wizards]]
 === Footprint Wizards
@@ -383,7 +383,7 @@ class FPC_FootprintWizard(HFPW.HelpfulFootprintWizardPlugin):
 
 # register into pcbnew
 FPC_FootprintWizard().register()
----------
+----------
 
 
 [[action_menu]]


### PR DESCRIPTION
A number of the example code blocks were terminated with one less `-` than needed which meant the formatting for most of the rest of the page was incorrect. This also broke the Footprint Wizard link near the top of the page.

Note: The formatted diff shows extensive changes but there's only a couple of `-` characters added in the raw diff.